### PR TITLE
feat: Outbox endpoint

### DIFF
--- a/src/federation/__tests__/outbox.test.ts
+++ b/src/federation/__tests__/outbox.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import * as schema from "../../db/schema";
+
+// Create test database before mocking
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let testSqlite: InstanceType<typeof Database>;
+
+// Mock the db module
+vi.mock("../../db", async () => {
+  const schema = await import("../../db/schema");
+  return {
+    db: testDb,
+    ...schema,
+  };
+});
+
+beforeAll(async () => {
+  testSqlite = new Database(":memory:");
+
+  testSqlite.exec(`
+    CREATE TABLE posts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      type TEXT NOT NULL,
+      title TEXT,
+      content TEXT NOT NULL,
+      excerpt TEXT,
+      url TEXT,
+      source_id INTEGER,
+      banner_image_id INTEGER,
+      published_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+
+  testDb = drizzle(testSqlite, { schema });
+});
+
+afterAll(() => {
+  testSqlite.close();
+});
+
+beforeEach(() => {
+  testSqlite.exec("DELETE FROM posts");
+});
+
+describe("Outbox Module", () => {
+  describe("getPublishedPosts", () => {
+    it("returns only published posts", async () => {
+      const { getPublishedPosts } = await import("../outbox");
+      const now = Date.now();
+
+      // Insert published post
+      testSqlite.exec(`
+        INSERT INTO posts (type, title, content, published_at, created_at, updated_at)
+        VALUES ('article', 'Published Post', 'Content', ${now}, ${now}, ${now})
+      `);
+
+      // Insert draft post (no published_at)
+      testSqlite.exec(`
+        INSERT INTO posts (type, title, content, created_at, updated_at)
+        VALUES ('article', 'Draft Post', 'Content', ${now}, ${now})
+      `);
+
+      const posts = getPublishedPosts();
+
+      expect(posts).toHaveLength(1);
+      expect(posts[0].title).toBe("Published Post");
+    });
+
+    it("orders posts by published_at descending", async () => {
+      const { getPublishedPosts } = await import("../outbox");
+      const now = Date.now();
+      const day = 24 * 60 * 60 * 1000;
+
+      testSqlite.exec(`
+        INSERT INTO posts (type, title, content, published_at, created_at, updated_at)
+        VALUES ('article', 'Old Post', 'Content', ${now - day}, ${now}, ${now})
+      `);
+      testSqlite.exec(`
+        INSERT INTO posts (type, title, content, published_at, created_at, updated_at)
+        VALUES ('article', 'New Post', 'Content', ${now}, ${now}, ${now})
+      `);
+
+      const posts = getPublishedPosts();
+
+      expect(posts).toHaveLength(2);
+      expect(posts[0].title).toBe("New Post");
+      expect(posts[1].title).toBe("Old Post");
+    });
+
+    it("respects limit and offset", async () => {
+      const { getPublishedPosts } = await import("../outbox");
+      const now = Date.now();
+
+      // Insert 5 posts
+      for (let i = 1; i <= 5; i++) {
+        testSqlite.exec(`
+          INSERT INTO posts (type, title, content, published_at, created_at, updated_at)
+          VALUES ('article', 'Post ${i}', 'Content', ${now - i * 1000}, ${now}, ${now})
+        `);
+      }
+
+      const firstPage = getPublishedPosts(2, 0);
+      expect(firstPage).toHaveLength(2);
+
+      const secondPage = getPublishedPosts(2, 2);
+      expect(secondPage).toHaveLength(2);
+
+      const thirdPage = getPublishedPosts(2, 4);
+      expect(thirdPage).toHaveLength(1);
+    });
+  });
+
+  describe("getPublishedPostCount", () => {
+    it("returns count of published posts", async () => {
+      const { getPublishedPostCount } = await import("../outbox");
+      const now = Date.now();
+
+      testSqlite.exec(`
+        INSERT INTO posts (type, title, content, published_at, created_at, updated_at)
+        VALUES ('article', 'Post 1', 'Content', ${now}, ${now}, ${now})
+      `);
+      testSqlite.exec(`
+        INSERT INTO posts (type, title, content, published_at, created_at, updated_at)
+        VALUES ('article', 'Post 2', 'Content', ${now}, ${now}, ${now})
+      `);
+      testSqlite.exec(`
+        INSERT INTO posts (type, title, content, created_at, updated_at)
+        VALUES ('article', 'Draft', 'Content', ${now}, ${now})
+      `);
+
+      const count = getPublishedPostCount();
+
+      expect(count).toBe(2);
+    });
+  });
+
+  describe("postToObject", () => {
+    it("creates Article for posts with title", async () => {
+      const { postToObject } = await import("../outbox");
+      const { Article } = await import("@fedify/fedify");
+
+      const post = {
+        id: 1,
+        type: "article",
+        title: "My Article",
+        content: "<p>Content here</p>",
+        excerpt: "Summary",
+        url: null,
+        published_at: new Date("2025-01-15T10:00:00Z"),
+      };
+
+      const actorUri = new URL("https://example.com/users/erik");
+      const object = postToObject(post, actorUri);
+
+      expect(object).toBeInstanceOf(Article);
+      expect(object.name?.toString()).toBe("My Article");
+      expect(object.content?.toString()).toBe("<p>Content here</p>");
+    });
+
+    it("creates Note for posts without title", async () => {
+      const { postToObject } = await import("../outbox");
+      const { Note } = await import("@fedify/fedify");
+
+      const post = {
+        id: 1,
+        type: "note",
+        title: null,
+        content: "A short note",
+        excerpt: null,
+        url: null,
+        published_at: new Date("2025-01-15T10:00:00Z"),
+      };
+
+      const actorUri = new URL("https://example.com/users/erik");
+      const object = postToObject(post, actorUri);
+
+      expect(object).toBeInstanceOf(Note);
+      expect(object.content?.toString()).toBe("A short note");
+    });
+
+    it("preserves original publish date", async () => {
+      const { postToObject } = await import("../outbox");
+
+      const originalDate = new Date("2020-06-15T14:30:00Z");
+      const post = {
+        id: 1,
+        type: "article",
+        title: "Old Post",
+        content: "Content",
+        excerpt: null,
+        url: null,
+        published_at: originalDate,
+      };
+
+      const actorUri = new URL("https://example.com/users/erik");
+      const object = postToObject(post, actorUri);
+
+      // The published field should match the original date
+      expect(object.published?.epochMilliseconds).toBe(originalDate.getTime());
+    });
+  });
+
+  describe("postToCreateActivity", () => {
+    it("wraps post in Create activity", async () => {
+      const { postToCreateActivity } = await import("../outbox");
+      const { Create } = await import("@fedify/fedify");
+
+      const post = {
+        id: 42,
+        type: "article",
+        title: "Test Post",
+        content: "Content",
+        excerpt: null,
+        url: null,
+        published_at: new Date("2025-01-15T10:00:00Z"),
+      };
+
+      const actorUri = new URL("https://example.com/users/erik");
+      const activity = postToCreateActivity(post, actorUri);
+
+      expect(activity).toBeInstanceOf(Create);
+      expect(activity.actorId?.href).toBe("https://example.com/users/erik");
+      expect(activity.id?.href).toContain("/posts/42#create");
+    });
+  });
+
+  describe("getOutboxActivities", () => {
+    it("returns Create activities for published posts", async () => {
+      const { getOutboxActivities } = await import("../outbox");
+      const { Create } = await import("@fedify/fedify");
+      const now = Date.now();
+
+      testSqlite.exec(`
+        INSERT INTO posts (type, title, content, published_at, created_at, updated_at)
+        VALUES ('article', 'Post 1', 'Content 1', ${now}, ${now}, ${now})
+      `);
+      testSqlite.exec(`
+        INSERT INTO posts (type, title, content, published_at, created_at, updated_at)
+        VALUES ('note', NULL, 'Note content', ${now}, ${now}, ${now})
+      `);
+
+      const actorUri = new URL("https://example.com/users/erik");
+      const activities = getOutboxActivities(actorUri);
+
+      expect(activities).toHaveLength(2);
+      expect(activities[0]).toBeInstanceOf(Create);
+      expect(activities[1]).toBeInstanceOf(Create);
+    });
+  });
+});

--- a/src/federation/followers.ts
+++ b/src/federation/followers.ts
@@ -53,11 +53,7 @@ export function addFollower(follower: NewFollower): Follower | null {
  * Returns true if a follower was removed, false if not found.
  */
 export function removeFollower(actorUri: string): boolean {
-  const result = db
-    .delete(followers)
-    .where(eq(followers.actor_uri, actorUri))
-    .returning()
-    .get();
+  const result = db.delete(followers).where(eq(followers.actor_uri, actorUri)).returning().get();
 
   if (result) {
     logger.info("federation", `Follower removed: ${actorUri}`);
@@ -72,11 +68,7 @@ export function removeFollower(actorUri: string): boolean {
  * Get a follower by their actor URI.
  */
 export function getFollower(actorUri: string): Follower | undefined {
-  return db
-    .select()
-    .from(followers)
-    .where(eq(followers.actor_uri, actorUri))
-    .get();
+  return db.select().from(followers).where(eq(followers.actor_uri, actorUri)).get();
 }
 
 /**

--- a/src/federation/outbox.ts
+++ b/src/federation/outbox.ts
@@ -1,6 +1,6 @@
 import { Create, Note, Article } from "@fedify/fedify";
 import { Temporal } from "@js-temporal/polyfill";
-import { desc, isNotNull } from "drizzle-orm";
+import { desc, isNotNull, count } from "drizzle-orm";
 import { db, posts } from "@/db";
 import { logger } from "@/utils/logger";
 
@@ -45,12 +45,8 @@ export function getPublishedPosts(limit: number = 20, offset: number = 0): Publi
  * Get total count of published posts.
  */
 export function getPublishedPostCount(): number {
-  const result = db
-    .select({ id: posts.id })
-    .from(posts)
-    .where(isNotNull(posts.published_at))
-    .all();
-  return result.length;
+  const result = db.select({ count: count() }).from(posts).where(isNotNull(posts.published_at)).get();
+  return result?.count ?? 0;
 }
 
 /**
@@ -65,10 +61,10 @@ function dateToInstant(date: Date): Temporal.Instant {
  */
 export function postToObject(post: PublishedPost, actorUri: URL): Note | Article {
   const postUri = new URL(`/posts/${post.id}`, `${protocol}://${domain}`);
-  
+
   // Use Article for posts with titles, Note for everything else (notes, links)
   const ObjectClass = post.title ? Article : Note;
-  
+
   return new ObjectClass({
     id: postUri,
     attribution: actorUri,
@@ -86,9 +82,9 @@ export function postToObject(post: PublishedPost, actorUri: URL): Note | Article
 export function postToCreateActivity(post: PublishedPost, actorUri: URL): Create {
   const activityUri = new URL(`/posts/${post.id}#create`, `${protocol}://${domain}`);
   const object = postToObject(post, actorUri);
-  
+
   logger.debug("federation", `Converting post ${post.id} to Create activity`);
-  
+
   return new Create({
     id: activityUri,
     actor: actorUri,
@@ -101,7 +97,11 @@ export function postToCreateActivity(post: PublishedPost, actorUri: URL): Create
  * Get Create activities for the outbox.
  * Returns activities for all published posts, ordered by published_at descending.
  */
-export function getOutboxActivities(actorUri: URL, limit: number = 20, offset: number = 0): Create[] {
+export function getOutboxActivities(
+  actorUri: URL,
+  limit: number = 20,
+  offset: number = 0
+): Create[] {
   const publishedPosts = getPublishedPosts(limit, offset);
   return publishedPosts.map((post) => postToCreateActivity(post, actorUri));
 }

--- a/src/federation/outbox.ts
+++ b/src/federation/outbox.ts
@@ -1,0 +1,107 @@
+import { Create, Note, Article } from "@fedify/fedify";
+import { Temporal } from "@js-temporal/polyfill";
+import { desc, isNotNull } from "drizzle-orm";
+import { db, posts } from "@/db";
+import { logger } from "@/utils/logger";
+
+// Domain from environment
+const domain = process.env.DOMAIN || "localhost:5000";
+const protocol = domain.includes("localhost") ? "http" : "https";
+
+export interface PublishedPost {
+  id: number;
+  type: string;
+  title: string | null;
+  content: string;
+  excerpt: string | null;
+  url: string | null;
+  published_at: Date;
+}
+
+/**
+ * Get published posts for the outbox, ordered by published_at descending.
+ * Only returns posts that have been published (published_at is not null).
+ */
+export function getPublishedPosts(limit: number = 20, offset: number = 0): PublishedPost[] {
+  return db
+    .select({
+      id: posts.id,
+      type: posts.type,
+      title: posts.title,
+      content: posts.content,
+      excerpt: posts.excerpt,
+      url: posts.url,
+      published_at: posts.published_at,
+    })
+    .from(posts)
+    .where(isNotNull(posts.published_at))
+    .orderBy(desc(posts.published_at))
+    .limit(limit)
+    .offset(offset)
+    .all() as PublishedPost[];
+}
+
+/**
+ * Get total count of published posts.
+ */
+export function getPublishedPostCount(): number {
+  const result = db
+    .select({ id: posts.id })
+    .from(posts)
+    .where(isNotNull(posts.published_at))
+    .all();
+  return result.length;
+}
+
+/**
+ * Convert a Date to Temporal.Instant for Fedify.
+ */
+function dateToInstant(date: Date): Temporal.Instant {
+  return Temporal.Instant.fromEpochMilliseconds(date.getTime());
+}
+
+/**
+ * Convert a post to an ActivityPub object (Note or Article).
+ */
+export function postToObject(post: PublishedPost, actorUri: URL): Note | Article {
+  const postUri = new URL(`/posts/${post.id}`, `${protocol}://${domain}`);
+  
+  // Use Article for posts with titles, Note for everything else (notes, links)
+  const ObjectClass = post.title ? Article : Note;
+  
+  return new ObjectClass({
+    id: postUri,
+    attribution: actorUri,
+    name: post.title ?? undefined,
+    content: post.content,
+    summary: post.excerpt ?? undefined,
+    published: post.published_at ? dateToInstant(new Date(post.published_at)) : undefined,
+    url: postUri,
+  });
+}
+
+/**
+ * Convert a post to a Create activity.
+ */
+export function postToCreateActivity(post: PublishedPost, actorUri: URL): Create {
+  const activityUri = new URL(`/posts/${post.id}#create`, `${protocol}://${domain}`);
+  const object = postToObject(post, actorUri);
+  
+  logger.debug("federation", `Converting post ${post.id} to Create activity`);
+  
+  return new Create({
+    id: activityUri,
+    actor: actorUri,
+    object: object,
+    published: post.published_at ? dateToInstant(new Date(post.published_at)) : undefined,
+  });
+}
+
+/**
+ * Get Create activities for the outbox.
+ * Returns activities for all published posts, ordered by published_at descending.
+ */
+export function getOutboxActivities(actorUri: URL, limit: number = 20, offset: number = 0): Create[] {
+  const publishedPosts = getPublishedPosts(limit, offset);
+  return publishedPosts.map((post) => postToCreateActivity(post, actorUri));
+}

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -163,26 +163,21 @@ export function createFedifyFederation() {
     });
 
   // Set up followers collection dispatcher - returns list of followers
-  federation.setFollowersDispatcher(
-    "/users/{identifier}/followers",
-    async (_ctx, identifier) => {
-      if (identifier !== "erik") {
-        return null;
-      }
-
-      const followerList = getAllFollowers();
-      // Return Recipient objects with required id and inboxId
-      return {
-        items: followerList.map((f) => ({
-          id: new URL(f.actor_uri),
-          inboxId: new URL(f.inbox_uri),
-          endpoints: f.shared_inbox_uri
-            ? { sharedInbox: new URL(f.shared_inbox_uri) }
-            : undefined,
-        })),
-      };
+  federation.setFollowersDispatcher("/users/{identifier}/followers", async (_ctx, identifier) => {
+    if (identifier !== "erik") {
+      return null;
     }
-  );
+
+    const followerList = getAllFollowers();
+    // Return Recipient objects with required id and inboxId
+    return {
+      items: followerList.map((f) => ({
+        id: new URL(f.actor_uri),
+        inboxId: new URL(f.inbox_uri),
+        endpoints: f.shared_inbox_uri ? { sharedInbox: new URL(f.shared_inbox_uri) } : undefined,
+      })),
+    };
+  });
 
   logger.info("federation", "Federation configured");
   return federation;

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -9,6 +9,7 @@ import {
 } from "@fedify/fedify";
 import { getOrCreateKeyPair } from "./keys";
 import { addFollower, removeFollower, getAllFollowers } from "./followers";
+import { getOutboxActivities, getPublishedPostCount } from "./outbox";
 import { logger } from "@/utils/logger";
 
 // Context type for federation - we use void since we don't need request-specific data
@@ -123,12 +124,43 @@ export function createFedifyFederation() {
     });
 
   // Set up outbox dispatcher - lists activities sent by this actor
-  // Implementation will be added in Task #1320
-  federation.setOutboxDispatcher("/users/{identifier}/outbox", async (_ctx, _identifier) => {
-    // Placeholder - returns empty collection
-    // Actual activity listing will be implemented in Task #1320
-    return { items: [] };
-  });
+  // Returns Create activities for all published posts (including imported/backdated ones)
+  const OUTBOX_PAGE_SIZE = 20;
+
+  federation
+    .setOutboxDispatcher("/users/{identifier}/outbox", async (ctx, identifier, cursor) => {
+      if (identifier !== "erik") {
+        return null;
+      }
+
+      const actorUri = ctx.getActorUri(identifier);
+      const offset = cursor ? parseInt(cursor, 10) : 0;
+      const activities = getOutboxActivities(actorUri, OUTBOX_PAGE_SIZE, offset);
+      const totalCount = getPublishedPostCount();
+
+      // Calculate next cursor if there are more items
+      const nextOffset = offset + activities.length;
+      const hasMore = nextOffset < totalCount;
+
+      return {
+        items: activities,
+        nextCursor: hasMore ? nextOffset.toString() : null,
+        prevCursor: offset > 0 ? Math.max(0, offset - OUTBOX_PAGE_SIZE).toString() : null,
+      };
+    })
+    .setCounter(async (_ctx, identifier) => {
+      if (identifier !== "erik") {
+        return null;
+      }
+      return getPublishedPostCount();
+    })
+    .setFirstCursor(async (_ctx, identifier) => {
+      if (identifier !== "erik") {
+        return null;
+      }
+      // First page starts at offset 0
+      return "0";
+    });
 
   // Set up followers collection dispatcher - returns list of followers
   federation.setFollowersDispatcher(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,10 @@ const app = new Hono();
 
 // Fedify middleware - handles ActivityPub requests
 // Must be before other routes so it can intercept AP requests via content negotiation
-app.use("*", fedifyMiddleware(federation, () => undefined));
+app.use(
+  "*",
+  fedifyMiddleware(federation, () => undefined)
+);
 
 // Request logging middleware
 app.use("*", async (c, next) => {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -300,7 +300,9 @@ export function createPagesRoutes(db: Database): Hono {
         ogImage={bannerUrl ?? undefined}
         description={description}
       >
-        <article class={`max-w-none ${isNote ? "pl-4 border-l-4 border-l-gray-300 dark:border-l-gray-600" : ""}`}>
+        <article
+          class={`max-w-none ${isNote ? "pl-4 border-l-4 border-l-gray-300 dark:border-l-gray-600" : ""}`}
+        >
           {/* Back link */}
           <a
             href="/"


### PR DESCRIPTION
## Summary
Implements the outbox endpoint that lists the actor's activities.

**Task:** #1320

## Changes
- Added `src/federation/outbox.ts` - converts posts to Create activities
- Updated outbox dispatcher in `setup.ts` with pagination support
- Added 9 tests for outbox module

## How It Works

`GET /users/erik/outbox` returns an OrderedCollection of Create activities:

```json
{
  "type": "OrderedCollection",
  "totalItems": 42,
  "first": "https://erikcraddock.me/users/erik/outbox?cursor=0",
  "orderedItems": [
    {
      "type": "Create",
      "actor": "https://erikcraddock.me/users/erik",
      "object": {
        "type": "Article",
        "name": "Post Title",
        "content": "...",
        "published": "2025-01-15T10:00:00Z"
      }
    }
  ]
}
```

## Design Decisions

- **Article vs Note**: Posts with titles become Article, without become Note
- **Original dates preserved**: `published_at` is used as-is (supports backdating for imported posts)
- **Pagination**: Cursor-based, 20 items per page

## Related
- Task #1375: Import old posts (will use this to show imported posts with original dates)

## Acceptance Criteria
- [x] Outbox returns OrderedCollection
- [x] Published posts appear as Create activities
- [x] Pagination works
- [x] Correct JSON-LD format

## Testing
- 9 new tests for outbox module
- 283 total tests pass