### PR TITLE
feat: Actor endpoint - /users/erik

### DIFF
--- a/src/federation/__tests__/setup.test.ts
+++ b/src/federation/__tests__/setup.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import * as schema from "../../db/schema";
+
+// Create test database before mocking
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let testSqlite: InstanceType<typeof Database>;
+
+// Mock the db module
+vi.mock("../../db", async () => {
+  const schema = await import("../../db/schema");
+  return {
+    db: testDb,
+    ...schema,
+  };
+});
+
+beforeAll(async () => {
+  testSqlite = new Database(":memory:");
+
+  testSqlite.exec(`
+    CREATE TABLE actor_keys (
+      id INTEGER PRIMARY KEY,
+      public_key TEXT NOT NULL,
+      private_key TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+  `);
+
+  testDb = drizzle(testSqlite, { schema });
+});
+
+afterAll(() => {
+  testSqlite.close();
+});
+
+beforeEach(() => {
+  testSqlite.exec("DELETE FROM actor_keys");
+});
+
+describe("Federation Setup", () => {
+  describe("createFedifyFederation", () => {
+    it("creates a federation instance", async () => {
+      const { createFedifyFederation } = await import("../setup");
+
+      const federation = createFedifyFederation();
+
+      expect(federation).toBeDefined();
+    });
+  });
+
+  describe("Actor Dispatcher", () => {
+    it("returns a Person actor for identifier 'erik'", async () => {
+      const { createFedifyFederation } = await import("../setup");
+      const federation = createFedifyFederation();
+
+      // Use Fedify's context to get the actor
+      const ctx = federation.createContext(new Request("https://example.com/users/erik"), {
+        documentLoader: async () => ({ document: {}, contextUrl: null }),
+      });
+
+      const actor = await ctx.getActor("erik");
+
+      expect(actor).not.toBeNull();
+      expect(actor?.preferredUsername?.toString()).toBe("erik");
+      expect(actor?.name?.toString()).toBe("Erik Craddock");
+      expect(actor?.summary?.toString()).toBe("Personal blog - articles, links, and notes");
+    });
+
+    it("returns null for unknown identifiers", async () => {
+      const { createFedifyFederation } = await import("../setup");
+      const federation = createFedifyFederation();
+
+      const ctx = federation.createContext(new Request("https://example.com/users/unknown"), {
+        documentLoader: async () => ({ document: {}, contextUrl: null }),
+      });
+
+      const actor = await ctx.getActor("unknown");
+
+      expect(actor).toBeNull();
+    });
+
+    it("includes inbox URI in actor", async () => {
+      const { createFedifyFederation } = await import("../setup");
+      const federation = createFedifyFederation();
+
+      const ctx = federation.createContext(new Request("https://example.com/users/erik"), {
+        documentLoader: async () => ({ document: {}, contextUrl: null }),
+      });
+
+      const actor = await ctx.getActor("erik");
+
+      expect(actor?.inboxId).toBeDefined();
+      expect(actor?.inboxId?.toString()).toContain("/users/erik/inbox");
+    });
+
+    it("includes outbox URI in actor", async () => {
+      const { createFedifyFederation } = await import("../setup");
+      const federation = createFedifyFederation();
+
+      const ctx = federation.createContext(new Request("https://example.com/users/erik"), {
+        documentLoader: async () => ({ document: {}, contextUrl: null }),
+      });
+
+      const actor = await ctx.getActor("erik");
+
+      expect(actor?.outboxId).toBeDefined();
+      expect(actor?.outboxId?.toString()).toContain("/users/erik/outbox");
+    });
+
+    it("includes followers URI in actor", async () => {
+      const { createFedifyFederation } = await import("../setup");
+      const federation = createFedifyFederation();
+
+      const ctx = federation.createContext(new Request("https://example.com/users/erik"), {
+        documentLoader: async () => ({ document: {}, contextUrl: null }),
+      });
+
+      const actor = await ctx.getActor("erik");
+
+      expect(actor?.followersId).toBeDefined();
+      expect(actor?.followersId?.toString()).toContain("/users/erik/followers");
+    });
+
+    it("includes public key in actor", async () => {
+      const { createFedifyFederation } = await import("../setup");
+      const federation = createFedifyFederation();
+
+      const ctx = federation.createContext(new Request("https://example.com/users/erik"), {
+        documentLoader: async () => ({ document: {}, contextUrl: null }),
+      });
+
+      const actor = await ctx.getActor("erik");
+
+      // Get the public key - it's returned as an async iterator
+      const publicKeys = actor?.getPublicKeys();
+      expect(publicKeys).toBeDefined();
+
+      let foundKey = false;
+      if (publicKeys) {
+        for await (const key of publicKeys) {
+          expect(key.id).toBeDefined();
+          expect(key.id?.toString()).toContain("#main-key");
+          foundKey = true;
+          break;
+        }
+      }
+      expect(foundKey).toBe(true);
+    });
+  });
+});

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -15,6 +15,7 @@ const domain = process.env.DOMAIN || "localhost:5000";
  * - KV store for Fedify's internal state (using in-memory for now, can switch to SQLite)
  * - Actor dispatcher for /users/{identifier}
  * - Key pairs dispatcher for HTTP signatures
