### PR TITLE
feat: add RSS feed at /feed.xml

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { serveStatic } from "hono/bun";
 import { pages } from "./routes/pages";
+import { feed } from "./routes/feed";
 import { logger } from "./utils/logger";
 
 const app = new Hono();
@@ -27,6 +28,7 @@ app.use("/css/*", serveStatic({ root: "./public" }));
 
 // Mount routes
 app.route("/", pages);
+app.route("/", feed);
 
 // ActivityPub actor endpoint (placeholder)
 app.get("/.well-known/webfinger", (c) => {

--- a/src/routes/__tests__/feed.test.ts
+++ b/src/routes/__tests__/feed.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import * as schema from "../../db/schema";
+
+// Create test database before mocking
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let testSqlite: InstanceType<typeof Database>;
+
+// Mock the db module to use our test database
+vi.mock("../../db", async () => {
+  const schema = await import("../../db/schema");
+  return {
+    db: testDb,
+    ...schema,
+  };
+});
+
+beforeAll(async () => {
+  // Create in-memory database for tests
+  testSqlite = new Database(":memory:");
+
+  // Create tables
+  testSqlite.exec(`
+    CREATE TABLE posts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      type TEXT NOT NULL,
+      title TEXT,
+      content TEXT NOT NULL,
+      excerpt TEXT,
+      url TEXT,
+      source_id INTEGER,
+      published_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+
+  testDb = drizzle(testSqlite, { schema });
+
+  // Insert test data
+  const now = Date.now();
+  const day = 24 * 60 * 60 * 1000;
+
+  testSqlite.exec(`
+    INSERT INTO posts (id, type, title, content, excerpt, published_at, created_at, updated_at)
+    VALUES (1, 'article', 'First Post', 'First post content.', 'First excerpt', ${now - day}, ${now}, ${now});
+
+    INSERT INTO posts (id, type, title, content, published_at, created_at, updated_at)
+    VALUES (2, 'article', 'Second Post', 'Second post content.', ${now}, ${now}, ${now});
+
+    INSERT INTO posts (id, type, title, content, created_at, updated_at)
+    VALUES (3, 'article', 'Draft Post', 'This is a draft.', ${now}, ${now});
+
+    INSERT INTO posts (id, type, title, content, published_at, created_at, updated_at)
+    VALUES (4, 'note', NULL, 'A note without title.', ${now - 2 * day}, ${now}, ${now});
+  `);
+});
+
+afterAll(() => {
+  testSqlite.close();
+});
+
+describe("feed routes", () => {
+  let createFeedRoutes: typeof import("../feed").createFeedRoutes;
+
+  beforeAll(async () => {
+    const module = await import("../feed");
+    createFeedRoutes = module.createFeedRoutes;
+  });
+
+  const getApp = () =>
+    createFeedRoutes(testDb as unknown as Parameters<typeof createFeedRoutes>[0]);
+
+  describe("GET /feed.xml", () => {
+    it("returns 200 with RSS content type", async () => {
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
+    });
+
+    it("returns valid RSS 2.0 XML structure", async () => {
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+      expect(xml).toContain('<rss version="2.0"');
+      expect(xml).toContain("<channel>");
+      expect(xml).toContain("</channel>");
+      expect(xml).toContain("</rss>");
+    });
+
+    it("includes channel metadata", async () => {
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      expect(xml).toContain("<title>erikcraddock.me</title>");
+      expect(xml).toContain("<description>");
+      expect(xml).toContain("<language>en-us</language>");
+      expect(xml).toContain("<lastBuildDate>");
+    });
+
+    it("includes atom:link for self-reference", async () => {
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      expect(xml).toContain('xmlns:atom="http://www.w3.org/2005/Atom"');
+      expect(xml).toContain('rel="self"');
+      expect(xml).toContain("/feed.xml");
+    });
+
+    it("includes published posts as items", async () => {
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      expect(xml).toContain("<item>");
+      expect(xml).toContain("First Post");
+      expect(xml).toContain("Second Post");
+    });
+
+    it("excludes draft posts", async () => {
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      expect(xml).not.toContain("Draft Post");
+    });
+
+    it("includes required item elements", async () => {
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      expect(xml).toContain("<title>");
+      expect(xml).toContain("<link>");
+      expect(xml).toContain("<description>");
+      expect(xml).toContain("<pubDate>");
+      expect(xml).toContain("<guid");
+    });
+
+    it("uses Untitled for posts without title", async () => {
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      // Post 4 has no title
+      expect(xml).toContain("<title>Untitled</title>");
+    });
+
+    it("escapes XML special characters", async () => {
+      // Add a post with special characters
+      const now = Date.now();
+      testSqlite.exec(`
+        INSERT INTO posts (id, type, title, content, published_at, created_at, updated_at)
+        VALUES (5, 'article', 'Test <>&"', 'Content with <special> chars & "quotes"', ${now}, ${now}, ${now});
+      `);
+
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      expect(xml).toContain("&lt;");
+      expect(xml).toContain("&gt;");
+      expect(xml).toContain("&amp;");
+    });
+
+    it("orders posts by published_at descending", async () => {
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      // Second Post was published most recently
+      const secondPostIndex = xml.indexOf("Second Post");
+      const firstPostIndex = xml.indexOf("First Post");
+
+      expect(secondPostIndex).toBeLessThan(firstPostIndex);
+    });
+  });
+});

--- a/src/routes/feed.ts
+++ b/src/routes/feed.ts
@@ -1,0 +1,97 @@
+import { Hono } from "hono";
+import { desc, isNotNull } from "drizzle-orm";
+import { db as defaultDb, posts } from "../db";
+import { truncate } from "../utils/text";
+
+// Database type for dependency injection
+type Database = typeof defaultDb;
+
+// Site configuration
+const SITE_URL = process.env.SITE_URL || "https://erikcraddock.me";
+const SITE_TITLE = "erikcraddock.me";
+const SITE_DESCRIPTION = "Personal blog by Erik Craddock";
+
+/**
+ * Escapes special XML characters
+ */
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Formats a date for RSS (RFC 822 format)
+ */
+function formatRssDate(date: Date): string {
+  return date.toUTCString();
+}
+
+/**
+ * Creates feed routes with the given database instance.
+ * Allows dependency injection for testing.
+ */
+export function createFeedRoutes(db: Database): Hono {
+  const feed = new Hono();
+
+  feed.get("/feed.xml", (c) => {
+    // Query recent published posts
+    const recentPosts = db
+      .select()
+      .from(posts)
+      .where(isNotNull(posts.published_at))
+      .orderBy(desc(posts.published_at))
+      .limit(20)
+      .all();
+
+    // Build RSS 2.0 XML
+    const items = recentPosts
+      .map((post) => {
+        const title = post.title || "Untitled";
+        const link = `${SITE_URL}/posts/${post.id}`;
+        const description = post.excerpt || truncate(post.content, 300);
+        const pubDate = post.published_at ? formatRssDate(new Date(post.published_at)) : "";
+
+        return `    <item>
+      <title>${escapeXml(title)}</title>
+      <link>${escapeXml(link)}</link>
+      <description>${escapeXml(description)}</description>
+      <pubDate>${pubDate}</pubDate>
+      <guid isPermaLink="true">${escapeXml(link)}</guid>
+    </item>`;
+      })
+      .join("\n");
+
+    const lastBuildDate =
+      recentPosts.length > 0 && recentPosts[0].published_at
+        ? formatRssDate(new Date(recentPosts[0].published_at))
+        : formatRssDate(new Date());
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(SITE_TITLE)}</title>
+    <link>${escapeXml(SITE_URL)}</link>
+    <description>${escapeXml(SITE_DESCRIPTION)}</description>
+    <language>en-us</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${escapeXml(SITE_URL)}/feed.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+    return c.text(xml, 200, {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    });
+  });
+
+  return feed;
+}
+
+// Default export using the global database
+const feed = createFeedRoutes(defaultDb);
+
+export { feed };

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -25,6 +25,12 @@ export function Layout({ title, children }: LayoutProps) {
         <title>{title}</title>
         <script>{raw(themeScript)}</script>
         <link rel="stylesheet" href="/css/main.css" />
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="erikcraddock.me RSS Feed"
+          href="/feed.xml"
+        />
       </head>
       <body class="min-h-screen flex flex-col bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
         <header class="bg-white shadow-sm dark:bg-gray-800 dark:shadow-gray-900/50">


### PR DESCRIPTION
## Summary
Add an RSS 2.0 feed at `/feed.xml` for blog syndication.

## Changes
- Create `src/routes/feed.ts` with RSS 2.0 feed generation
- Query recent published posts (limit 20)
- Each item includes: title, link, description (excerpt), pubDate, guid
- Set `Content-Type: application/rss+xml` header
- Include `atom:link` self-reference for feed validators
- Escape XML special characters
- Add feed autodiscovery link to layout `<head>`
- Mount feed route in `src/index.tsx`

## Task
Closes #1296

## Acceptance Criteria
- [x] `/feed.xml` returns valid RSS/Atom XML
- [x] Feed contains recent posts with correct data
- [x] Feed validates (RSS 2.0 structure with atom namespace)
- [x] Layout includes `<link rel="alternate" type="application/rss+xml">`

## Testing
- 10 new tests for feed route
- 90 total tests passing
- Manual validation of XML structure