### PR TITLE
feat: Author management - admin only

### DIFF
--- a/src/auth/__tests__/authors.test.ts
+++ b/src/auth/__tests__/authors.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import * as schema from "../../db/schema";
+
+// Create test database before mocking
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let testSqlite: InstanceType<typeof Database>;
+
+// Mock the db module to use our test database
+vi.mock("../../db", async () => {
+  const schema = await import("../../db/schema");
+  return {
+    db: testDb,
+    ...schema,
+  };
+});
+
+beforeAll(async () => {
+  testSqlite = new Database(":memory:");
+
+  testSqlite.exec(`
+    CREATE TABLE authors (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE,
+      created_at INTEGER NOT NULL
+    );
+  `);
+
+  testDb = drizzle(testSqlite, { schema });
+});
+
+afterAll(() => {
+  testSqlite.close();
+});
+
+describe("Authors", () => {
+  beforeEach(() => {
+    testSqlite.exec("DELETE FROM authors");
+  });
+
+  describe("listAuthors", () => {
+    it("returns empty list when no authors exist", async () => {
+      const { listAuthors } = await import("../authors");
+      const result = listAuthors();
+      expect(result).toEqual([]);
+    });
+
+    it("returns all authors", async () => {
+      testSqlite.exec(
+        "INSERT INTO authors (email, created_at) VALUES ('a@test.com', 1000), ('b@test.com', 2000)"
+      );
+      const { listAuthors } = await import("../authors");
+      const result = listAuthors();
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("addAuthor", () => {
+    it("adds a new author", async () => {
+      const { addAuthor } = await import("../authors");
+      const result = addAuthor("new@test.com");
+      expect(result).not.toBeNull();
+      expect(result!.email).toBe("new@test.com");
+    });
+
+    it("normalizes email to lowercase", async () => {
+      const { addAuthor } = await import("../authors");
+      const result = addAuthor("  User@Test.COM  ");
+      expect(result).not.toBeNull();
+      expect(result!.email).toBe("user@test.com");
+    });
+
+    it("returns null for duplicate email", async () => {
+      const { addAuthor } = await import("../authors");
+      addAuthor("dup@test.com");
+      const result = addAuthor("dup@test.com");
+      expect(result).toBeNull();
+    });
+
+    it("returns null for invalid email", async () => {
+      const { addAuthor } = await import("../authors");
+      expect(addAuthor("")).toBeNull();
+      expect(addAuthor("notanemail")).toBeNull();
+    });
+  });
+
+  describe("deleteAuthor", () => {
+    it("deletes an author by ID", async () => {
+      const { addAuthor, deleteAuthor, listAuthors } = await import("../authors");
+      const author = addAuthor("delete-me@test.com");
+      expect(author).not.toBeNull();
+
+      const result = deleteAuthor(author!.id, "admin@test.com");
+      expect(result).toBe(true);
+      expect(listAuthors()).toHaveLength(0);
+    });
+
+    it("returns false when deleting own email", async () => {
+      const { addAuthor, deleteAuthor } = await import("../authors");
+      const author = addAuthor("admin@test.com");
+      expect(author).not.toBeNull();
+
+      const result = deleteAuthor(author!.id, "admin@test.com");
+      expect(result).toBe(false);
+    });
+
+    it("returns false for non-existent author", async () => {
+      const { deleteAuthor } = await import("../authors");
+      const result = deleteAuthor(999, "admin@test.com");
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/auth/__tests__/passkey.test.ts
+++ b/src/auth/__tests__/passkey.test.ts
@@ -191,7 +191,8 @@ describe("Passkey Service", () => {
 
   describe("verifyAndStorePasskey", () => {
     it("stores passkey on successful verification", async () => {
-      const { generatePasskeyRegistrationOptions, verifyAndStorePasskey } = await import("../passkey");
+      const { generatePasskeyRegistrationOptions, verifyAndStorePasskey } =
+        await import("../passkey");
       await generatePasskeyRegistrationOptions(testAuthorId, "test@example.com");
 
       const mockResponse = {
@@ -263,7 +264,13 @@ describe("Passkey Service", () => {
         .prepare(
           "INSERT INTO passkeys (author_id, credential_id, public_key, name, created_at) VALUES (?, ?, ?, ?, ?)"
         )
-        .run(testAuthorId, "verify-cred", Buffer.from([1, 2, 3, 4]).toString("base64"), "Verify Test", Date.now());
+        .run(
+          testAuthorId,
+          "verify-cred",
+          Buffer.from([1, 2, 3, 4]).toString("base64"),
+          "Verify Test",
+          Date.now()
+        );
 
       const { generatePasskeyAuthOptions, verifyPasskeyAuth } = await import("../passkey");
       await generatePasskeyAuthOptions();

--- a/src/auth/__tests__/passkey.test.ts
+++ b/src/auth/__tests__/passkey.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import Database from "better-sqlite3";
+import type {
+  RegistrationResponseJSON,
+  AuthenticatorAssertionResponseJSON,
+} from "@simplewebauthn/server";
 import * as schema from "../../db/schema";
 
 // Create test database before mocking
@@ -224,7 +228,7 @@ describe("Passkey Service", () => {
         testAuthorId,
         "unknown@example.com",
         "Test",
-        {} as any
+        {} as RegistrationResponseJSON
       );
 
       expect(result.success).toBe(false);
@@ -250,7 +254,7 @@ describe("Passkey Service", () => {
       const result = await verifyPasskeyAuth({
         id: "nonexistent-cred",
         rawId: "nonexistent-cred",
-        response: {} as any,
+        response: {} as AuthenticatorAssertionResponseJSON,
         type: "public-key",
         clientExtensionResults: {},
       });

--- a/src/auth/authors.ts
+++ b/src/auth/authors.ts
@@ -1,0 +1,64 @@
+import { eq } from "drizzle-orm";
+import { db, authors } from "@/db";
+import { logger } from "@/utils/logger";
+
+/**
+ * List all authors
+ */
+export function listAuthors() {
+  return db.select().from(authors).all();
+}
+
+/**
+ * Add an email to the authors allow list.
+ * Returns the new author, or null if the email already exists.
+ */
+export function addAuthor(email: string): { id: number; email: string; created_at: Date } | null {
+  const normalized = email.toLowerCase().trim();
+
+  if (!normalized || !normalized.includes("@")) {
+    logger.warn("authors", "Invalid email provided", { email });
+    return null;
+  }
+
+  // Check if already exists
+  const existing = db.select().from(authors).where(eq(authors.email, normalized)).get();
+  if (existing) {
+    logger.debug("authors", "Author already exists", { email: normalized });
+    return null;
+  }
+
+  const result = db
+    .insert(authors)
+    .values({
+      email: normalized,
+      created_at: new Date(),
+    })
+    .returning()
+    .get();
+
+  logger.info("authors", "Author added", { email: normalized });
+  return result;
+}
+
+/**
+ * Delete an author by ID.
+ * Returns false if the author doesn't exist or if trying to delete the admin.
+ */
+export function deleteAuthor(authorId: number, currentEmail: string): boolean {
+  const author = db.select().from(authors).where(eq(authors.id, authorId)).get();
+
+  if (!author) {
+    logger.warn("authors", "Author not found for deletion", { authorId });
+    return false;
+  }
+
+  if (author.email.toLowerCase() === currentEmail.toLowerCase()) {
+    logger.warn("authors", "Cannot delete own email", { email: currentEmail });
+    return false;
+  }
+
+  db.delete(authors).where(eq(authors.id, authorId)).run();
+  logger.info("authors", "Author deleted", { authorId, email: author.email });
+  return true;
+}

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { Layout } from "@/templates/layout";
 import { requireAuth, requireAdmin } from "@/auth/middleware";
 import { listApiKeys, createApiKey, revokeApiKey, getAuthorByEmail } from "@/auth/api-key";
+import { listAuthors, addAuthor, deleteAuthor } from "@/auth/authors";
 import {
   listPasskeys,
   generatePasskeyRegistrationOptions,
@@ -493,16 +494,132 @@ admin.post("/passkeys/:id/delete", async (c) => {
  */
 admin.get("/authors", requireAdmin, (c) => {
   const auth = c.get("auth");
+  const authorsList = listAuthors();
+  const error = c.req.query("error");
+  const success = c.req.query("success");
 
   return c.html(
     <Layout title="Authors | Admin">
       <div class="max-w-4xl mx-auto">
         <AdminHeader title="Authors" isAdmin={auth.isAdmin} />
 
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-          <p class="text-gray-500 dark:text-gray-400">Author management coming soon...</p>
+        {error && (
+          <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 mb-6">
+            <p class="text-red-700 dark:text-red-300">{error}</p>
+          </div>
+        )}
+
+        {success && (
+          <div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4 mb-6">
+            <p class="text-green-700 dark:text-green-300">{success}</p>
+          </div>
+        )}
+
+        {/* Add author form */}
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
+          <h2 class="text-lg font-semibold mb-4">Add Author</h2>
+          <form method="post" action="/admin/authors" class="flex gap-4">
+            <input
+              type="email"
+              name="email"
+              placeholder="Email address"
+              required
+              class="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            />
+            <button
+              type="submit"
+              class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            >
+              Add Author
+            </button>
+          </form>
+        </div>
+
+        {/* Authors list */}
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow">
+          <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <h2 class="text-lg font-semibold">Allowed Authors</h2>
+          </div>
+
+          {authorsList.length === 0 ? (
+            <div class="p-6 text-gray-500 dark:text-gray-400">No authors yet. Add one above.</div>
+          ) : (
+            <ul class="divide-y divide-gray-200 dark:divide-gray-700">
+              {authorsList.map((author) => {
+                const isSelf = author.email.toLowerCase() === auth.email.toLowerCase();
+                return (
+                  <li class="p-4 flex items-center justify-between">
+                    <div>
+                      <p class="font-medium text-gray-900 dark:text-white">
+                        {author.email}
+                        {isSelf && (
+                          <span class="ml-2 px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300 rounded">
+                            You
+                          </span>
+                        )}
+                      </p>
+                      <p class="text-sm text-gray-500 dark:text-gray-400">
+                        Added: {formatDate(author.created_at)}
+                      </p>
+                    </div>
+                    {!isSelf && (
+                      <form method="post" action={`/admin/authors/${author.id}/delete`}>
+                        <button
+                          type="submit"
+                          class="px-3 py-1 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
+                          onclick="return confirm('Remove this author? They will lose access.')"
+                        >
+                          Remove
+                        </button>
+                      </form>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
         </div>
       </div>
     </Layout>
   );
+});
+
+/**
+ * POST /admin/authors - Add author (admin only)
+ */
+admin.post("/authors", requireAdmin, async (c) => {
+  const body = await c.req.parseBody();
+  const email = body.email as string;
+
+  if (!email || !email.trim()) {
+    return c.redirect("/admin/authors?error=Email is required");
+  }
+
+  const result = addAuthor(email);
+
+  if (!result) {
+    return c.redirect("/admin/authors?error=Invalid email or author already exists");
+  }
+
+  return c.redirect(`/admin/authors?success=${encodeURIComponent(`Added ${result.email}`)}`);
+});
+
+/**
+ * POST /admin/authors/:id/delete - Remove author (admin only)
+ */
+admin.post("/authors/:id/delete", requireAdmin, (c) => {
+  const auth = c.get("auth");
+  const authorId = parseInt(c.req.param("id"), 10);
+
+  if (isNaN(authorId)) {
+    return c.redirect("/admin/authors?error=Invalid author ID");
+  }
+
+  const success = deleteAuthor(authorId, auth.email);
+
+  if (!success) {
+    return c.redirect("/admin/authors?error=Could not remove author");
+  }
+
+  return c.redirect("/admin/authors?success=Author removed");
 });


### PR DESCRIPTION
## Summary
Implements admin-only author management page at `/admin/authors`.

## What Changed
- **New**: `src/auth/authors.ts` - `listAuthors`, `addAuthor`, `deleteAuthor` functions
- **New**: `src/auth/__tests__/authors.test.ts` - 9 tests for author functions
- **Updated**: `src/routes/admin.tsx` - Full authors page with add/remove UI, wired to POST routes

## How It Works
- Admin (matched by `ADMIN_EMAIL` env var) can add/remove emails from the allowed authors list
- Routes protected by existing `requireAdmin` middleware
- Cannot remove own email (self-protection)
- Non-admins get redirected (403 behavior via middleware)

## Acceptance Criteria
- [x] Only admin can access /admin/authors
- [x] Can add new email to allowed list
- [x] Can remove email from allowed list
- [x] Cannot remove own email
- [x] Non-admin gets 403 error
- [x] Nav link hidden for non-admins

## Notes
- Pre-existing lint errors in `passkey.test.ts` (2 `no-explicit-any`) exist on `main` — not introduced here

Task: #1314