+ * - Inbox, outbox, and followers collection dispatchers
  */
 export function createFedifyFederation() {
   logger.info("federation", `Creating federation for domain: ${domain}`);
@@ -36,14 +37,15 @@ export function createFedifyFederation() {
 
       const actorUri = ctx.getActorUri(identifier);
 
-      // Note: inbox, outbox, following, followers will be added in subsequent tasks
-      // For now, we just set up the basic actor with key pair
       return new Person({
         id: actorUri,
         preferredUsername: identifier,
         name: "Erik Craddock",
         summary: "Personal blog - articles, links, and notes",
         url: new URL("/", ctx.url),
+        inbox: ctx.getInboxUri(identifier),
+        outbox: ctx.getOutboxUri(identifier),
+        followers: ctx.getFollowersUri(identifier),
         publicKey: new CryptographicKey({
           id: new URL(`${actorUri}#main-key`),
           owner: actorUri,
@@ -60,6 +62,30 @@ export function createFedifyFederation() {
       const keyPair = await getOrCreateKeyPair();
       return [keyPair];
     });
+
+  // Set up inbox dispatcher - handles incoming activities
+  // Implementation will be added in Task #1319
+  federation.setInboxDispatcher("/users/{identifier}/inbox", async (_ctx, _identifier) => {
+    // Placeholder - returns empty collection
+    // Actual Follow/Undo handling will be implemented in Task #1319
+    return { items: [] };
+  });
+
+  // Set up outbox dispatcher - lists activities sent by this actor
+  // Implementation will be added in Task #1320
+  federation.setOutboxDispatcher("/users/{identifier}/outbox", async (_ctx, _identifier) => {
+    // Placeholder - returns empty collection
+    // Actual activity listing will be implemented in Task #1320
+    return { items: [] };
+  });
+
+  // Set up followers collection dispatcher - lists followers
+  // Implementation will be added in Task #1318
+  federation.setFollowersDispatcher("/users/{identifier}/followers", async (_ctx, _identifier) => {
+    // Placeholder - returns empty collection
+    // Actual follower listing will be implemented in Task #1318
+    return { items: [] };
+  });
 
   logger.info("federation", "Federation configured");
   return federation;


### PR DESCRIPTION
## Summary
Implements the ActivityPub actor endpoint for the site's identity.

**Task:** #1316

## Changes
- Updated `src/federation/setup.ts` to add inbox, outbox, and followers URIs to the Person actor
- Added placeholder dispatchers for inbox, outbox, and followers collections (actual implementation in tasks #1318, #1319, #1320)
- Added 7 tests for actor endpoint functionality

## What It Does
`GET /users/erik` with `Accept: application/activity+json` now returns a complete ActivityPub Person:

```json
{
  "@context": [...],
  "id": "http://localhost:5000/users/erik",
  "type": "Person",
  "preferredUsername": "erik",
  "name": "Erik Craddock",
  "summary": "Personal blog - articles, links, and notes",
  "inbox": "http://localhost:5000/users/erik/inbox",
  "outbox": "http://localhost:5000/users/erik/outbox",
  "followers": "http://localhost:5000/users/erik/followers",
  "publicKey": {...}
}
```

## Acceptance Criteria
- [x] `GET /users/erik` returns ActivityPub actor JSON
- [x] Accept header handling (ActivityPub vs HTML)
- [x] Public key included in response
- [x] All required fields present
- [x] Valid JSON-LD format

## Testing
- 7 new tests added
- All 264 tests pass
- Verified manually with curl