### PR TITLE
feat: Note post type with distinct styling

### DIFF
--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -79,6 +79,12 @@ beforeAll(async () => {
     INSERT INTO posts (id, type, title, content, published_at, created_at, updated_at)
     VALUES (3, 'article', 'Another Post', 'Another post content.', ${now}, ${now}, ${now});
 
+    INSERT INTO posts (id, type, title, content, published_at, created_at, updated_at)
+    VALUES (4, 'note', NULL, 'Short note content 🚀', ${now}, ${now}, ${now});
+
+    INSERT INTO posts (id, type, title, content, published_at, created_at, updated_at)
+    VALUES (5, 'note', NULL, '${"x".repeat(300)}', ${now}, ${now}, ${now});
+
     INSERT INTO tags (id, name, slug) VALUES (1, 'Testing', 'testing');
     INSERT INTO tags (id, name, slug) VALUES (2, 'TypeScript', 'typescript');
     INSERT INTO tags (id, name, slug) VALUES (3, 'Empty Tag', 'empty-tag');
@@ -451,6 +457,79 @@ describe("pages routes", () => {
 
       const html = await res.text();
       expect(html).toContain("Tag Not Found");
+    });
+  });
+
+  describe("Note posts", () => {
+    describe("GET / (home page)", () => {
+      it("displays short notes with full content", async () => {
+        const app = getApp();
+        const res = await app.request("/");
+        const html = await res.text();
+
+        // Short note should show full content
+        expect(html).toContain("Short note content 🚀");
+      });
+
+      it("displays notes with left border styling", async () => {
+        const app = getApp();
+        const res = await app.request("/");
+        const html = await res.text();
+
+        // Notes should have left border class
+        expect(html).toContain("border-l-2");
+        expect(html).toContain("border-l-gray-300");
+      });
+
+      it("truncates long notes with ellipsis", async () => {
+        const app = getApp();
+        const res = await app.request("/");
+        const html = await res.text();
+
+        // Long note (300 chars of 'x') should be truncated
+        // Should not contain all 300 x's, but should have truncated version
+        expect(html).not.toContain("x".repeat(300));
+        expect(html).toContain("…"); // Ellipsis for truncated content
+      });
+    });
+
+    describe("GET /posts/:id (single note page)", () => {
+      it("displays note with left border styling", async () => {
+        const app = getApp();
+        const res = await app.request("/posts/4");
+        const html = await res.text();
+
+        expect(res.status).toBe(200);
+        expect(html).toContain("border-l-4");
+        expect(html).toContain("border-l-gray-300");
+      });
+
+      it("displays full note content", async () => {
+        const app = getApp();
+        const res = await app.request("/posts/4");
+        const html = await res.text();
+
+        expect(html).toContain("Short note content 🚀");
+      });
+
+      it("uses 'Note' as title fallback in page title", async () => {
+        const app = getApp();
+        const res = await app.request("/posts/4");
+        const html = await res.text();
+
+        // The <title> should contain "Note" since notes don't have titles
+        expect(html).toContain("<title>Note | erikcraddock.me</title>");
+      });
+
+      it("does not display title heading for notes", async () => {
+        const app = getApp();
+        const res = await app.request("/posts/4");
+        const html = await res.text();
+
+        // Should not have an h1 with "Short note content" (that's content, not title)
+        // Notes have no title, so there shouldn't be a title heading
+        expect(html).not.toContain("<h1");
+      });
     });
   });
 });

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -16,12 +16,21 @@ type Post = typeof posts.$inferSelect;
 type Source = typeof sources.$inferSelect;
 type PostWithSource = Post & { source?: Source | null };
 
+/** Max length for showing full note content inline */
+const NOTE_INLINE_MAX_LENGTH = 280;
+
 /** Reusable post card component */
 function PostCard({ post }: { post: PostWithSource }) {
   const isLink = post.type === "link";
+  const isNote = post.type === "note";
+
+  // Notes show full content if short enough
+  const noteContent = isNote && post.content.length <= NOTE_INLINE_MAX_LENGTH ? post.content : null;
 
   return (
-    <article class="border-b border-gray-200 dark:border-gray-700 pb-6">
+    <article
+      class={`border-b border-gray-200 dark:border-gray-700 ${isNote ? "pb-4" : "pb-6"} ${isNote ? "pl-4 border-l-2 border-l-gray-300 dark:border-l-gray-600" : ""}`}
+    >
       {/* Link posts: show external URL prominently */}
       {isLink && post.url && (
         <a
@@ -43,14 +52,23 @@ function PostCard({ post }: { post: PostWithSource }) {
       )}
 
       <a href={`/posts/${post.id}`} class="block group">
+        {/* Title for articles and links (notes don't have titles) */}
         {post.title ? (
           <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 mb-2">
             {post.title}
           </h2>
         ) : null}
-        <p class="text-gray-600 dark:text-gray-400 mb-2">
-          {post.excerpt || truncate(post.content, 200)}
-        </p>
+
+        {/* Content: notes show full content if short, others show excerpt */}
+        {isNote ? (
+          <p class="text-gray-700 dark:text-gray-300 mb-2 whitespace-pre-wrap">
+            {noteContent || truncate(post.content, 200) + "…"}
+          </p>
+        ) : (
+          <p class="text-gray-600 dark:text-gray-400 mb-2">
+            {post.excerpt || truncate(post.content, 200)}
+          </p>
+        )}
 
         {/* Meta: date and source attribution */}
         <div class="flex flex-wrap items-center gap-2 text-sm text-gray-400 dark:text-gray-500">
@@ -250,6 +268,7 @@ export function createPagesRoutes(db: Database): Hono {
     const post = result.post;
     const source = result.source;
     const isLink = post.type === "link";
+    const isNote = post.type === "note";
 
     // Query tags for this post
     const postTagsResult = db
@@ -272,7 +291,7 @@ export function createPagesRoutes(db: Database): Hono {
       }
     }
 
-    const title = post.title || "Post";
+    const title = post.title || (isNote ? "Note" : "Post");
     const description = post.excerpt || truncate(post.content, 160);
 
     return c.html(
@@ -281,7 +300,7 @@ export function createPagesRoutes(db: Database): Hono {
         ogImage={bannerUrl ?? undefined}
         description={description}
       >
-        <article class="max-w-none">
+        <article class={`max-w-none ${isNote ? "pl-4 border-l-4 border-l-gray-300 dark:border-l-gray-600" : ""}`}>
           {/* Back link */}
           <a
             href="/"


### PR DESCRIPTION
## Summary
Implements distinct rendering for note post types (short-form content like tweets/toots).

## Changes

### Home Page (PostCard)
- Notes display with a **left border** for visual distinction from articles and links
- Short notes (≤280 chars) show **full content inline**
- Longer notes show truncated content with ellipsis
- Notes have slightly lighter text color and preserve whitespace

### Single Post Page
- Notes have left border styling (consistent with card view)
- Browser tab title shows "Note" instead of "Post" for notes
- No title displayed (notes don't have titles)

## Visual Changes
Notes now have a distinctive left border that makes them immediately recognizable as short-form content, similar to how quotes are often styled.

## Testing
- All 245 tests pass
- Visual verification done via browser

## Acceptance Criteria
- [x] Can create note posts via API (already worked)
- [x] Notes display without title on home page
- [x] Notes show full content inline (if short)
- [x] Visually distinct from articles and links
- [ ] ~~Notes federate as Note type~~ (deferred to ActivityPub tasks)

## Closes
Task #1324