### PR TITLE
feat: add POST /api/posts endpoint

### DIFF
--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -423,3 +423,236 @@ describe("GET /api/posts/:id", () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe("POST /api/posts", () => {
+  let testApiKey: string;
+
+  beforeEach(async () => {
+    // Clean up
+    testSqlite.exec("DELETE FROM post_tags");
+    testSqlite.exec("DELETE FROM tags");
+    testSqlite.exec("DELETE FROM posts");
+    testSqlite.exec("DELETE FROM api_keys");
+    testSqlite.exec("DELETE FROM authors");
+
+    // Create test author
+    const author = testSqlite
+      .prepare("INSERT INTO authors (email, display_name, created_at) VALUES (?, ?, ?) RETURNING id")
+      .get("test@example.com", "Test User", Date.now()) as { id: number };
+
+    // Create API key
+    const { hashToken } = await import("../../auth/crypto");
+    testApiKey = "ek_test1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab";
+    const keyHash = await hashToken(testApiKey);
+
+    testSqlite
+      .prepare("INSERT INTO api_keys (author_id, key_hash, name, created_at) VALUES (?, ?, ?, ?)")
+      .run(author.id, keyHash, "Test Key", Date.now());
+  });
+
+  it("creates an article post", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "article",
+        title: "My Article",
+        content: "This is the content",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.type).toBe("article");
+    expect(json.data.title).toBe("My Article");
+    expect(json.data.content).toBe("This is the content");
+    expect(json.data.id).toBeGreaterThan(0);
+  });
+
+  it("creates a note without title", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "note",
+        content: "Just a quick thought",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.type).toBe("note");
+    expect(json.data.title).toBeNull();
+  });
+
+  it("creates a link post with url", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "link",
+        title: "Cool Link",
+        content: "Check this out",
+        url: "https://example.com",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.type).toBe("link");
+    expect(json.data.url).toBe("https://example.com");
+  });
+
+  it("auto-generates excerpt if not provided", async () => {
+    const { api } = await import("../api");
+    const longContent = "A".repeat(250);
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "note",
+        content: longContent,
+      }),
+    });
+
+    const json = await res.json();
+    expect(json.data.excerpt).toBe("A".repeat(200) + "...");
+  });
+
+  it("creates tags if they don't exist", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "article",
+        title: "Tagged Post",
+        content: "Content here",
+        tags: ["javascript", "web-dev"],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.tags).toContain("Javascript");
+    expect(json.data.tags).toContain("Web Dev");
+
+    // Verify tags were created in DB
+    const jsTag = testSqlite.prepare("SELECT * FROM tags WHERE slug = ?").get("javascript");
+    expect(jsTag).toBeDefined();
+  });
+
+  it("returns 400 for missing type", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        content: "No type provided",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("type");
+  });
+
+  it("returns 400 for missing content", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "note",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Content");
+  });
+
+  it("returns 400 for article without title", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "article",
+        content: "Content but no title",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Title");
+  });
+
+  it("returns 400 for link without url", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "link",
+        title: "A Link",
+        content: "Content",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("URL");
+  });
+
+  it("returns 401 without API key", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: "note", content: "test" }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { requireApiKey } from "@/auth/api-key";
-import { listPosts, getPost, PostType } from "@/services/posts";
+import { listPosts, getPost, createPost, PostType } from "@/services/posts";
 
 export const api = new Hono();
 
