### PR TITLE
feat: add about page and sources/blogroll page

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,4 +1,4 @@
-import { db, posts, tags, postTags } from "../src/db";
+import { db, posts, tags, postTags, sources } from "../src/db";
 
 async function seed() {
   console.log("🌱 Seeding database...");
@@ -6,10 +6,21 @@ async function seed() {
   // Check if already seeded
   const existingPosts = db.select().from(posts).all();
   if (existingPosts.length > 0) {
-    console.log("Database already has posts, skipping seed.");
-    return;
+    console.log("Database already has posts, skipping post seed.");
+  } else {
+    await seedPosts();
   }
 
+  // Seed sources if empty
+  const existingSources = db.select().from(sources).all();
+  if (existingSources.length > 0) {
+    console.log("Database already has sources, skipping source seed.");
+  } else {
+    await seedSources();
+  }
+}
+
+async function seedPosts() {
   const now = new Date();
 
   // Create tags
@@ -36,11 +47,22 @@ async function seed() {
 
 When someone follows @erik@erikcraddock.me, they'll see my posts show up in their home feed, just like following any other account.
 
+> The best way to predict the future is to invent it.
+>
+> — Alan Kay
+
 The tech stack includes:
 - **Hono** for the web framework
 - **Fedify** for ActivityPub
 - **Drizzle + SQLite** for the database
 - **Tailwind** for styling
+
+Here is some \`inline code\` and a code block:
+
+\`\`\`javascript
+const greeting = "Hello, world!";
+console.log(greeting);
+\`\`\`
 
 More posts coming soon as I build this out!`,
       excerpt: "Introducing my new federated blog that can be followed from Mastodon.",
@@ -92,6 +114,44 @@ The small upfront cost of adding types pays off enormously as the project grows.
   }
 
   console.log(`✅ Seeded ${postData.length} posts and ${tagData.length} tags`);
+}
+
+async function seedSources() {
+  console.log("Creating sources...");
+
+  const sourceData = [
+    {
+      name: "Simon Willison's Weblog",
+      url: "https://simonwillison.net/",
+      feed_url: "https://simonwillison.net/atom/everything/",
+    },
+    {
+      name: "Julia Evans",
+      url: "https://jvns.ca/",
+      feed_url: "https://jvns.ca/atom.xml",
+    },
+    {
+      name: "Xe Iaso",
+      url: "https://xeiaso.net/",
+      feed_url: "https://xeiaso.net/blog.rss",
+    },
+    {
+      name: "Drew DeVault's Blog",
+      url: "https://drewdevault.com/",
+      feed_url: "https://drewdevault.com/blog/index.xml",
+    },
+    {
+      name: "Daring Fireball",
+      url: "https://daringfireball.net/",
+      feed_url: "https://daringfireball.net/feeds/main",
+    },
+  ];
+
+  for (const source of sourceData) {
+    db.insert(sources).values(source).run();
+  }
+
+  console.log(`✅ Seeded ${sourceData.length} sources`);
 }
 
 seed().catch(console.error);

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -46,6 +46,13 @@ beforeAll(async () => {
       tag_id INTEGER NOT NULL,
       PRIMARY KEY (post_id, tag_id)
     );
+
+    CREATE TABLE sources (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      url TEXT NOT NULL,
+      feed_url TEXT
+    );
   `);
 
   testDb = drizzle(testSqlite, { schema });
@@ -70,6 +77,9 @@ beforeAll(async () => {
     INSERT INTO post_tags (post_id, tag_id) VALUES (1, 2);
     INSERT INTO post_tags (post_id, tag_id) VALUES (2, 1);
     INSERT INTO post_tags (post_id, tag_id) VALUES (3, 2);
+
+    INSERT INTO sources (id, name, url, feed_url) VALUES (1, 'Test Blog', 'https://example.com', 'https://example.com/feed.xml');
+    INSERT INTO sources (id, name, url, feed_url) VALUES (2, 'Another Site', 'https://another.example.com', NULL);
   `);
 });
 
