### PR TITLE
feat: add PUT/DELETE /api/posts/:id endpoints

### DIFF
--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -656,3 +656,196 @@ describe("POST /api/posts", () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe("PUT /api/posts/:id", () => {
+  let testApiKey: string;
+
+  beforeEach(async () => {
+    testSqlite.exec("DELETE FROM post_tags");
+    testSqlite.exec("DELETE FROM tags");
+    testSqlite.exec("DELETE FROM posts");
+    testSqlite.exec("DELETE FROM api_keys");
+    testSqlite.exec("DELETE FROM authors");
+
+    const author = testSqlite
+      .prepare("INSERT INTO authors (email, display_name, created_at) VALUES (?, ?, ?) RETURNING id")
+      .get("test@example.com", "Test User", Date.now()) as { id: number };
+
+    const { hashToken } = await import("../../auth/crypto");
+    testApiKey = "ek_test1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab";
+    const keyHash = await hashToken(testApiKey);
+
+    testSqlite
+      .prepare("INSERT INTO api_keys (author_id, key_hash, name, created_at) VALUES (?, ?, ?, ?)")
+      .run(author.id, keyHash, "Test Key", Date.now());
+  });
+
+  it("updates post title", async () => {
+    const now = Date.now();
+    const post = testSqlite
+      .prepare(
+        "INSERT INTO posts (type, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?) RETURNING id"
+      )
+      .get("article", "Old Title", "Content", now, now) as { id: number };
+
+    const { api } = await import("../api");
+
+    const res = await api.request(`/posts/${post.id}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ title: "New Title" }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.title).toBe("New Title");
+    expect(json.data.content).toBe("Content"); // Unchanged
+  });
+
+  it("updates post tags", async () => {
+    const now = Date.now();
+    const post = testSqlite
+      .prepare(
+        "INSERT INTO posts (type, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?) RETURNING id"
+      )
+      .get("article", "Title", "Content", now, now) as { id: number };
+
+    const { api } = await import("../api");
+
+    const res = await api.request(`/posts/${post.id}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ tags: ["new-tag"] }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.tags).toContain("New Tag");
+  });
+
+  it("returns 404 for non-existent post", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts/99999", {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ title: "New Title" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 without API key", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts/1", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "New Title" }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("DELETE /api/posts/:id", () => {
+  let testApiKey: string;
+
+  beforeEach(async () => {
+    testSqlite.exec("DELETE FROM post_tags");
+    testSqlite.exec("DELETE FROM tags");
+    testSqlite.exec("DELETE FROM posts");
+    testSqlite.exec("DELETE FROM api_keys");
+    testSqlite.exec("DELETE FROM authors");
+
+    const author = testSqlite
+      .prepare("INSERT INTO authors (email, display_name, created_at) VALUES (?, ?, ?) RETURNING id")
+      .get("test@example.com", "Test User", Date.now()) as { id: number };
+
+    const { hashToken } = await import("../../auth/crypto");
+    testApiKey = "ek_test1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab";
+    const keyHash = await hashToken(testApiKey);
+
+    testSqlite
+      .prepare("INSERT INTO api_keys (author_id, key_hash, name, created_at) VALUES (?, ?, ?, ?)")
+      .run(author.id, keyHash, "Test Key", Date.now());
+  });
+
+  it("deletes post", async () => {
+    const now = Date.now();
+    const post = testSqlite
+      .prepare(
+        "INSERT INTO posts (type, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?) RETURNING id"
+      )
+      .get("article", "Title", "Content", now, now) as { id: number };
+
+    const { api } = await import("../api");
+
+    const res = await api.request(`/posts/${post.id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${testApiKey}` },
+    });
+
+    expect(res.status).toBe(204);
+
+    // Verify deleted
+    const deleted = testSqlite.prepare("SELECT * FROM posts WHERE id = ?").get(post.id);
+    expect(deleted).toBeUndefined();
+  });
+
+  it("deletes tag associations", async () => {
+    const now = Date.now();
+    const post = testSqlite
+      .prepare(
+        "INSERT INTO posts (type, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?) RETURNING id"
+      )
+      .get("article", "Title", "Content", now, now) as { id: number };
+
+    const tag = testSqlite
+      .prepare("INSERT INTO tags (name, slug) VALUES (?, ?) RETURNING id")
+      .get("Test", "test") as { id: number };
+
+    testSqlite.prepare("INSERT INTO post_tags (post_id, tag_id) VALUES (?, ?)").run(post.id, tag.id);
+
+    const { api } = await import("../api");
+
+    await api.request(`/posts/${post.id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${testApiKey}` },
+    });
+
+    // Verify tag association deleted
+    const assoc = testSqlite.prepare("SELECT * FROM post_tags WHERE post_id = ?").get(post.id);
+    expect(assoc).toBeUndefined();
+  });
+
+  it("returns 404 for non-existent post", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts/99999", {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${testApiKey}` },
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 without API key", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts/1", {
+      method: "DELETE",
+    });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { requireApiKey } from "@/auth/api-key";
-import { listPosts, getPost, createPost, PostType } from "@/services/posts";
+import { listPosts, getPost, createPost, updatePost, deletePost, PostType } from "@/services/posts";
 
 export const api = new Hono();
 
