### PR TITLE
feat: improve Makefile dev environment commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,16 +72,45 @@ Use the `browser-tools` skill to open pages and take screenshots when verifying:
 
 ## Development
 
-**ALWAYS start the dev server using `make dev`** - this runs all services (app, database, etc.) via the Makefile.
+**ALWAYS start the dev server using `make dev`** - this runs all services via overmind.
 
-Key Makefile targets:
+### Makefile Commands
 
-- `make dev` - Start development server (REQUIRED)
-- `make test` - Run tests
-- `make lint` - Run linter
-- `make fmt` - Format code
+Run `make help` to see all commands. Key targets:
 
-Read the Makefile to understand available commands before starting work.
+**Development:**
+
+- `make dev` - Start dev environment (daemonized)
+- `make dev-stop` - Stop dev environment
+- `make dev-restart` - Restart dev environment
+- `make dev-status` - Show process status (running PIDs)
+- `make dev-logs` - Stream all logs (Ctrl+C to stop)
+- `make dev-tail` - Show last 50 lines of logs (non-blocking)
+
+**Connect to terminals** (Ctrl+b d to detach):
+
+- `make connect-app` - Attach to app terminal
+- `make connect-css` - Attach to CSS watcher terminal
+
+**Quality:**
+
+- `make check` - Run linting and tests
+- `make pre-pr` - Run pre-PR checks
+
+### Reading Logs
+
+For quick log inspection without blocking:
+
+```bash
+make dev-tail      # Last 50 lines from each service
+make dev-status    # Process status with PIDs
+```
+
+For streaming logs (blocks terminal):
+
+```bash
+make dev-logs      # Ctrl+C to stop
+```
 
 ## Task Lifecycle
 

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,114 @@
-.PHONY: dev dev-stop dev-status dev-logs check pre-pr help
+.PHONY: dev dev-stop dev-restart dev-status dev-logs dev-tail \
+        connect-app connect-css \
+        check pre-pr help
+
+SOCKET := ./.overmind.sock
+
+# =============================================================================
+# Help
+# =============================================================================
 
 help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@echo "erikcraddock.me Development"
+	@echo ""
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Development:"
+	@echo "  dev             Start dev environment"
+	@echo "  dev-stop        Stop dev environment"
+	@echo "  dev-restart     Restart dev environment"
+	@echo "  dev-status      Show process status"
+	@echo "  dev-logs        Stream all logs (Ctrl+C to stop)"
+	@echo "  dev-tail        Show last 50 lines of logs"
+	@echo ""
+	@echo "Connect (Ctrl+b d to detach):"
+	@echo "  connect-app     Attach to app terminal"
+	@echo "  connect-css     Attach to css terminal"
+	@echo ""
+	@echo "Quality:"
+	@echo "  check           Run linting and tests"
+	@echo "  pre-pr          Run pre-PR checks"
 
-dev: ## Start the dev environment
-	@if [ "$$(make -s dev-status)" = "running" ]; then \
+# =============================================================================
+# Development Environment
+# =============================================================================
+
+dev: ## Start dev environment
+	@if [ -S $(SOCKET) ] && overmind ps -s $(SOCKET) > /dev/null 2>&1; then \
 		echo "Dev environment already running"; \
+		overmind ps -s $(SOCKET); \
 	else \
-		overmind start -f Procfile.dev; \
+		rm -f $(SOCKET); \
+		overmind start -f Procfile.dev -s $(SOCKET) -D; \
+		sleep 2; \
+		overmind ps -s $(SOCKET); \
+		echo ""; \
+		echo "Dev started: http://localhost:5000"; \
 	fi
 
-dev-stop: ## Stop the dev environment
-	overmind quit || true
-	@rm -f .overmind.sock
+dev-stop: ## Stop dev environment
+	@if [ -S $(SOCKET) ]; then overmind quit -s $(SOCKET) || true; fi
+	@rm -f $(SOCKET)
+	@tmux kill-session -t erikcraddock-me 2>/dev/null || true
+	@for sock in /tmp/tmux-$$(id -u)/overmind-erikcraddock-me-*; do \
+		if [ -S "$$sock" ]; then \
+			tmux -L "$$(basename $$sock)" kill-server 2>/dev/null || true; \
+		fi; \
+	done
 
