### PR TITLE
feat: seed posts and display on home page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: dev dev-stop dev-restart dev-status dev-logs dev-tail \
         connect-app connect-css \
-        db-generate db-migrate db-push db-studio \
+        db-generate db-migrate db-push db-studio db-seed \
         check pre-pr help
 
 SOCKET := ./.overmind.sock
@@ -31,6 +31,7 @@ help: ## Show this help
 	@echo "  db-migrate      Run pending migrations"
 	@echo "  db-push         Push schema directly to database (dev only)"
 	@echo "  db-studio       Open Drizzle Studio to browse database"
+	@echo "  db-seed         Seed database with sample data"
 	@echo ""
 	@echo "Quality:"
 	@echo "  check           Run linting and tests"
@@ -132,6 +133,10 @@ db-push: ## Push schema directly to database (dev only)
 db-studio: ## Open Drizzle Studio to browse database
 	@mkdir -p data
 	npx drizzle-kit studio
+
+db-seed: ## Seed database with sample data
+	@mkdir -p data
+	bun scripts/seed.ts
 
 # =============================================================================
 # Quality

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
-        "better-sqlite3": "^12.6.2",
         "drizzle-orm": "^0.45.1",
         "hono": "^4.0.0"
       },
@@ -17,9 +16,10 @@
         "@eslint/js": "^9.0.0",
         "@tailwindcss/cli": "^4.1.18",
         "@tailwindcss/postcss": "^4.1.18",
-        "@types/better-sqlite3": "^7.6.13",
+        "@types/bun": "^1.3.6",
         "@types/node": "^20.0.0",
         "@vitest/coverage-v8": "^1.0.0",
+        "better-sqlite3": "^12.6.2",
         "drizzle-kit": "^0.31.8",
         "eslint": "^9.0.0",
         "postcss": "^8.5.6",
