### PR TITLE
test: add schema tests for posts, tags, post_tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,32 @@ make dev-logs      # Ctrl+C to stop
 2. Run `./scripts/pre-pr.sh` before opening PR
 3. After PR is created, use the `request-review` skill to spawn a separate agent to review the PR
 
+## Testing Requirements
+
+Every task must include tests for its acceptance criteria.
+
+**Acceptance criteria = test cases.** If you can verify it manually, write a test for it.
+
+**Before closing a task:**
+
+- [ ] New functionality has corresponding tests in `src/__tests__/` or colocated `*.test.ts`
+- [ ] Tests verify the acceptance criteria, not just "code runs"
+- [ ] `npm test` passes with the new tests
+
+**Don't verify acceptance criteria manually** - that's what tests are for.
+
+**Example:** If acceptance criteria says "Schema exports posts table":
+
+```typescript
+import { posts } from "@/db/schema";
+
+describe("schema", () => {
+  it("exports posts table", () => {
+    expect(posts).toBeDefined();
+  });
+});
+```
+
 ## Conventions
 
 - Use TypeScript strict mode

--- a/src/db/__tests__/schema.test.ts
+++ b/src/db/__tests__/schema.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import { eq } from "drizzle-orm";
+import * as schema from "../schema";
+import { posts, tags, postTags } from "../schema";
+
+describe("schema exports", () => {
+  it("exports posts table", () => {
+    expect(posts).toBeDefined();
+    expect(posts.id).toBeDefined();
+    expect(posts.type).toBeDefined();
+    expect(posts.title).toBeDefined();
+    expect(posts.content).toBeDefined();
+  });
+
+  it("exports tags table", () => {
+    expect(tags).toBeDefined();
+    expect(tags.id).toBeDefined();
+    expect(tags.name).toBeDefined();
+    expect(tags.slug).toBeDefined();
+  });
+
+  it("exports postTags junction table", () => {
+    expect(postTags).toBeDefined();
+    expect(postTags.post_id).toBeDefined();
+    expect(postTags.tag_id).toBeDefined();
+  });
+});
+
+describe("database operations", () => {
+  let sqlite: Database.Database;
+  let db: ReturnType<typeof drizzle>;
+
+  beforeAll(() => {
+    // Use in-memory database for tests
+    sqlite = new Database(":memory:");
+    db = drizzle(sqlite, { schema });
+
+    // Create tables
+    sqlite.exec(`
+      CREATE TABLE posts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT NOT NULL,
+        title TEXT,
+        content TEXT NOT NULL,
+        excerpt TEXT,
+        url TEXT,
+        source_id INTEGER,
+        published_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE tags (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL UNIQUE,
+        slug TEXT NOT NULL UNIQUE
+      );
+
+      CREATE TABLE post_tags (
+        post_id INTEGER NOT NULL,
+        tag_id INTEGER NOT NULL,
+        PRIMARY KEY (post_id, tag_id),
+        FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE,
+        FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+      );
+    `);
+  });
+
+  afterAll(() => {
+    sqlite.close();
+  });
+
+  it("can insert and query posts", async () => {
+    const now = new Date();
+
+    const result = db
+      .insert(posts)
+      .values({
+        type: "article",
+        title: "Test Post",
+        content: "This is test content",
+        created_at: now,
+        updated_at: now,
+      })
+      .returning()
+      .get();
+
+    expect(result).toBeDefined();
+    expect(result.id).toBe(1);
+    expect(result.type).toBe("article");
+    expect(result.title).toBe("Test Post");
+
+    const queried = db.select().from(posts).where(eq(posts.id, 1)).get();
+    expect(queried).toBeDefined();
+    expect(queried?.title).toBe("Test Post");
+  });
+
+  it("can insert and query tags", async () => {
+    const result = db
+      .insert(tags)
+      .values({
+        name: "TypeScript",
+        slug: "typescript",
+      })
+      .returning()
+      .get();
+
+    expect(result).toBeDefined();
+    expect(result.id).toBe(1);
+    expect(result.name).toBe("TypeScript");
+    expect(result.slug).toBe("typescript");
+
+    const queried = db.select().from(tags).where(eq(tags.slug, "typescript")).get();
+    expect(queried).toBeDefined();
+    expect(queried?.name).toBe("TypeScript");
+  });
+
+  it("can create post-tag relationships", async () => {
+    // Insert another post and tag for this test
+    const post = db
+      .insert(posts)
+      .values({
+        type: "note",
+        content: "A quick note",
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .returning()
+      .get();
+
+    const tag = db
+      .insert(tags)
+      .values({
+        name: "Quick",
+        slug: "quick",
+      })
+      .returning()
+      .get();
+
+    // Create relationship
+    db.insert(postTags)
+      .values({
+        post_id: post.id,
+        tag_id: tag.id,
+      })
+      .run();
+
+    // Query the relationship
+    const relationship = db.select().from(postTags).where(eq(postTags.post_id, post.id)).get();
+
+    expect(relationship).toBeDefined();
+    expect(relationship?.post_id).toBe(post.id);
+    expect(relationship?.tag_id).toBe(tag.id);
+  });
+});
+
+describe("db module", () => {
+  it("exports db connection", async () => {
+    const { db } = await import("../index");
+    expect(db).toBeDefined();
+  });
+
+  it("re-exports schema", async () => {
+    const dbModule = await import("../index");
+    expect(dbModule.posts).toBeDefined();
+    expect(dbModule.tags).toBeDefined();
+    expect(dbModule.postTags).toBeDefined();
+  });
+});

--- a/src/db/__tests__/schema.test.ts
+++ b/src/db/__tests__/schema.test.ts
@@ -72,7 +72,7 @@ describe("database operations", () => {
     sqlite.close();
   });
 
-  it("can insert and query posts", async () => {
+  it("can insert and query posts", () => {
     const now = new Date();
 
     const result = db
@@ -97,7 +97,7 @@ describe("database operations", () => {
     expect(queried?.title).toBe("Test Post");
   });
 
-  it("can insert and query tags", async () => {
+  it("can insert and query tags", () => {
     const result = db
       .insert(tags)
       .values({
@@ -117,7 +117,7 @@ describe("database operations", () => {
     expect(queried?.name).toBe("TypeScript");
   });
 
-  it("can create post-tag relationships", async () => {
+  it("can create post-tag relationships", () => {
     // Insert another post and tag for this test
     const post = db
       .insert(posts)


### PR DESCRIPTION
## Summary
Add automated tests for the database schema (posts, tags, post_tags) to verify acceptance criteria.

## Changes
- Add `src/db/__tests__/schema.test.ts` with 8 tests:
  - Schema exports posts, tags, postTags tables
  - Can insert and query posts
  - Can insert and query tags
  - Can create post-tag relationships
  - db module exports connection
  - db module re-exports schema
- Update `AGENTS.md` with Testing Requirements section

## Testing
- Uses in-memory SQLite for isolation
- All 9 tests pass (8 new + 1 existing)

## Why
Task #1287 created the schema but without tests. This task adds the missing test coverage and documents testing requirements to prevent future gaps.

## Task
Closes #1292