@@ -118,6 +128,87 @@ describe("pages routes", () => {
       expect(html).toContain("dark:bg-gray-900");
       expect(html).toContain("dark:text-gray-100");
       expect(html).toContain("dark:border-gray-700");
+    });
+
+    it("includes navigation links to About and Sources", async () => {
+      const app = getApp();
+      const res = await app.request("/");
+      const html = await res.text();
+
+      expect(html).toContain('href="/about"');
+      expect(html).toContain('href="/sources"');
+    });
+  });
+
+  describe("GET /about", () => {
+    it("returns 200 and displays about page", async () => {
+      const app = getApp();
+      const res = await app.request("/about");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("About");
+      expect(html).toContain("Erik Craddock");
+    });
+
+    it("includes ActivityPub follow information", async () => {
+      const app = getApp();
+      const res = await app.request("/about");
+      const html = await res.text();
+
+      expect(html).toContain("@erik@erikcraddock.me");
+      expect(html).toContain("Fediverse");
+    });
+
+    it("includes dark mode classes", async () => {
+      const app = getApp();
+      const res = await app.request("/about");
+      const html = await res.text();
+
+      expect(html).toContain("dark:bg-gray-900");
+      expect(html).toContain("dark:text-gray-100");
+    });
+  });
+
+  describe("GET /sources", () => {
+    it("returns 200 and displays sources page", async () => {
+      const app = getApp();
+      const res = await app.request("/sources");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("Sources");
+    });
+
+    it("lists sources from database", async () => {
+      const app = getApp();
+      const res = await app.request("/sources");
+      const html = await res.text();
+
+      expect(html).toContain("Test Blog");
+      expect(html).toContain("https://example.com");
+      expect(html).toContain("Another Site");
+    });
+
+    it("shows RSS link for sources with feed_url", async () => {
+      const app = getApp();
+      const res = await app.request("/sources");
+      const html = await res.text();
+
+      expect(html).toContain("RSS");
+      expect(html).toContain("https://example.com/feed.xml");
+    });
+
+    it("includes dark mode classes", async () => {
+      const app = getApp();
+      const res = await app.request("/sources");
+      const html = await res.text();
+
+      expect(html).toContain("dark:bg-gray-900");
+      expect(html).toContain("dark:text-gray-100");
+      expect(html).toContain("dark:text-blue-400");
     });
   });
 

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { raw } from "hono/html";
 import { desc, eq, isNotNull, and } from "drizzle-orm";
-import { db as defaultDb, posts, tags, postTags } from "../db";
+import { db as defaultDb, posts, tags, postTags, sources } from "../db";
 import { Layout } from "../templates/layout";
 import { NotFound } from "../templates/not-found";
 import { truncate } from "../utils/text";
@@ -72,6 +72,85 @@ export function createPagesRoutes(db: Database): Hono {
     return c.html(
       <Layout title="Home | erikcraddock.me">
         <PostList posts={allPosts} />
+      </Layout>
+    );
+  });
+
+  // About page
+  pages.get("/about", (c) => {
+    return c.html(
+      <Layout title="About | erikcraddock.me">
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">About</h1>
+
+        <div class="prose prose-gray dark:prose-invert max-w-none">
+          <p>
+            Hi, I'm Erik Craddock. This is my personal blog where I write about software
+            development, technology, and whatever else interests me.
+          </p>
+
+          <p>
+            This site is built with modern web technologies and supports ActivityPub, which means
+            you can follow it from Mastodon and other federated platforms.
+          </p>
+
+          <h2>Follow Me</h2>
+          <p>
+            You can follow this blog on the Fediverse at <code>@erik@erikcraddock.me</code>. New
+            posts will appear in your home feed just like any other account you follow.
+          </p>
+
+          <h2>Contact</h2>
+          <p>Feel free to reach out via the Fediverse or check out my projects on GitHub.</p>
+        </div>
+      </Layout>
+    );
+  });
+
+  // Sources / Blogroll page
+  pages.get("/sources", (c) => {
+    const allSources = db.select().from(sources).orderBy(sources.name).all();
+
+    return c.html(
+      <Layout title="Sources | erikcraddock.me">
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">Sources</h1>
+
+        <p class="text-gray-600 dark:text-gray-400 mb-8">
+          Blogs and websites I read and recommend. These are the sources that inspire my thinking
+          and writing.
+        </p>
+
+        {allSources.length === 0 ? (
+          <p class="text-gray-600 dark:text-gray-400">No sources yet.</p>
+        ) : (
+          <ul class="space-y-4">
+            {allSources.map((source) => (
+              <li key={source.id} class="border-b border-gray-200 dark:border-gray-700 pb-4">
+                <a
+                  href={source.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-lg font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  {source.name}
+                </a>
+                {source.feed_url ? (
+                  <span class="ml-2 text-sm text-gray-400 dark:text-gray-500">
+                    (
+                    <a
+                      href={source.feed_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="hover:text-gray-600 dark:hover:text-gray-300"
+                    >
+                      RSS
+                    </a>
+                    )
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
       </Layout>
     );
   });

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -35,7 +35,21 @@ export function Layout({ title, children }: LayoutProps) {
             >
               erikcraddock.me
             </a>
-            <ThemeToggle />
+            <div class="flex items-center gap-6">
+              <a
+                href="/about"
+                class="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+              >
+                About
+              </a>
+              <a
+                href="/sources"
+                class="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+              >
+                Sources
+              </a>
+              <ThemeToggle />
+            </div>
           </nav>
         </header>
         <main class="flex-1 max-w-4xl mx-auto px-4 py-8 w-full">{children}</main>


### PR DESCRIPTION
## Summary
Add static about page and sources (blogroll) page with navigation.

## Changes
- Add `GET /about` route with placeholder bio content
- Add `GET /sources` route listing sources from database
- Add navigation links (About, Sources) to site header
- Sources display name, URL link, and RSS link (if available)
- Add sample sources to seed script (5 recommended blogs)
- Dark mode styling throughout

## Task
Closes #1297

## Acceptance Criteria
- [x] `/about` shows about page with placeholder content
- [x] `/sources` lists sources from database
- [x] Sources show name and link to URL
- [x] Navigation includes links to both pages
- [x] Sources table exists in schema ✓ (already existed)

## Testing
- 8 new tests added (about: 3, sources: 4, nav: 1)
- 80 total tests passing
- Visual verification in browser