@@ -108,4 +108,56 @@ api.post("/posts", async (c) => {
   });
 
   return c.json({ data: post }, 201);
+});
+
+/**
+ * PUT /api/posts/:id - Update post
+ */
+api.put("/posts/:id", async (c) => {
+  const id = parseInt(c.req.param("id"), 10);
+
+  if (isNaN(id)) {
+    return c.json({ error: "Invalid post ID" }, 400);
+  }
+
+  const body = await c.req.json();
+  const { title, content, excerpt, url, tags } = body;
+
+  // Validate tags if provided
+  if (tags !== undefined && !Array.isArray(tags)) {
+    return c.json({ error: "Tags must be an array" }, 400);
+  }
+
+  const post = updatePost(id, {
+    title: title !== undefined ? (title?.trim() || null) : undefined,
+    content: content?.trim(),
+    excerpt: excerpt !== undefined ? (excerpt?.trim() || null) : undefined,
+    url: url !== undefined ? (url?.trim() || null) : undefined,
+    tags,
+  });
+
+  if (!post) {
+    return c.json({ error: "Post not found" }, 404);
+  }
+
+  return c.json({ data: post });
+});
+
+/**
+ * DELETE /api/posts/:id - Delete post
+ */
+api.delete("/posts/:id", (c) => {
+  const id = parseInt(c.req.param("id"), 10);
+
+  if (isNaN(id)) {
+    return c.json({ error: "Invalid post ID" }, 400);
+  }
+
+  const deleted = deletePost(id);
+
+  if (!deleted) {
+    return c.json({ error: "Post not found" }, 404);
+  }
+
+  return c.body(null, 204);
 });

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -199,6 +199,77 @@ export function createPost(input: CreatePostInput) {
   };
 }
 
+export interface UpdatePostInput {
+  title?: string | null;
+  content?: string;
+  excerpt?: string | null;
+  url?: string | null;
+  tags?: string[]; // Tag slugs
+}
+
+/**
+ * Update an existing post
+ */
+export function updatePost(id: number, input: UpdatePostInput) {
+  const existing = db.select().from(posts).where(eq(posts.id, id)).get();
+
+  if (!existing) {
+    return null;
+  }
+
+  const { title, content, excerpt, url, tags: tagSlugs } = input;
+
+  // Build update object with only provided fields
+  const updates: Record<string, unknown> = {
+    updated_at: new Date(),
+  };
+
+  if (title !== undefined) updates.title = title;
+  if (content !== undefined) updates.content = content;
+  if (excerpt !== undefined) updates.excerpt = excerpt;
+  if (url !== undefined) updates.url = url;
+
+  // Update post
+  db.update(posts).set(updates).where(eq(posts.id, id)).run();
+
+  // Update tags if provided
+  if (tagSlugs !== undefined) {
+    // Remove existing tag associations
+    db.delete(postTags).where(eq(postTags.post_id, id)).run();
+
+    // Add new tags
+    for (const slug of tagSlugs) {
+      const normalizedSlug = slugify(slug);
+      if (normalizedSlug) {
+        const tagId = getOrCreateTag(normalizedSlug);
+        db.insert(postTags).values({ post_id: id, tag_id: tagId }).run();
+      }
+    }
+  }
+
+  // Return updated post
+  return getPost(id);
+}
+
+/**
+ * Delete a post
+ */
+export function deletePost(id: number): boolean {
+  const existing = db.select().from(posts).where(eq(posts.id, id)).get();
+
+  if (!existing) {
+    return false;
+  }
+
+  // Delete tag associations (cascade should handle this, but be explicit)
+  db.delete(postTags).where(eq(postTags.post_id, id)).run();
+
+  // Delete the post
+  db.delete(posts).where(eq(posts.id, id)).run();
+
+  return true;
+}
+
 /**
  * Get a single post by ID
  */


### PR DESCRIPTION
## Summary

API endpoints to update and delete posts.

## Task #1301

## Changes

### PUT /api/posts/:id
- Updates only provided fields
- Updates `updated_at` timestamp
- Can replace tags array
- Returns updated post

### DELETE /api/posts/:id
- Removes post and tag associations
- Returns 204 No Content

## Test Coverage (171 tests, 8 new)

**PUT:**
- Updates post title
- Updates post tags
- Returns 404 for non-existent
- Returns 401 without API key

**DELETE:**
- Deletes post
- Deletes tag associations
- Returns 404 for non-existent
- Returns 401 without API key

Task: #1301