### PR TITLE
refactor: extract public routes to src/routes/pages.tsx

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,20 +1,14 @@
 import { Hono } from "hono";
 import { serveStatic } from "hono/bun";
-import { Layout } from "./templates/layout";
+import { pages } from "./routes/pages";
 
 const app = new Hono();
 
 // Serve static files from public/
 app.use("/css/*", serveStatic({ root: "./public" }));
 
-app.get("/", (c) => {
-  return c.html(
-    <Layout title="Home | erikcraddock.me">
-      <h1 class="text-3xl font-bold mb-4">Welcome</h1>
-      <p class="text-gray-600">Coming soon.</p>
-    </Layout>
-  );
-});
+// Mount routes
+app.route("/", pages);
 
 // ActivityPub actor endpoint (placeholder)
 app.get("/.well-known/webfinger", (c) => {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+import { Layout } from "../templates/layout";
+
+const pages = new Hono();
+
+pages.get("/", (c) => {
+  return c.html(
+    <Layout title="Home | erikcraddock.me">
+      <h1 class="text-3xl font-bold mb-4">Welcome</h1>
+      <p class="text-gray-600">Coming soon.</p>
+    </Layout>
+  );
+});
+
+export { pages };


### PR DESCRIPTION
## Summary
Organize routes per CODE_STANDARDS.md pattern. Most home page work was already done in #1289.

## Changes
- Create `src/routes/pages.tsx` with home route
- Update `src/index.tsx` to mount routes via `app.route('/', pages)`

## Acceptance Criteria
- [x] `make dev` starts server
- [x] Visiting `http://localhost:5000/` shows styled home page
- [x] Layout has header, main content, footer
- [x] Tailwind classes work

## Notes
- Task mentions port 3000, but dev runs on 5000 (Bun default)
- Layout and Tailwind were set up in #1288 and #1289

## Task
Closes #1291