### PR TITLE
feat: add posts by tag page

### DIFF
--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -59,11 +59,17 @@ beforeAll(async () => {
     INSERT INTO posts (id, type, title, content, created_at, updated_at)
     VALUES (2, 'article', 'Draft Post', 'This is a draft.', ${now}, ${now});
 
+    INSERT INTO posts (id, type, title, content, published_at, created_at, updated_at)
+    VALUES (3, 'article', 'Another Post', 'Another post content.', ${now}, ${now}, ${now});
+
     INSERT INTO tags (id, name, slug) VALUES (1, 'Testing', 'testing');
     INSERT INTO tags (id, name, slug) VALUES (2, 'TypeScript', 'typescript');
+    INSERT INTO tags (id, name, slug) VALUES (3, 'Empty Tag', 'empty-tag');
 
     INSERT INTO post_tags (post_id, tag_id) VALUES (1, 1);
     INSERT INTO post_tags (post_id, tag_id) VALUES (1, 2);
+    INSERT INTO post_tags (post_id, tag_id) VALUES (2, 1);
+    INSERT INTO post_tags (post_id, tag_id) VALUES (3, 2);
   `);
 });
 
@@ -194,6 +200,83 @@ describe("pages routes", () => {
 
       const html = await res.text();
       expect(html).toContain("Post Not Found");
+    });
+  });
+
+  describe("GET /tags/:slug", () => {
+    it("returns 200 and displays tag name as heading", async () => {
+      const app = getApp();
+      const res = await app.request("/tags/testing");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      // Quotes are HTML-escaped as &quot;
+      expect(html).toContain("Posts tagged");
+      expect(html).toContain("Testing");
+    });
+
+    it("displays only published posts with that tag", async () => {
+      const app = getApp();
+      const res = await app.request("/tags/testing");
+      const html = await res.text();
+
+      // Post 1 is published and has "testing" tag
+      expect(html).toContain("Test Post");
+      // Post 2 is a draft with "testing" tag - should NOT appear
+      expect(html).not.toContain("Draft Post");
+    });
+
+    it("shows posts filtered by tag", async () => {
+      const app = getApp();
+      const res = await app.request("/tags/typescript");
+      const html = await res.text();
+
+      // Posts 1 and 3 have "typescript" tag
+      expect(html).toContain("Test Post");
+      expect(html).toContain("Another Post");
+    });
+
+    it("includes back link to home", async () => {
+      const app = getApp();
+      const res = await app.request("/tags/testing");
+      const html = await res.text();
+
+      expect(html).toContain('href="/"');
+      expect(html).toContain("Back to home");
+    });
+
+    it("includes dark mode classes", async () => {
+      const app = getApp();
+      const res = await app.request("/tags/testing");
+      const html = await res.text();
+
+      expect(html).toContain("dark:bg-gray-900");
+      expect(html).toContain("dark:text-gray-100");
+      expect(html).toContain("dark:border-gray-700");
+    });
+
+    it("shows empty message for tag with no published posts", async () => {
+      const app = getApp();
+      const res = await app.request("/tags/empty-tag");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      // Quotes are HTML-escaped as &quot;
+      expect(html).toContain("No posts tagged");
+      expect(html).toContain("Empty Tag");
+      expect(html).toContain("yet.");
+    });
+
+    it("returns 404 for non-existent tag", async () => {
+      const app = getApp();
+      const res = await app.request("/tags/nonexistent");
+
+      expect(res.status).toBe(404);
+
+      const html = await res.text();
+      expect(html).toContain("Tag Not Found");
     });
   });
 });

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { raw } from "hono/html";
-import { desc, eq, isNotNull } from "drizzle-orm";
+import { desc, eq, isNotNull, and } from "drizzle-orm";
 import { db as defaultDb, posts, tags, postTags } from "../db";
 import { Layout } from "../templates/layout";
 import { NotFound } from "../templates/not-found";
@@ -10,6 +10,49 @@ import { renderMarkdown } from "../utils/markdown";
 // Database type for dependency injection
 type Database = typeof defaultDb;
 
+// Post type for the card component
+type Post = typeof posts.$inferSelect;
+
+/** Reusable post card component */
+function PostCard({ post }: { post: Post }) {
+  return (
+    <article class="border-b border-gray-200 dark:border-gray-700 pb-6">
+      <a href={`/posts/${post.id}`} class="block group">
+        {post.title ? (
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 mb-2">
+            {post.title}
+          </h2>
+        ) : null}
+        <p class="text-gray-600 dark:text-gray-400 mb-2">
+          {post.excerpt || truncate(post.content, 200)}
+        </p>
+        <time class="text-sm text-gray-400 dark:text-gray-500">
+          {post.published_at
+            ? new Date(post.published_at).toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })
+            : "Draft"}
+        </time>
+      </a>
+    </article>
+  );
+}
+
+/** Reusable post list component */
+function PostList({ posts: postList, emptyMessage }: { posts: Post[]; emptyMessage?: string }) {
+  return (
+    <div class="space-y-8">
+      {postList.length === 0 ? (
+        <p class="text-gray-600 dark:text-gray-400">{emptyMessage || "No posts yet."}</p>
+      ) : (
+        postList.map((post) => <PostCard key={post.id} post={post} />)
+      )}
+    </div>
+  );
+}
+
 /**
  * Creates page routes with the given database instance.
  * Allows dependency injection for testing.
@@ -17,6 +60,7 @@ type Database = typeof defaultDb;
 export function createPagesRoutes(db: Database): Hono {
   const pages = new Hono();
 
+  // Home page
   pages.get("/", (c) => {
     const allPosts = db
       .select()
@@ -27,35 +71,7 @@ export function createPagesRoutes(db: Database): Hono {
 
     return c.html(
       <Layout title="Home | erikcraddock.me">
-        <div class="space-y-8">
-          {allPosts.length === 0 ? (
-            <p class="text-gray-600 dark:text-gray-400">No posts yet.</p>
-          ) : (
-            allPosts.map((post) => (
-              <article key={post.id} class="border-b border-gray-200 dark:border-gray-700 pb-6">
-                <a href={`/posts/${post.id}`} class="block group">
-                  {post.title ? (
-                    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 mb-2">
-                      {post.title}
-                    </h2>
-                  ) : null}
-                  <p class="text-gray-600 dark:text-gray-400 mb-2">
-                    {post.excerpt || truncate(post.content, 200)}
-                  </p>
-                  <time class="text-sm text-gray-400 dark:text-gray-500">
-                    {post.published_at
-                      ? new Date(post.published_at).toLocaleDateString("en-US", {
-                          year: "numeric",
-                          month: "long",
-                          day: "numeric",
-                        })
-                      : "Draft"}
-                  </time>
-                </a>
-              </article>
-            ))
-          )}
-        </div>
+        <PostList posts={allPosts} />
       </Layout>
     );
   });
@@ -144,6 +160,61 @@ export function createPagesRoutes(db: Database): Hono {
           {/* Post content */}
           <div class="prose prose-gray max-w-none">{raw(renderMarkdown(post.content))}</div>
         </article>
+      </Layout>
+    );
+  });
+
+  // Posts by tag page
+  pages.get("/tags/:slug", (c) => {
+    const slug = c.req.param("slug");
+
+    // Query the tag by slug
+    const tag = db.select().from(tags).where(eq(tags.slug, slug)).get();
+
+    if (!tag) {
+      return c.html(
+        <NotFound title="Tag Not Found" message="The tag you're looking for doesn't exist." />,
+        404
+      );
+    }
+
+    // Query published posts with this tag
+    const taggedPosts = db
+      .select({
+        id: posts.id,
+        type: posts.type,
+        title: posts.title,
+        content: posts.content,
+        excerpt: posts.excerpt,
+        url: posts.url,
+        source_id: posts.source_id,
+        published_at: posts.published_at,
+        created_at: posts.created_at,
+        updated_at: posts.updated_at,
+      })
+      .from(posts)
+      .innerJoin(postTags, eq(posts.id, postTags.post_id))
+      .where(and(eq(postTags.tag_id, tag.id), isNotNull(posts.published_at)))
+      .orderBy(desc(posts.published_at))
+      .all();
+
+    return c.html(
+      <Layout title={`${tag.name} | erikcraddock.me`}>
+        {/* Back link */}
+        <a
+          href="/"
+          class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 text-sm mb-6 inline-block"
+        >
+          ← Back to home
+        </a>
+
+        {/* Tag heading */}
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">
+          Posts tagged "{tag.name}"
+        </h1>
+
+        {/* Post list */}
+        <PostList posts={taggedPosts} emptyMessage={`No posts tagged "${tag.name}" yet.`} />
       </Layout>
     );
   });


### PR DESCRIPTION
## Summary
Add the tag page that lists all posts with a specific tag. Clicking a tag on a post now takes you to a filtered list.

## Changes
- Add `GET /tags/:slug` route in `src/routes/pages.tsx`
- Extract `PostCard` and `PostList` components for reuse (DRY)
- Query tag by slug, then published posts with that tag
- Display tag name as page heading
- Show 404 for non-existent tags
- Include back link to home
- Dark mode styling included

## Task
Closes #1295

## Acceptance Criteria
- [x] `/tags/:slug` shows posts filtered by that tag
- [x] Tag name displayed as heading
- [x] Post list matches home page format
- [x] 404 shown for non-existent tag
- [x] Navigation back to home works

## Testing
- 7 new tests added for tag page route
- 72 total tests passing
- Visual verification in browser (both modes)