-dev-status: ## Check if dev environment is running
-	@if [ -S .overmind.sock ]; then echo "running"; else echo "stopped"; fi
+dev-restart: dev-stop dev ## Restart dev environment
 
-dev-logs: ## Connect to dev environment logs
-	overmind connect
+dev-status: ## Show process status
+	@if [ -S $(SOCKET) ] && overmind ps -s $(SOCKET) > /dev/null 2>&1; then \
+		overmind ps -s $(SOCKET); \
+	else \
+		echo "Not running"; \
+	fi
+
+dev-logs: ## Stream all logs (Ctrl+C to stop)
+	@if [ -S $(SOCKET) ]; then \
+		overmind echo -s $(SOCKET); \
+	else \
+		echo "Dev environment not running. Start with: make dev"; \
+	fi
+
+dev-tail: ## Show last 50 lines of logs
+	@if [ ! -S $(SOCKET) ]; then \
+		echo "Dev environment not running. Start with: make dev"; \
+	else \
+		TMUX_SOCK=$$(ls -t /tmp/tmux-$$(id -u)/overmind-erikcraddock-me-* 2>/dev/null | head -1); \
+		if [ -n "$$TMUX_SOCK" ]; then \
+			echo "=== app ===" && \
+			tmux -L "$$(basename $$TMUX_SOCK)" capture-pane -t erikcraddock-me:app -p -S -25 2>/dev/null || echo "(no output)"; \
+			echo "" && \
+			echo "=== css ===" && \
+			tmux -L "$$(basename $$TMUX_SOCK)" capture-pane -t erikcraddock-me:css -p -S -25 2>/dev/null || echo "(no output)"; \
+		else \
+			echo "Could not find tmux socket"; \
+		fi; \
+	fi
+
+# =============================================================================
+# Connect to Service Terminals
+# =============================================================================
+
+connect-app: ## Attach to app terminal (Ctrl+b d to detach)
+	@if [ -S $(SOCKET) ]; then \
+		overmind connect app -s $(SOCKET); \
+	else \
+		echo "Dev environment not running. Start with: make dev"; \
+	fi
+
+connect-css: ## Attach to css terminal (Ctrl+b d to detach)
+	@if [ -S $(SOCKET) ]; then \
+		overmind connect css -s $(SOCKET); \
+	else \
+		echo "Dev environment not running. Start with: make dev"; \
+	fi
+
+# =============================================================================
+# Quality
+# =============================================================================
 
 check: ## Run linting and tests
 	npm run lint && npm test


### PR DESCRIPTION
## Summary
Overhaul Makefile commands for interacting with overmind dev environment.

## Problems Fixed
1. **make dev hung** - Now runs daemonized with `-D` flag
2. **dev-status unreliable** - Now uses `overmind ps` (shows PIDs)
3. **No easy way to view logs** - Added `dev-tail` for non-blocking log inspection
4. **Stale tmux sessions** - `dev-stop` now cleans up tmux sessions

## New Commands
| Command | Description |
|---------|-------------|
| `make dev` | Start dev environment (daemonized) |
| `make dev-stop` | Stop and clean up |
| `make dev-restart` | Restart environment |
| `make dev-status` | Show process status with PIDs |
| `make dev-logs` | Stream all logs (Ctrl+C to stop) |
| `make dev-tail` | Show last 50 lines (non-blocking) |
| `make connect-app` | Attach to app terminal |
| `make connect-css` | Attach to CSS watcher terminal |

## Testing
All commands tested manually:
- Start/stop/restart cycle works
- Status shows running processes
- Tail shows recent logs without blocking
- Cleanup handles stale tmux sessions

## Task
Closes #1349