@@ -2237,15 +2237,14 @@
         "tailwindcss": "4.1.18"
       }
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "devOptional": true,
+    "node_modules/@types/bun": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.6.tgz",
+      "integrity": "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@types/node": "*"
+        "bun-types": "1.3.6"
       }
     },
     "node_modules/@types/estree": {
@@ -2268,7 +2267,6 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2759,6 +2757,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2779,6 +2778,7 @@
       "version": "12.6.2",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
       "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -2794,6 +2794,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
@@ -2803,6 +2804,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -2825,6 +2827,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2851,6 +2854,17 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.6.tgz",
+      "integrity": "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -2925,6 +2939,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/color-convert": {
@@ -2998,6 +3013,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -3026,6 +3042,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -3042,6 +3059,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3686,6 +3704,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -3967,6 +3986,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "devOptional": true,
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
@@ -4028,6 +4048,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/find-up": {
@@ -4072,6 +4093,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fs.realpath": {
@@ -4136,6 +4158,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/glob": {
@@ -4234,6 +4257,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -4303,12 +4327,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/is-extglob": {
@@ -4856,6 +4882,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4881,6 +4908,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4890,6 +4918,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/mlly": {
@@ -4952,6 +4981,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -4965,6 +4995,7 @@
       "version": "3.87.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
       "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -5013,6 +5044,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5216,6 +5248,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -5296,6 +5329,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -5316,6 +5350,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "devOptional": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -5331,6 +5366,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5347,6 +5383,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -5426,6 +5463,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5446,6 +5484,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5501,6 +5540,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5521,6 +5561,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5591,6 +5632,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -5673,6 +5715,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -5685,6 +5728,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
@@ -5793,6 +5837,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -5891,6 +5936,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -6520,6 +6566,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.9",
-    "better-sqlite3": "^12.6.2",
     "drizzle-orm": "^0.45.1",
     "hono": "^4.0.0"
   },
@@ -26,9 +25,10 @@
     "@eslint/js": "^9.0.0",
     "@tailwindcss/cli": "^4.1.18",
     "@tailwindcss/postcss": "^4.1.18",
-    "@types/better-sqlite3": "^7.6.13",
+    "@types/bun": "^1.3.6",
     "@types/node": "^20.0.0",
     "@vitest/coverage-v8": "^1.0.0",
+    "better-sqlite3": "^12.6.2",
     "drizzle-kit": "^0.31.8",
     "eslint": "^9.0.0",
     "postcss": "^8.5.6",

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,97 @@
+import { db, posts, tags, postTags } from "../src/db";
+
+async function seed() {
+  console.log("🌱 Seeding database...");
+
+  // Check if already seeded
+  const existingPosts = db.select().from(posts).all();
+  if (existingPosts.length > 0) {
+    console.log("Database already has posts, skipping seed.");
+    return;
+  }
+
+  const now = new Date();
+
+  // Create tags
+  console.log("Creating tags...");
+  const tagData = [
+    { name: "TypeScript", slug: "typescript" },
+    { name: "Web Development", slug: "web-development" },
+    { name: "ActivityPub", slug: "activitypub" },
+  ];
+
+  const createdTags: { id: number; slug: string }[] = [];
+  for (const tag of tagData) {
+    const result = db.insert(tags).values(tag).returning().get();
+    createdTags.push({ id: result.id, slug: tag.slug });
+  }
+
+  // Create posts
+  console.log("Creating posts...");
+  const postData = [
+    {
+      type: "article",
+      title: "Building a Federated Blog",
+      content: `This is the first post on my new federated blog. The goal is to create a personal website that can be followed from Mastodon and other ActivityPub-compatible platforms.
+
+When someone follows @erik@erikcraddock.me, they'll see my posts show up in their home feed, just like following any other account.
+
+The tech stack includes:
+- **Hono** for the web framework
+- **Fedify** for ActivityPub
+- **Drizzle + SQLite** for the database
+- **Tailwind** for styling
+
+More posts coming soon as I build this out!`,
+      excerpt: "Introducing my new federated blog that can be followed from Mastodon.",
+      published_at: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000), // 2 days ago
+      created_at: now,
+      updated_at: now,
+      tagSlugs: ["typescript", "web-development", "activitypub"],
+    },
+    {
+      type: "article",
+      title: "Why TypeScript for Everything",
+      content: `I've been using TypeScript for all my projects lately, and I wanted to share why.
+
+The type safety catches so many bugs at compile time that would otherwise slip through. The IDE support is incredible - autocomplete, refactoring, and inline documentation all work seamlessly.
+
+For this blog project, TypeScript with strict mode enabled has been invaluable. The Drizzle ORM integration means my database queries are fully typed, and Hono's JSX support gives me type-safe templates.
+
+The small upfront cost of adding types pays off enormously as the project grows.`,
+      excerpt: "Why I use TypeScript for every project, from small scripts to full applications.",
+      published_at: new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000), // 5 days ago
+      created_at: now,
+      updated_at: now,
+      tagSlugs: ["typescript", "web-development"],
+    },
+    {
+      type: "note",
+      title: null,
+      content: "Just pushed the first version of the site. Still lots to do but it's a start! 🚀",
+      excerpt: null,
+      published_at: new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000), // 1 day ago
+      created_at: now,
+      updated_at: now,
+      tagSlugs: [],
+    },
+  ];
+
+  for (const post of postData) {
+    const { tagSlugs, ...postValues } = post;
+
+    const result = db.insert(posts).values(postValues).returning().get();
+
+    // Create post-tag associations
+    for (const slug of tagSlugs) {
+      const tag = createdTags.find((t) => t.slug === slug);
+      if (tag) {
+        db.insert(postTags).values({ post_id: result.id, tag_id: tag.id }).run();
+      }
+    }
+  }
+
+  console.log(`✅ Seeded ${postData.length} posts and ${tagData.length} tags`);
+}
+
+seed().catch(console.error);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,11 +1,11 @@
-import { drizzle } from "drizzle-orm/better-sqlite3";
-import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { Database } from "bun:sqlite";
 import * as schema from "./schema";
 
 const databasePath = process.env.DATABASE_PATH || "./data/site.db";
 
 const sqlite = new Database(databasePath);
-sqlite.pragma("journal_mode = WAL");
+sqlite.exec("PRAGMA journal_mode = WAL;");
 
 export const db = drizzle(sqlite, { schema });
 

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { desc, isNotNull } from "drizzle-orm";
 import { db, posts } from "../db";
 import { Layout } from "../templates/layout";
+import { truncate } from "../utils/text";
 
 const pages = new Hono();
 
@@ -27,10 +28,7 @@ pages.get("/", (c) => {
                     {post.title}
                   </h2>
                 ) : null}
