### PR TITLE
feat: Media upload to S3

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -112,15 +112,12 @@ export const sessions = sqliteTable("sessions", {
   created_at: integer("created_at", { mode: "timestamp" }).notNull(),
 });
 
-// Media attachments for posts
+// Media files stored in S3
 export const media = sqliteTable("media", {
   id: integer("id").primaryKey({ autoIncrement: true }),
-  post_id: integer("post_id")
-    .notNull()
-    .references(() => posts.id, { onDelete: "cascade" }),
   filename: text("filename").notNull(),
   mime_type: text("mime_type").notNull(),
-  s3_key: text("s3_key").notNull(),
+  s3_key: text("s3_key").notNull().unique(),
   alt_text: text("alt_text"),
   created_at: integer("created_at", { mode: "timestamp" }).notNull(),
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { feed } from "./routes/feed";
 import { auth } from "./routes/auth";
 import { admin } from "./routes/admin";
 import { api } from "./routes/api";
+import { mediaRoute } from "./routes/media";
 import { logger } from "./utils/logger";
 
 const app = new Hono();
@@ -35,6 +36,7 @@ app.route("/", feed);
 app.route("/", auth);
 app.route("/admin", admin);
 app.route("/api", api);
+app.route("/media", mediaRoute);
 
 // ActivityPub actor endpoint (placeholder)
 app.get("/.well-known/webfinger", (c) => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -10,6 +10,7 @@ import {
   unpublishPost,
   PostType,
 } from "@/services/posts";
+import { createMedia, deleteMedia, isAllowedMimeType } from "@/services/media";
 
 export const api = new Hono();
 
@@ -207,4 +208,65 @@ api.post("/posts/:id/unpublish", (c) => {
   }
 
   return c.json({ data: post });
+});
+
+/**
+ * POST /api/media - Upload media file
+ * Accepts multipart/form-data with:
+ *   - file: the image file (required)
+ *   - alt: alt text (optional)
+ *   - key: custom S3 key (optional)
+ */
+api.post("/media", async (c) => {
+  const body = await c.req.parseBody();
+  const file = body.file;
+
+  if (!file || !(file instanceof File)) {
+    return c.json({ error: "File is required" }, 400);
+  }
+
+  if (!isAllowedMimeType(file.type)) {
+    return c.json({ error: "Invalid file type. Allowed: jpg, png, gif, webp" }, 400);
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const altText = typeof body.alt === "string" ? body.alt.trim() : undefined;
+  const customKey = typeof body.key === "string" ? body.key.trim() : undefined;
+
+  try {
+    const record = await createMedia({
+      file: buffer,
+      filename: file.name,
+      mimeType: file.type,
+      altText: altText || undefined,
+      customKey: customKey || undefined,
+    });
+
+    return c.json({ data: record }, 201);
+  } catch (error) {
+    return c.json({ error: String(error) }, 500);
+  }
+});
+
+/**
+ * DELETE /api/media/:id - Delete media file
+ */
+api.delete("/media/:id", async (c) => {
+  const id = parseInt(c.req.param("id"), 10);
+
+  if (isNaN(id)) {
+    return c.json({ error: "Invalid media ID" }, 400);
+  }
+
+  try {
+    const deleted = await deleteMedia(id);
+
+    if (!deleted) {
+      return c.json({ error: "Media not found" }, 404);
+    }
+
+    return c.body(null, 204);
+  } catch (error) {
+    return c.json({ error: String(error) }, 500);
+  }
 });

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { requireApiKey } from "@/auth/api-key";
 import {
   listPosts,
@@ -217,36 +218,43 @@ api.post("/posts/:id/unpublish", (c) => {
  *   - alt: alt text (optional)
  *   - key: custom S3 key (optional)
  */
-api.post("/media", async (c) => {
-  const body = await c.req.parseBody();
-  const file = body.file;
+api.post(
+  "/media",
+  bodyLimit({
+    maxSize: 10 * 1024 * 1024, // 10 MB
+    onError: (c) => c.json({ error: "File too large. Maximum size is 10 MB" }, 413),
+  }),
+  async (c) => {
+    const body = await c.req.parseBody();
+    const file = body.file;
 
-  if (!file || !(file instanceof File)) {
-    return c.json({ error: "File is required" }, 400);
+    if (!file || !(file instanceof File)) {
+      return c.json({ error: "File is required" }, 400);
+    }
+
+    if (!isAllowedMimeType(file.type)) {
+      return c.json({ error: "Invalid file type. Allowed: jpg, png, gif, webp" }, 400);
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const altText = typeof body.alt === "string" ? body.alt.trim() : undefined;
+    const customKey = typeof body.key === "string" ? body.key.trim() : undefined;
+
+    try {
+      const record = await createMedia({
+        file: buffer,
+        filename: file.name,
+        mimeType: file.type,
+        altText: altText || undefined,
+        customKey: customKey || undefined,
+      });
+
+      return c.json({ data: record }, 201);
+    } catch (error) {
+      return c.json({ error: String(error) }, 500);
+    }
   }
-
-  if (!isAllowedMimeType(file.type)) {
-    return c.json({ error: "Invalid file type. Allowed: jpg, png, gif, webp" }, 400);
-  }
-
-  const buffer = Buffer.from(await file.arrayBuffer());
-  const altText = typeof body.alt === "string" ? body.alt.trim() : undefined;
-  const customKey = typeof body.key === "string" ? body.key.trim() : undefined;
-
-  try {
-    const record = await createMedia({
-      file: buffer,
-      filename: file.name,
-      mimeType: file.type,
-      altText: altText || undefined,
-      customKey: customKey || undefined,
-    });
-
-    return c.json({ data: record }, 201);
-  } catch (error) {
-    return c.json({ error: String(error) }, 500);
-  }
-});
+);
 
 /**
  * DELETE /api/media/:id - Delete media file

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -1,0 +1,45 @@
+import { Hono } from "hono";
+import { getFile } from "@/services/s3";
+import { logger } from "@/utils/logger";
+
+export const mediaRoute = new Hono();
+
+/**
+ * GET /media/:key - Serve media files from S3
+ * Public route, no auth required.
+ * Proxies files from S3 with caching headers.
+ */
+mediaRoute.get("/:key{.+}", async (c) => {
+  const key = c.req.param("key");
+
+  if (!key) {
+    return c.body("Not found", 404);
+  }
+
+  try {
+    const buffer = await getFile(key);
+
+    // Determine content type from extension
+    const ext = key.split(".").pop()?.toLowerCase();
+    const contentTypes: Record<string, string> = {
+      jpg: "image/jpeg",
+      jpeg: "image/jpeg",
+      png: "image/png",
+      gif: "image/gif",
+      webp: "image/webp",
+    };
+    const contentType = contentTypes[ext || ""] || "application/octet-stream";
+
+    return new Response(new Uint8Array(buffer), {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=31536000, immutable",
+        "Content-Length": buffer.length.toString(),
+      },
+    });
+  } catch (error) {
+    logger.debug("media", "File not found in S3", { key, error: String(error) });
+    return c.body("Not found", 404);
+  }
+});

--- a/src/routes/media.ts
+++ b/src/routes/media.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { getFile } from "@/services/s3";
+import { getMediaByKey } from "@/services/media";
 import { logger } from "@/utils/logger";
 
 export const mediaRoute = new Hono();
@@ -8,6 +9,7 @@ export const mediaRoute = new Hono();
  * GET /media/:key - Serve media files from S3
  * Public route, no auth required.
  * Proxies files from S3 with caching headers.
+ * Uses stored mime_type from DB as source of truth.
  */
 mediaRoute.get("/:key{.+}", async (c) => {
   const key = c.req.param("key");
@@ -16,25 +18,20 @@ mediaRoute.get("/:key{.+}", async (c) => {
     return c.body("Not found", 404);
   }
 
+  // Look up media record for content type
+  const record = getMediaByKey(key);
+  if (!record) {
+    return c.body("Not found", 404);
+  }
+
   try {
     const buffer = await getFile(key);
-
-    // Determine content type from extension
-    const ext = key.split(".").pop()?.toLowerCase();
-    const contentTypes: Record<string, string> = {
-      jpg: "image/jpeg",
-      jpeg: "image/jpeg",
-      png: "image/png",
-      gif: "image/gif",
-      webp: "image/webp",
-    };
-    const contentType = contentTypes[ext || ""] || "application/octet-stream";
 
     return new Response(new Uint8Array(buffer), {
       status: 200,
       headers: {
-        "Content-Type": contentType,
-        "Cache-Control": "public, max-age=31536000, immutable",
+        "Content-Type": record.mime_type,
+        "Cache-Control": "public, max-age=86400",
         "Content-Length": buffer.length.toString(),
       },
     });

--- a/src/services/__tests__/media.test.ts
+++ b/src/services/__tests__/media.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import * as schema from "../../db/schema";
+
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let testSqlite: InstanceType<typeof Database>;
+
+// Mock the db module
+vi.mock("../../db", async () => {
+  const schema = await import("../../db/schema");
+  return {
+    db: testDb,
+    ...schema,
+  };
+});
+
+// Mock S3 operations
+vi.mock("../s3", () => ({
+  uploadFile: vi.fn().mockResolvedValue({ key: "test.jpg", url: "/media/test.jpg" }),
+  deleteFile: vi.fn().mockResolvedValue(undefined),
+  generateKey: vi.fn().mockReturnValue("abc123.jpg"),
+}));
+
+beforeAll(() => {
+  testSqlite = new Database(":memory:");
+
+  testSqlite.exec(`
+    CREATE TABLE media (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      filename TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      s3_key TEXT NOT NULL UNIQUE,
+      alt_text TEXT,
+      created_at INTEGER NOT NULL
+    );
+  `);
+
+  testDb = drizzle(testSqlite, { schema });
+});
+
+afterAll(() => {
+  testSqlite.close();
+});
+
+describe("Media Service", () => {
+  beforeEach(() => {
+    testSqlite.exec("DELETE FROM media");
+    vi.clearAllMocks();
+  });
+
+  describe("isAllowedMimeType", () => {
+    it("allows jpeg", async () => {
+      const { isAllowedMimeType } = await import("../media");
+      expect(isAllowedMimeType("image/jpeg")).toBe(true);
+    });
+
+    it("allows png", async () => {
+      const { isAllowedMimeType } = await import("../media");
+      expect(isAllowedMimeType("image/png")).toBe(true);
+    });
+
+    it("allows gif", async () => {
+      const { isAllowedMimeType } = await import("../media");
+      expect(isAllowedMimeType("image/gif")).toBe(true);
+    });
+
+    it("allows webp", async () => {
+      const { isAllowedMimeType } = await import("../media");
+      expect(isAllowedMimeType("image/webp")).toBe(true);
+    });
+
+    it("rejects pdf", async () => {
+      const { isAllowedMimeType } = await import("../media");
+      expect(isAllowedMimeType("application/pdf")).toBe(false);
+    });
+
+    it("rejects svg", async () => {
+      const { isAllowedMimeType } = await import("../media");
+      expect(isAllowedMimeType("image/svg+xml")).toBe(false);
+    });
+  });
+
+  describe("mediaUrl", () => {
+    it("returns /media/ prefixed path", async () => {
+      const { mediaUrl } = await import("../media");
+      expect(mediaUrl("abc123.jpg")).toBe("/media/abc123.jpg");
+    });
+
+    it("handles keys with path separators", async () => {
+      const { mediaUrl } = await import("../media");
+      expect(mediaUrl("posts/my-post/banner.jpg")).toBe("/media/posts/my-post/banner.jpg");
+    });
+  });
+
+  describe("createMedia", () => {
+    it("creates a media record with auto-generated key", async () => {
+      const { createMedia } = await import("../media");
+      const { uploadFile } = await import("../s3");
+
+      const result = await createMedia({
+        file: Buffer.from("fake image data"),
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+      });
+
+      expect(result.id).toBeDefined();
+      expect(result.filename).toBe("photo.jpg");
+      expect(result.mime_type).toBe("image/jpeg");
+      expect(result.s3_key).toBe("abc123.jpg");
+      expect(result.url).toBe("/media/abc123.jpg");
+      expect(uploadFile).toHaveBeenCalledWith("abc123.jpg", expect.any(Buffer), "image/jpeg");
+    });
+
+    it("creates a media record with custom key", async () => {
+      const { createMedia } = await import("../media");
+      const { uploadFile, generateKey } = await import("../s3");
+
+      const result = await createMedia({
+        file: Buffer.from("fake image data"),
+        filename: "banner.png",
+        mimeType: "image/png",
+        customKey: "posts/my-post/banner.png",
+      });
+
+      expect(result.s3_key).toBe("posts/my-post/banner.png");
+      expect(result.url).toBe("/media/posts/my-post/banner.png");
+      expect(generateKey).not.toHaveBeenCalled();
+      expect(uploadFile).toHaveBeenCalledWith(
+        "posts/my-post/banner.png",
+        expect.any(Buffer),
+        "image/png"
+      );
+    });
+
+    it("sets alt text when provided", async () => {
+      const { createMedia } = await import("../media");
+
+      const result = await createMedia({
+        file: Buffer.from("fake image data"),
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        altText: "A nice photo",
+      });
+
+      expect(result.alt_text).toBe("A nice photo");
+    });
+
+    it("rejects invalid mime type", async () => {
+      const { createMedia } = await import("../media");
+
+      await expect(
+        createMedia({
+          file: Buffer.from("fake pdf data"),
+          filename: "doc.pdf",
+          mimeType: "application/pdf",
+        })
+      ).rejects.toThrow("Invalid file type");
+    });
+  });
+
+  describe("getMedia", () => {
+    it("returns media record with url", async () => {
+      testSqlite.exec(
+        "INSERT INTO media (filename, mime_type, s3_key, created_at) VALUES ('test.jpg', 'image/jpeg', 'get-key.jpg', 1000)"
+      );
+      const row = testSqlite.prepare("SELECT id FROM media WHERE s3_key = 'get-key.jpg'").get() as {
+        id: number;
+      };
+      const { getMedia } = await import("../media");
+
+      const result = getMedia(row.id);
+      expect(result).not.toBeNull();
+      expect(result!.filename).toBe("test.jpg");
+      expect(result!.url).toBe("/media/get-key.jpg");
+    });
+
+    it("returns null for non-existent id", async () => {
+      const { getMedia } = await import("../media");
+      expect(getMedia(999)).toBeNull();
+    });
+  });
+
+  describe("deleteMedia", () => {
+    it("deletes record and S3 file", async () => {
+      testSqlite.exec(
+        "INSERT INTO media (filename, mime_type, s3_key, created_at) VALUES ('test.jpg', 'image/jpeg', 'del-key.jpg', 1000)"
+      );
+      const { deleteMedia, getMedia } = await import("../media");
+      const { deleteFile } = await import("../s3");
+
+      // Get the ID of the inserted record
+      const row = testSqlite.prepare("SELECT id FROM media WHERE s3_key = 'del-key.jpg'").get() as {
+        id: number;
+      };
+
+      const result = await deleteMedia(row.id);
+      expect(result).toBe(true);
+      expect(deleteFile).toHaveBeenCalledWith("del-key.jpg");
+      expect(getMedia(row.id)).toBeNull();
+    });
+
+    it("returns false for non-existent id", async () => {
+      const { deleteMedia } = await import("../media");
+      const result = await deleteMedia(999);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/services/__tests__/media.test.ts
+++ b/src/services/__tests__/media.test.ts
@@ -146,6 +146,40 @@ describe("Media Service", () => {
       expect(result.alt_text).toBe("A nice photo");
     });
 
+    it("overwrites existing record when custom key matches", async () => {
+      const { createMedia, getMediaByKey } = await import("../media");
+      const { uploadFile } = await import("../s3");
+
+      const first = await createMedia({
+        file: Buffer.from("first image"),
+        filename: "original.jpg",
+        mimeType: "image/jpeg",
+        customKey: "overwrite-test.jpg",
+      });
+
+      const second = await createMedia({
+        file: Buffer.from("second image"),
+        filename: "replacement.png",
+        mimeType: "image/png",
+        altText: "Updated alt",
+        customKey: "overwrite-test.jpg",
+      });
+
+      // Same ID, updated fields
+      expect(second.id).toBe(first.id);
+      expect(second.filename).toBe("replacement.png");
+      expect(second.mime_type).toBe("image/png");
+      expect(second.alt_text).toBe("Updated alt");
+
+      // S3 upload called twice
+      expect(uploadFile).toHaveBeenCalledTimes(2);
+
+      // Only one record in DB
+      const record = getMediaByKey("overwrite-test.jpg");
+      expect(record).not.toBeNull();
+      expect(record!.filename).toBe("replacement.png");
+    });
+
     it("rejects invalid mime type", async () => {
       const { createMedia } = await import("../media");
 
@@ -178,6 +212,25 @@ describe("Media Service", () => {
     it("returns null for non-existent id", async () => {
       const { getMedia } = await import("../media");
       expect(getMedia(999)).toBeNull();
+    });
+  });
+
+  describe("getMediaByKey", () => {
+    it("returns media record by S3 key", async () => {
+      testSqlite.exec(
+        "INSERT INTO media (filename, mime_type, s3_key, created_at) VALUES ('bykey.jpg', 'image/jpeg', 'lookup-key.jpg', 1000)"
+      );
+      const { getMediaByKey } = await import("../media");
+
+      const result = getMediaByKey("lookup-key.jpg");
+      expect(result).not.toBeNull();
+      expect(result!.filename).toBe("bykey.jpg");
+      expect(result!.mime_type).toBe("image/jpeg");
+    });
+
+    it("returns null for non-existent key", async () => {
+      const { getMediaByKey } = await import("../media");
+      expect(getMediaByKey("no-such-key.jpg")).toBeNull();
     });
   });
 

--- a/src/services/media.ts
+++ b/src/services/media.ts
@@ -50,19 +50,36 @@ export async function createMedia(options: {
 
   await uploadFile(s3Key, file, mimeType);
 
-  const record = db
-    .insert(media)
-    .values({
-      filename,
-      mime_type: mimeType,
-      s3_key: s3Key,
-      alt_text: altText || null,
-      created_at: new Date(),
-    })
-    .returning()
-    .get();
+  // Check if a record with this key already exists (overwrite case)
+  const existing = db.select().from(media).where(eq(media.s3_key, s3Key)).get();
 
-  logger.info("media", "Media created", { id: record.id, s3Key, filename });
+  let record;
+  if (existing) {
+    record = db
+      .update(media)
+      .set({
+        filename,
+        mime_type: mimeType,
+        alt_text: altText || null,
+      })
+      .where(eq(media.id, existing.id))
+      .returning()
+      .get();
+    logger.info("media", "Media overwritten", { id: record.id, s3Key, filename });
+  } else {
+    record = db
+      .insert(media)
+      .values({
+        filename,
+        mime_type: mimeType,
+        s3_key: s3Key,
+        alt_text: altText || null,
+        created_at: new Date(),
+      })
+      .returning()
+      .get();
+    logger.info("media", "Media created", { id: record.id, s3Key, filename });
+  }
 
   return { ...record, url: mediaUrl(record.s3_key) };
 }
@@ -72,6 +89,15 @@ export async function createMedia(options: {
  */
 export function getMedia(id: number): MediaRecord | null {
   const record = db.select().from(media).where(eq(media.id, id)).get();
+  if (!record) return null;
+  return { ...record, url: mediaUrl(record.s3_key) };
+}
+
+/**
+ * Get a media record by S3 key
+ */
+export function getMediaByKey(s3Key: string): MediaRecord | null {
+  const record = db.select().from(media).where(eq(media.s3_key, s3Key)).get();
   if (!record) return null;
   return { ...record, url: mediaUrl(record.s3_key) };
 }

--- a/src/services/media.ts
+++ b/src/services/media.ts
@@ -1,0 +1,95 @@
+import { eq } from "drizzle-orm";
+import { db, media } from "@/db";
+import { uploadFile, deleteFile, generateKey } from "./s3";
+import { logger } from "@/utils/logger";
+
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+export interface MediaRecord {
+  id: number;
+  filename: string;
+  mime_type: string;
+  s3_key: string;
+  alt_text: string | null;
+  created_at: Date;
+  url: string;
+}
+
+/**
+ * Build the public URL for a media file
+ */
+export function mediaUrl(s3Key: string): string {
+  return `/media/${s3Key}`;
+}
+
+/**
+ * Validate that a MIME type is allowed
+ */
+export function isAllowedMimeType(mimeType: string): boolean {
+  return ALLOWED_MIME_TYPES.includes(mimeType);
+}
+
+/**
+ * Upload a file and create a media record.
+ * If customKey is provided, use it as the S3 key; otherwise generate one.
+ */
+export async function createMedia(options: {
+  file: Buffer | Uint8Array;
+  filename: string;
+  mimeType: string;
+  altText?: string;
+  customKey?: string;
+}): Promise<MediaRecord> {
+  const { file, filename, mimeType, altText, customKey } = options;
+
+  if (!isAllowedMimeType(mimeType)) {
+    throw new Error(`Invalid file type: ${mimeType}. Allowed: ${ALLOWED_MIME_TYPES.join(", ")}`);
+  }
+
+  const s3Key = customKey || generateKey(filename);
+
+  await uploadFile(s3Key, file, mimeType);
+
+  const record = db
+    .insert(media)
+    .values({
+      filename,
+      mime_type: mimeType,
+      s3_key: s3Key,
+      alt_text: altText || null,
+      created_at: new Date(),
+    })
+    .returning()
+    .get();
+
+  logger.info("media", "Media created", { id: record.id, s3Key, filename });
+
+  return { ...record, url: mediaUrl(record.s3_key) };
+}
+
+/**
+ * Get a media record by ID
+ */
+export function getMedia(id: number): MediaRecord | null {
+  const record = db.select().from(media).where(eq(media.id, id)).get();
+  if (!record) return null;
+  return { ...record, url: mediaUrl(record.s3_key) };
+}
+
+/**
+ * Delete a media record and its S3 file
+ */
+export async function deleteMedia(id: number): Promise<boolean> {
+  const record = db.select().from(media).where(eq(media.id, id)).get();
+
+  if (!record) {
+    logger.warn("media", "Media not found for deletion", { id });
+    return false;
+  }
+
+  await deleteFile(record.s3_key);
+  db.delete(media).where(eq(media.id, id)).run();
+
+  logger.info("media", "Media deleted", { id, s3Key: record.s3_key });
+  return true;
+}


### PR DESCRIPTION
## Summary
Media upload and management via S3-compatible storage (Garage), with a public proxy route for serving files.

## What Changed
- **Updated**: `src/db/schema.ts` — removed `post_id` from media table, added unique constraint on `s3_key`
- **New**: `src/services/media.ts` — create, get, delete media with MIME type validation
- **Updated**: `src/routes/api.tsx` — `POST /api/media` (upload) and `DELETE /api/media/:id`
- **New**: `src/routes/media.ts` — `GET /media/:key` public proxy route
- **Updated**: `src/index.tsx` — mount media route
- **New**: `src/services/__tests__/media.test.ts` — 16 tests

## How It Works
1. Upload: `POST /api/media` with multipart form data (file + optional alt text + optional custom key)
2. Returns media record with public URL (`/media/<key>`)
3. Public access: `GET /media/:key` proxies from S3 with cache headers
4. Delete: `DELETE /api/media/:id` removes from S3 and database

## Design Decisions
- No `post_id` on media — post association handled via `banner_image_id` on posts (Task #1369)
- Public proxy route instead of direct S3 URLs — URLs stay stable if storage changes
- Optional custom key allows meaningful paths (e.g., `posts/my-post/banner.jpg`)
- Flat random key as default when no custom key provided

Task: #1322