### PR TITLE
feat: Banner image support for posts

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -9,6 +9,7 @@ export const posts = sqliteTable("posts", {
   excerpt: text("excerpt"),
   url: text("url"), // for link type posts
   source_id: integer("source_id").references(() => sources.id),
+  banner_image_id: integer("banner_image_id").references(() => media.id, { onDelete: "set null" }),
   published_at: integer("published_at", { mode: "timestamp" }),
   created_at: integer("created_at", { mode: "timestamp" }).notNull(),
   updated_at: integer("updated_at", { mode: "timestamp" }).notNull(),

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -37,6 +37,15 @@ beforeAll(async () => {
       revoked_at INTEGER
     );
 
+    CREATE TABLE media (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      filename TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      s3_key TEXT NOT NULL UNIQUE,
+      alt_text TEXT,
+      created_at INTEGER NOT NULL
+    );
+
     CREATE TABLE posts (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       type TEXT NOT NULL,
@@ -45,6 +54,7 @@ beforeAll(async () => {
       excerpt TEXT,
       url TEXT,
       source_id INTEGER,
+      banner_image_id INTEGER REFERENCES media(id) ON DELETE SET NULL,
       published_at INTEGER,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -673,6 +673,81 @@ describe("POST /api/posts", () => {
 
     expect(res.status).toBe(401);
   });
+
+  it("creates post with valid banner_image_id", async () => {
+    const { api } = await import("../api");
+
+    // Insert a media record
+    testSqlite.exec(
+      "INSERT INTO media (filename, mime_type, s3_key, created_at) VALUES ('banner.jpg', 'image/jpeg', 'test-banner.jpg', 1000)"
+    );
+    const mediaRow = testSqlite
+      .prepare("SELECT id FROM media WHERE s3_key = 'test-banner.jpg'")
+      .get() as { id: number };
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "article",
+        title: "Post with Banner",
+        content: "Content here",
+        banner_image_id: mediaRow.id,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.banner_image_id).toBe(mediaRow.id);
+    expect(json.data.banner_url).toBe("/media/test-banner.jpg");
+  });
+
+  it("returns 400 for non-existent banner_image_id", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "article",
+        title: "Post with Bad Banner",
+        content: "Content here",
+        banner_image_id: 99999,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Banner image not found");
+  });
+
+  it("returns 400 for invalid banner_image_id type", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "article",
+        title: "Post with Invalid Banner",
+        content: "Content here",
+        banner_image_id: "not-a-number",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("banner_image_id must be a number");
+  });
 });
 
 describe("PUT /api/posts/:id", () => {
@@ -774,6 +849,100 @@ describe("PUT /api/posts/:id", () => {
     });
 
     expect(res.status).toBe(401);
+  });
+
+  it("updates post with banner_image_id", async () => {
+    const { api } = await import("../api");
+
+    // Create a post
+    const now = Date.now();
+    testSqlite.exec(
+      `INSERT INTO posts (type, title, content, created_at, updated_at) VALUES ('article', 'Test', 'Content', ${now}, ${now})`
+    );
+    const postRow = testSqlite.prepare("SELECT id FROM posts WHERE title = 'Test'").get() as {
+      id: number;
+    };
+
+    // Insert a media record
+    testSqlite.exec(
+      "INSERT INTO media (filename, mime_type, s3_key, created_at) VALUES ('update-banner.jpg', 'image/jpeg', 'update-banner.jpg', 1000)"
+    );
+    const mediaRow = testSqlite
+      .prepare("SELECT id FROM media WHERE s3_key = 'update-banner.jpg'")
+      .get() as { id: number };
+
+    const res = await api.request(`/posts/${postRow.id}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ banner_image_id: mediaRow.id }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.banner_image_id).toBe(mediaRow.id);
+    expect(json.data.banner_url).toBe("/media/update-banner.jpg");
+  });
+
+  it("clears banner_image_id with null", async () => {
+    const { api } = await import("../api");
+
+    // Create media and post with banner
+    testSqlite.exec(
+      "INSERT INTO media (filename, mime_type, s3_key, created_at) VALUES ('clear-banner.jpg', 'image/jpeg', 'clear-banner.jpg', 1000)"
+    );
+    const mediaRow = testSqlite
+      .prepare("SELECT id FROM media WHERE s3_key = 'clear-banner.jpg'")
+      .get() as { id: number };
+
+    const now = Date.now();
+    testSqlite.exec(
+      `INSERT INTO posts (type, title, content, banner_image_id, created_at, updated_at) VALUES ('article', 'With Banner', 'Content', ${mediaRow.id}, ${now}, ${now})`
+    );
+    const postRow = testSqlite
+      .prepare("SELECT id FROM posts WHERE title = 'With Banner'")
+      .get() as { id: number };
+
+    const res = await api.request(`/posts/${postRow.id}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ banner_image_id: null }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.banner_image_id).toBeNull();
+    expect(json.data.banner_url).toBeNull();
+  });
+
+  it("returns 400 for non-existent banner_image_id on update", async () => {
+    const { api } = await import("../api");
+
+    const now = Date.now();
+    testSqlite.exec(
+      `INSERT INTO posts (type, title, content, created_at, updated_at) VALUES ('article', 'Update Test', 'Content', ${now}, ${now})`
+    );
+    const postRow = testSqlite
+      .prepare("SELECT id FROM posts WHERE title = 'Update Test'")
+      .get() as { id: number };
+
+    const res = await api.request(`/posts/${postRow.id}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ banner_image_id: 99999 }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Banner image not found");
   });
 });
 

--- a/src/routes/__tests__/feed.test.ts
+++ b/src/routes/__tests__/feed.test.ts
@@ -22,6 +22,15 @@ beforeAll(async () => {
 
   // Create tables
   testSqlite.exec(`
+    CREATE TABLE media (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      filename TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      s3_key TEXT NOT NULL UNIQUE,
+      alt_text TEXT,
+      created_at INTEGER NOT NULL
+    );
+
     CREATE TABLE posts (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       type TEXT NOT NULL,
@@ -30,6 +39,7 @@ beforeAll(async () => {
       excerpt TEXT,
       url TEXT,
       source_id INTEGER,
+      banner_image_id INTEGER REFERENCES media(id) ON DELETE SET NULL,
       published_at INTEGER,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL

--- a/src/routes/__tests__/feed.test.ts
+++ b/src/routes/__tests__/feed.test.ts
@@ -191,5 +191,50 @@ describe("feed routes", () => {
 
       expect(secondPostIndex).toBeLessThan(firstPostIndex);
     });
+
+    it("includes enclosure for posts with banner image", async () => {
+      // Add media record
+      testSqlite.exec(
+        "INSERT INTO media (filename, mime_type, s3_key, created_at) VALUES ('feed-banner.jpg', 'image/jpeg', 'feed-banner.jpg', 1000)"
+      );
+      const mediaRow = testSqlite
+        .prepare("SELECT id FROM media WHERE s3_key = 'feed-banner.jpg'")
+        .get() as { id: number };
+
+      // Add post with banner
+      const now = Date.now();
+      testSqlite.exec(
+        `INSERT INTO posts (type, title, content, banner_image_id, published_at, created_at, updated_at) VALUES ('article', 'Post with Banner', 'Content', ${mediaRow.id}, ${now}, ${now}, ${now})`
+      );
+
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      expect(xml).toContain("<enclosure");
+      expect(xml).toContain('url="https://erikcraddock.me/media/feed-banner.jpg"');
+      expect(xml).toContain('type="image/jpeg"');
+    });
+
+    it("does not include enclosure for posts without banner image", async () => {
+      // The existing test posts don't have banner images
+      const app = getApp();
+      const res = await app.request("/feed.xml");
+      const xml = await res.text();
+
+      // Get the item blocks
+      const itemRegex = /<item>[\s\S]*?<\/item>/g;
+      const items = xml.match(itemRegex) || [];
+
+      // Find items that contain "First Post" or "Second Post" and check they don't have enclosures
+      const existingPosts = items.filter(
+        (item) =>
+          item.includes("First Post") || item.includes("Second Post") || item.includes("Third Post")
+      );
+
+      for (const item of existingPosts) {
+        expect(item).not.toContain("<enclosure");
+      }
+    });
   });
 });

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -22,6 +22,15 @@ beforeAll(async () => {
 
   // Create tables
   testSqlite.exec(`
+    CREATE TABLE media (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      filename TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      s3_key TEXT NOT NULL UNIQUE,
+      alt_text TEXT,
+      created_at INTEGER NOT NULL
+    );
+
     CREATE TABLE posts (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       type TEXT NOT NULL,
@@ -30,6 +39,7 @@ beforeAll(async () => {
       excerpt TEXT,
       url TEXT,
       source_id INTEGER,
+      banner_image_id INTEGER REFERENCES media(id) ON DELETE SET NULL,
       published_at INTEGER,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -302,6 +302,79 @@ describe("pages routes", () => {
       const html = await res.text();
       expect(html).toContain("Post Not Found");
     });
+
+    it("displays banner image when set", async () => {
+      // Add media record
+      testSqlite.exec(
+        "INSERT INTO media (filename, mime_type, s3_key, created_at) VALUES ('page-banner.jpg', 'image/jpeg', 'page-banner.jpg', 1000)"
+      );
+      const mediaRow = testSqlite
+        .prepare("SELECT id FROM media WHERE s3_key = 'page-banner.jpg'")
+        .get() as { id: number };
+
+      // Add post with banner
+      const now = Date.now();
+      testSqlite.exec(
+        `INSERT INTO posts (type, title, content, banner_image_id, published_at, created_at, updated_at) VALUES ('article', 'Banner Post', 'Content here', ${mediaRow.id}, ${now}, ${now}, ${now})`
+      );
+      const postRow = testSqlite
+        .prepare("SELECT id FROM posts WHERE title = 'Banner Post'")
+        .get() as { id: number };
+
+      const app = getApp();
+      const res = await app.request(`/posts/${postRow.id}`);
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain('src="/media/page-banner.jpg"');
+      expect(html).toContain('alt="Banner Post"');
+    });
+
+    it("includes og:image meta tag when banner is set", async () => {
+      // Add media record
+      testSqlite.exec(
+        "INSERT INTO media (filename, mime_type, s3_key, created_at) VALUES ('og-banner.jpg', 'image/jpeg', 'og-banner.jpg', 1000)"
+      );
+      const mediaRow = testSqlite
+        .prepare("SELECT id FROM media WHERE s3_key = 'og-banner.jpg'")
+        .get() as { id: number };
+
+      // Add post with banner
+      const now = Date.now();
+      testSqlite.exec(
+        `INSERT INTO posts (type, title, content, banner_image_id, published_at, created_at, updated_at) VALUES ('article', 'OG Banner Post', 'Content here', ${mediaRow.id}, ${now}, ${now}, ${now})`
+      );
+      const postRow = testSqlite
+        .prepare("SELECT id FROM posts WHERE title = 'OG Banner Post'")
+        .get() as { id: number };
+
+      const app = getApp();
+      const res = await app.request(`/posts/${postRow.id}`);
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain('property="og:image"');
+      expect(html).toContain("/media/og-banner.jpg");
+    });
+
+    it("does not display banner image when not set", async () => {
+      const app = getApp();
+
+      // Use existing post without banner (from test setup)
+      const postRow = testSqlite
+        .prepare("SELECT id FROM posts WHERE title = 'Test Post'")
+        .get() as { id: number };
+
+      const res = await app.request(`/posts/${postRow.id}`);
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      // Should not have a banner image element before the title
+      expect(html).not.toContain('class="w-full h-64 object-cover');
+    });
   });
 
   describe("GET /tags/:slug", () => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -83,7 +83,7 @@ api.post("/posts", async (c) => {
   const body = await c.req.json();
 
   // Validate type
-  const { type, title, content, excerpt, url, tags } = body;
+  const { type, title, content, excerpt, url, tags, banner_image_id } = body;
 
   if (!type || !["article", "link", "note"].includes(type)) {
     return c.json({ error: "Invalid or missing type. Must be article, link, or note" }, 400);
@@ -109,16 +109,30 @@ api.post("/posts", async (c) => {
     return c.json({ error: "Tags must be an array" }, 400);
   }
 
-  const post = createPost({
-    type,
-    title: title?.trim() || null,
-    content: content.trim(),
-    excerpt: excerpt?.trim() || null,
-    url: url?.trim() || null,
-    tags: tags || [],
-  });
+  // Validate banner_image_id if provided
+  if (
+    banner_image_id !== undefined &&
+    banner_image_id !== null &&
+    typeof banner_image_id !== "number"
+  ) {
+    return c.json({ error: "banner_image_id must be a number" }, 400);
+  }
 
-  return c.json({ data: post }, 201);
+  try {
+    const post = createPost({
+      type,
+      title: title?.trim() || null,
+      content: content.trim(),
+      excerpt: excerpt?.trim() || null,
+      url: url?.trim() || null,
+      tags: tags || [],
+      banner_image_id: banner_image_id ?? null,
+    });
+
+    return c.json({ data: post }, 201);
+  } catch (error) {
+    return c.json({ error: String(error) }, 400);
+  }
 });
 
 /**
@@ -132,26 +146,40 @@ api.put("/posts/:id", async (c) => {
   }
 
   const body = await c.req.json();
-  const { title, content, excerpt, url, tags } = body;
+  const { title, content, excerpt, url, tags, banner_image_id } = body;
 
   // Validate tags if provided
   if (tags !== undefined && !Array.isArray(tags)) {
     return c.json({ error: "Tags must be an array" }, 400);
   }
 
-  const post = updatePost(id, {
-    title: title !== undefined ? title?.trim() || null : undefined,
-    content: content?.trim(),
-    excerpt: excerpt !== undefined ? excerpt?.trim() || null : undefined,
-    url: url !== undefined ? url?.trim() || null : undefined,
-    tags,
-  });
-
-  if (!post) {
-    return c.json({ error: "Post not found" }, 404);
+  // Validate banner_image_id if provided
+  if (
+    banner_image_id !== undefined &&
+    banner_image_id !== null &&
+    typeof banner_image_id !== "number"
+  ) {
+    return c.json({ error: "banner_image_id must be a number" }, 400);
   }
 
-  return c.json({ data: post });
+  try {
+    const post = updatePost(id, {
+      title: title !== undefined ? title?.trim() || null : undefined,
+      content: content?.trim(),
+      excerpt: excerpt !== undefined ? excerpt?.trim() || null : undefined,
+      url: url !== undefined ? url?.trim() || null : undefined,
+      tags,
+      banner_image_id,
+    });
+
+    if (!post) {
+      return c.json({ error: "Post not found" }, 404);
+    }
+
+    return c.json({ data: post });
+  } catch (error) {
+    return c.json({ error: String(error) }, 400);
+  }
 });
 
 /**

--- a/src/routes/feed.ts
+++ b/src/routes/feed.ts
@@ -1,7 +1,8 @@
 import { Hono } from "hono";
-import { desc, isNotNull } from "drizzle-orm";
-import { db as defaultDb, posts } from "../db";
+import { desc, isNotNull, eq } from "drizzle-orm";
+import { db as defaultDb, posts, media } from "../db";
 import { truncate } from "../utils/text";
+import { mediaUrl } from "../services/media";
 
 // Database type for dependency injection
 type Database = typeof defaultDb;
@@ -55,12 +56,26 @@ export function createFeedRoutes(db: Database): Hono {
         const description = post.excerpt || truncate(post.content, 300);
         const pubDate = post.published_at ? formatRssDate(new Date(post.published_at)) : "";
 
+        // Get banner image for enclosure
+        let enclosure = "";
+        if (post.banner_image_id) {
+          const bannerMedia = db
+            .select()
+            .from(media)
+            .where(eq(media.id, post.banner_image_id))
+            .get();
+          if (bannerMedia) {
+            const bannerFullUrl = `${SITE_URL}${mediaUrl(bannerMedia.s3_key)}`;
+            enclosure = `\n      <enclosure url="${escapeXml(bannerFullUrl)}" type="${escapeXml(bannerMedia.mime_type)}" length="0"/>`;
+          }
+        }
+
         return `    <item>
       <title>${escapeXml(title)}</title>
       <link>${escapeXml(link)}</link>
       <description>${escapeXml(description)}</description>
       <pubDate>${pubDate}</pubDate>
-      <guid isPermaLink="true">${escapeXml(link)}</guid>
+      <guid isPermaLink="true">${escapeXml(link)}</guid>${enclosure}
     </item>`;
       })
       .join("\n");

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1,11 +1,12 @@
 import { Hono } from "hono";
 import { raw } from "hono/html";
 import { desc, eq, isNotNull, and } from "drizzle-orm";
-import { db as defaultDb, posts, tags, postTags, sources } from "../db";
+import { db as defaultDb, posts, tags, postTags, sources, media } from "../db";
 import { Layout } from "../templates/layout";
 import { NotFound } from "../templates/not-found";
 import { truncate } from "../utils/text";
 import { renderMarkdown } from "../utils/markdown";
+import { mediaUrl } from "../services/media";
 
 // Database type for dependency injection
 type Database = typeof defaultDb;
@@ -189,10 +190,24 @@ export function createPagesRoutes(db: Database): Hono {
       .where(eq(postTags.post_id, id))
       .all();
 
+    // Get banner image URL if set
+    let bannerUrl: string | null = null;
+    if (post.banner_image_id) {
+      const bannerMedia = db.select().from(media).where(eq(media.id, post.banner_image_id)).get();
+      if (bannerMedia) {
+        bannerUrl = mediaUrl(bannerMedia.s3_key);
+      }
+    }
+
     const title = post.title || "Post";
+    const description = post.excerpt || truncate(post.content, 160);
 
     return c.html(
-      <Layout title={`${title} | erikcraddock.me`}>
+      <Layout
+        title={`${title} | erikcraddock.me`}
+        ogImage={bannerUrl ?? undefined}
+        description={description}
+      >
         <article class="max-w-none">
           {/* Back link */}
           <a
@@ -201,6 +216,15 @@ export function createPagesRoutes(db: Database): Hono {
           >
             ← Back to home
           </a>
+
+          {/* Banner image */}
+          {bannerUrl && (
+            <img
+              src={bannerUrl}
+              alt={post.title || "Post banner"}
+              class="w-full h-64 object-cover rounded-lg mb-6"
+            />
+          )}
 
           {/* Post header */}
           {post.title ? (
@@ -267,6 +291,7 @@ export function createPagesRoutes(db: Database): Hono {
         excerpt: posts.excerpt,
         url: posts.url,
         source_id: posts.source_id,
+        banner_image_id: posts.banner_image_id,
         published_at: posts.published_at,
         created_at: posts.created_at,
         updated_at: posts.updated_at,

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -1,5 +1,6 @@
 import { eq, desc, and, isNotNull } from "drizzle-orm";
-import { db, posts, tags, postTags } from "@/db";
+import { db, posts, tags, postTags, media } from "@/db";
+import { mediaUrl } from "./media";
 
 export type PostType = "article" | "link" | "note";
 
@@ -107,6 +108,7 @@ export interface CreatePostInput {
   excerpt?: string | null;
   url?: string | null;
   tags?: string[]; // Tag slugs
+  banner_image_id?: number | null;
 }
 
 /**
@@ -146,7 +148,15 @@ function getOrCreateTag(slug: string): number {
  * Create a new post
  */
 export function createPost(input: CreatePostInput) {
-  const { type, title, content, excerpt, url, tags: tagSlugs } = input;
+  const { type, title, content, excerpt, url, tags: tagSlugs, banner_image_id } = input;
+
+  // Validate banner_image_id if provided
+  if (banner_image_id !== undefined && banner_image_id !== null) {
+    const bannerMedia = db.select().from(media).where(eq(media.id, banner_image_id)).get();
+    if (!bannerMedia) {
+      throw new Error(`Banner image not found: ${banner_image_id}`);
+    }
+  }
 
   // Auto-generate excerpt if not provided
   const finalExcerpt = excerpt ?? content.slice(0, 200) + (content.length > 200 ? "..." : "");
@@ -162,6 +172,7 @@ export function createPost(input: CreatePostInput) {
       content,
       excerpt: finalExcerpt,
       url: url ?? null,
+      banner_image_id: banner_image_id ?? null,
       created_at: now,
       updated_at: now,
     })
@@ -186,8 +197,18 @@ export function createPost(input: CreatePostInput) {
     }
   }
 
+  // Get banner URL if banner_image_id is set
+  let banner_url: string | null = null;
+  if (post.banner_image_id) {
+    const bannerMedia = db.select().from(media).where(eq(media.id, post.banner_image_id)).get();
+    if (bannerMedia) {
+      banner_url = mediaUrl(bannerMedia.s3_key);
+    }
+  }
+
   return {
     ...post,
+    banner_url,
     published_at: post.published_at?.toISOString() ?? null,
     created_at: post.created_at.toISOString(),
     updated_at: post.updated_at.toISOString(),
@@ -201,6 +222,7 @@ export interface UpdatePostInput {
   excerpt?: string | null;
   url?: string | null;
   tags?: string[]; // Tag slugs
+  banner_image_id?: number | null;
 }
 
 /**
@@ -213,7 +235,15 @@ export function updatePost(id: number, input: UpdatePostInput) {
     return null;
   }
 
-  const { title, content, excerpt, url, tags: tagSlugs } = input;
+  const { title, content, excerpt, url, tags: tagSlugs, banner_image_id } = input;
+
+  // Validate banner_image_id if provided
+  if (banner_image_id !== undefined && banner_image_id !== null) {
+    const bannerMedia = db.select().from(media).where(eq(media.id, banner_image_id)).get();
+    if (!bannerMedia) {
+      throw new Error(`Banner image not found: ${banner_image_id}`);
+    }
+  }
 
   // Build update object with only provided fields
   const updates: Record<string, unknown> = {
@@ -224,6 +254,7 @@ export function updatePost(id: number, input: UpdatePostInput) {
   if (content !== undefined) updates.content = content;
   if (excerpt !== undefined) updates.excerpt = excerpt;
   if (url !== undefined) updates.url = url;
+  if (banner_image_id !== undefined) updates.banner_image_id = banner_image_id;
 
   // Update post
   db.update(posts).set(updates).where(eq(posts.id, id)).run();
@@ -328,8 +359,18 @@ export function getPost(id: number) {
     .where(eq(postTags.post_id, post.id))
     .all();
 
+  // Get banner URL if banner_image_id is set
+  let banner_url: string | null = null;
+  if (post.banner_image_id) {
+    const bannerMedia = db.select().from(media).where(eq(media.id, post.banner_image_id)).get();
+    if (bannerMedia) {
+      banner_url = mediaUrl(bannerMedia.s3_key);
+    }
+  }
+
   return {
     ...post,
+    banner_url,
     published_at: post.published_at?.toISOString() ?? null,
     created_at: post.created_at.toISOString(),
     updated_at: post.updated_at.toISOString(),

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -4,6 +4,8 @@ import { raw } from "hono/html";
 interface LayoutProps {
   title: string;
   children: Child;
+  ogImage?: string;
+  description?: string;
 }
 
 // Inline script to prevent flash of wrong theme
@@ -16,13 +18,36 @@ const themeScript = `
 })();
 `;
 
-export function Layout({ title, children }: LayoutProps) {
+export function Layout({ title, children, ogImage, description }: LayoutProps) {
+  const siteUrl = process.env.SITE_URL || "https://erikcraddock.me";
+
   return (
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{title}</title>
+        {description && <meta name="description" content={description} />}
+        {/* Open Graph tags */}
+        <meta property="og:title" content={title} />
+        {description && <meta property="og:description" content={description} />}
+        {ogImage && (
+          <meta
+            property="og:image"
+            content={ogImage.startsWith("http") ? ogImage : `${siteUrl}${ogImage}`}
+          />
+        )}
+        <meta property="og:type" content="article" />
+        {/* Twitter Card tags */}
+        <meta name="twitter:card" content={ogImage ? "summary_large_image" : "summary"} />
+        <meta name="twitter:title" content={title} />
+        {description && <meta name="twitter:description" content={description} />}
+        {ogImage && (
+          <meta
+            name="twitter:image"
+            content={ogImage.startsWith("http") ? ogImage : `${siteUrl}${ogImage}`}
+          />
+        )}
         <script>{raw(themeScript)}</script>
         <link rel="stylesheet" href="/css/main.css" />
         <link


### PR DESCRIPTION
## Summary
Add banner image support so articles can have a header image for display and social sharing.

## What Changed
- **Schema**: Added `banner_image_id` column to posts table (nullable FK to media)
- **Service**: `createPost` and `updatePost` accept `banner_image_id`, validate it exists, return `banner_url`
- **API**: `POST /api/posts` and `PUT /api/posts/:id` accept `banner_image_id`
- **Layout**: Added `ogImage` and `description` props for Open Graph/Twitter meta tags
- **Post page**: Displays banner image above title, passes og:image to Layout
- **RSS feed**: Includes `<enclosure>` for posts with banner images
- **Tests**: Updated test database schemas to include `banner_image_id` and `media` table

## How It Works
1. Upload image: `POST /api/media` → get `{ id: 5, url: "/media/abc.jpg" }`
2. Create/update post with `banner_image_id: 5`
3. Post detail page displays banner, og:image meta tag is set
4. RSS feed includes enclosure for readers that support it

## Acceptance Criteria
- [x] Posts table has banner_image_id column
- [x] Can set banner image when creating/updating a post via API
- [x] Post detail page displays banner image
- [x] og:image meta tag set from banner image
- [x] RSS feed includes banner image

## Notes
- ActivityPub attachment handled in Task #1321 (Publish: send Create activity)

Task: #1369