@@ -63,4 +63,49 @@ api.get("/posts/:id", (c) => {
   }
 
   return c.json({ data: post });
+});
+
+/**
+ * POST /api/posts - Create new post
+ */
+api.post("/posts", async (c) => {
+  const body = await c.req.json();
+
+  // Validate type
+  const { type, title, content, excerpt, url, tags } = body;
+
+  if (!type || !["article", "link", "note"].includes(type)) {
+    return c.json({ error: "Invalid or missing type. Must be article, link, or note" }, 400);
+  }
+
+  // Validate content
+  if (!content || typeof content !== "string" || content.trim().length === 0) {
+    return c.json({ error: "Content is required" }, 400);
+  }
+
+  // Articles require title
+  if (type === "article" && (!title || typeof title !== "string" || title.trim().length === 0)) {
+    return c.json({ error: "Title is required for articles" }, 400);
+  }
+
+  // Links require url
+  if (type === "link" && (!url || typeof url !== "string" || url.trim().length === 0)) {
+    return c.json({ error: "URL is required for links" }, 400);
+  }
+
+  // Validate tags if provided
+  if (tags !== undefined && !Array.isArray(tags)) {
+    return c.json({ error: "Tags must be an array" }, 400);
+  }
+
+  const post = createPost({
+    type,
+    title: title?.trim() || null,
+    content: content.trim(),
+    excerpt: excerpt?.trim() || null,
+    url: url?.trim() || null,
+    tags: tags || [],
+  });
+
+  return c.json({ data: post }, 201);
 });

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -100,6 +100,105 @@ export function listPosts(options: ListPostsOptions = {}): PostListItem[] {
   return postsWithTags;
 }
 
+export interface CreatePostInput {
+  type: PostType;
+  title?: string | null;
+  content: string;
+  excerpt?: string | null;
+  url?: string | null;
+  tags?: string[]; // Tag slugs
+}
+
+/**
+ * Generate a slug from a string
+ */
+function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Get or create a tag by slug
+ */
+function getOrCreateTag(slug: string): number {
+  const existing = db.select().from(tags).where(eq(tags.slug, slug)).get();
+
+  if (existing) {
+    return existing.id;
+  }
+
+  // Create new tag - convert slug to title case for name
+  const name = slug
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+
+  const created = db
+    .insert(tags)
+    .values({ name, slug })
+    .returning()
+    .get();
+
+  return created.id;
+}
+
+/**
+ * Create a new post
+ */
+export function createPost(input: CreatePostInput) {
+  const { type, title, content, excerpt, url, tags: tagSlugs } = input;
+
+  // Auto-generate excerpt if not provided
+  const finalExcerpt = excerpt ?? content.slice(0, 200) + (content.length > 200 ? "..." : "");
+
+  const now = new Date();
+
+  // Create the post
+  const post = db
+    .insert(posts)
+    .values({
+      type,
+      title: title ?? null,
+      content,
+      excerpt: finalExcerpt,
+      url: url ?? null,
+      created_at: now,
+      updated_at: now,
+    })
+    .returning()
+    .get();
+
+  // Handle tags
+  const tagNames: string[] = [];
+  if (tagSlugs && tagSlugs.length > 0) {
+    for (const slug of tagSlugs) {
+      const normalizedSlug = slugify(slug);
+      if (normalizedSlug) {
+        const tagId = getOrCreateTag(normalizedSlug);
+        db.insert(postTags).values({ post_id: post.id, tag_id: tagId }).run();
+
+        // Get the tag name for the response
+        const tag = db.select().from(tags).where(eq(tags.id, tagId)).get();
+        if (tag) {
+          tagNames.push(tag.name);
+        }
+      }
+    }
+  }
+
+  return {
+    ...post,
+    published_at: post.published_at?.toISOString() ?? null,
+    created_at: post.created_at.toISOString(),
+    updated_at: post.updated_at.toISOString(),
+    tags: tagNames,
+  };
+}
+
 /**
  * Get a single post by ID
  */


### PR DESCRIPTION
## Summary

API endpoint to create new posts.

## Task #1300

## Changes

### Posts Service
- `createPost()` - Create post with tags
- `slugify()` - Generate tag slugs
- `getOrCreateTag()` - Find or create tags

### API Route (`POST /api/posts`)

**Request:**
```json
{
  "type": "article",
  "title": "My Post",
  "content": "Full content...",
  "excerpt": "Optional",
  "url": "https://... (for links)",
  "tags": ["tag-slug"]
}
```

**Validation:**
- `type` required (article/link/note)
- `content` required
- `title` required for articles
- `url` required for links
- `tags` must be array if provided

**Features:**
- Auto-generates excerpt (first 200 chars) if not provided
- Creates tags if they don't exist
- Returns 201 with created post

## Test Coverage (163 tests, 10 new)

- Creates article/note/link posts
- Auto-generates excerpt
- Creates tags
- Validates required fields
- Returns proper error codes

Task: #1300