-                <p class="text-gray-600 mb-2">
-                  {post.excerpt || post.content.slice(0, 200)}
-                  {!post.excerpt && post.content.length > 200 ? "..." : ""}
-                </p>
+                <p class="text-gray-600 mb-2">{post.excerpt || truncate(post.content, 200)}</p>
                 <time class="text-sm text-gray-400">
                   {post.published_at
                     ? new Date(post.published_at).toLocaleDateString("en-US", {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1,13 +1,50 @@
 import { Hono } from "hono";
+import { desc, isNotNull } from "drizzle-orm";
+import { db, posts } from "../db";
 import { Layout } from "../templates/layout";
 
 const pages = new Hono();
 
 pages.get("/", (c) => {
+  const allPosts = db
+    .select()
+    .from(posts)
+    .where(isNotNull(posts.published_at))
+    .orderBy(desc(posts.published_at))
+    .all();
+
   return c.html(
     <Layout title="Home | erikcraddock.me">
-      <h1 class="text-3xl font-bold mb-4">Welcome</h1>
-      <p class="text-gray-600">Coming soon.</p>
+      <div class="space-y-8">
+        {allPosts.length === 0 ? (
+          <p class="text-gray-600">No posts yet.</p>
+        ) : (
+          allPosts.map((post) => (
+            <article key={post.id} class="border-b border-gray-200 pb-6">
+              <a href={`/posts/${post.id}`} class="block group">
+                {post.title ? (
+                  <h2 class="text-xl font-semibold text-gray-900 group-hover:text-blue-600 mb-2">
+                    {post.title}
+                  </h2>
+                ) : null}
+                <p class="text-gray-600 mb-2">
+                  {post.excerpt || post.content.slice(0, 200)}
+                  {!post.excerpt && post.content.length > 200 ? "..." : ""}
+                </p>
+                <time class="text-sm text-gray-400">
+                  {post.published_at
+                    ? new Date(post.published_at).toLocaleDateString("en-US", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })
+                    : "Draft"}
+                </time>
+              </a>
+            </article>
+          ))
+        )}
+      </div>
     </Layout>
   );
 });

--- a/src/utils/__tests__/text.test.ts
+++ b/src/utils/__tests__/text.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { truncate } from "../text";
+
+describe("truncate", () => {
+  it("returns text unchanged if under maxLength", () => {
+    expect(truncate("short text", 100)).toBe("short text");
+  });
+
+  it("returns text unchanged if exactly maxLength", () => {
+    expect(truncate("12345", 5)).toBe("12345");
+  });
+
+  it("truncates at word boundary", () => {
+    const text = "The quick brown fox jumps over the lazy dog";
+    const result = truncate(text, 20);
+    // Should cut at "The quick brown fox" (19 chars) not mid-word
+    expect(result).toBe("The quick brown fox...");
+    expect(result).not.toContain("fox j");
+  });
+
+  it("adds ellipsis when truncated", () => {
+    const text = "This is a longer piece of text";
+    const result = truncate(text, 15);
+    expect(result.endsWith("...")).toBe(true);
+  });
+
+  it("handles single long word by cutting at maxLength", () => {
+    const text = "supercalifragilisticexpialidocious";
+    const result = truncate(text, 10);
+    expect(result).toBe("supercalif...");
+  });
+
+  it("handles text with no spaces", () => {
+    const text = "NoSpacesHere";
+    const result = truncate(text, 5);
+    expect(result).toBe("NoSpa...");
+  });
+
+  it("handles empty string", () => {
+    expect(truncate("", 10)).toBe("");
+  });
+
+  it("handles maxLength of 0", () => {
+    expect(truncate("some text", 0)).toBe("...");
+  });
+});

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,17 @@
+/**
+ * Truncate text to a maximum length, breaking on word boundaries.
+ * Adds ellipsis if truncated.
+ */
+export function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  // Find the last space before maxLength
+  const lastSpace = text.lastIndexOf(" ", maxLength);
+
+  // If no space found, just cut at maxLength (single long word)
+  const cutoff = lastSpace > 0 ? lastSpace : maxLength;
+
+  return text.slice(0, cutoff) + "...";
+}


### PR DESCRIPTION
## Summary
Create seed data for posts and display them on the home page.

## Changes
- Add `scripts/seed.ts` with 3 sample posts (2 articles, 1 note) and 3 tags
- Add `make db-seed` Makefile target
- Update home page to query posts from database and display them
- Switch from better-sqlite3 to bun:sqlite (Bun native driver)
- Add @types/bun for TypeScript support
- Keep better-sqlite3 as devDependency for drizzle-kit CLI

## Acceptance Criteria
- [x] `make db-seed` populates database with sample data
- [x] Home page displays list of posts from database
- [x] Posts show title, excerpt, and date
- [x] Each post links to its detail page (/posts/:id)
- [x] Seed script is idempotent (checks for existing posts)

## Visual Verification
Screenshot shows 3 posts displayed with titles, excerpts, and dates.

## Task
Closes #1293