### PR TITLE
feat: seed admin author from ADMIN_EMAIL env var

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,7 +1,11 @@
-import { db, posts, tags, postTags, sources } from "../src/db";
+import { eq } from "drizzle-orm";
+import { db, posts, tags, postTags, sources, authors } from "../src/db";
 
 async function seed() {
   console.log("🌱 Seeding database...");
+
+  // Always ensure admin author exists
+  await seedAdminAuthor();
 
   // Check if already seeded
   const existingPosts = db.select().from(posts).all();
@@ -18,6 +22,32 @@ async function seed() {
   } else {
     await seedSources();
   }
+}
+
+async function seedAdminAuthor() {
+  const adminEmail = process.env.ADMIN_EMAIL;
+
+  if (!adminEmail) {
+    console.log("⚠️  ADMIN_EMAIL not set, skipping admin author seed.");
+    return;
+  }
+
+  // Check if admin already exists
+  const existing = db.select().from(authors).where(eq(authors.email, adminEmail)).get();
+
+  if (existing) {
+    console.log(`Admin author already exists: ${adminEmail}`);
+    return;
+  }
+
+  db.insert(authors)
+    .values({
+      email: adminEmail,
+      created_at: new Date(),
+    })
+    .run();
+
+  console.log(`✅ Seeded admin author: ${adminEmail}`);
 }
 
 async function seedPosts() {


### PR DESCRIPTION
## Summary

Completes the auth database schema setup by adding admin author seeding.

## Changes

- Add `seedAdminAuthor()` function to `scripts/seed.ts`
- Reads `ADMIN_EMAIL` from environment variables
- Creates author record if not already present
- Skips gracefully if `ADMIN_EMAIL` not set

## Notes

The schema tables (`authors`, `magic_links`, `sessions`) were already present in `src/db/schema.ts`. This PR completes the task by ensuring the admin user gets seeded.

## Checklist

- [x] All three tables exist in schema
- [x] Foreign key from sessions to authors  
- [x] Seed script adds admin email to authors
- [x] `make db-push` applies schema changes
- [x] Tests pass
- [x] Typecheck passes
- [x] Lint passes

Task: #1303