### PR TITLE
fix: magic link email authorization and dev mode toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,14 +20,14 @@ S3_SECRET_KEY=<from setup-garage.sh output>
 S3_BUCKET=erikcraddock-media
 S3_REGION=garage
 
-# SMTP (optional in dev - magic links are logged to console)
-# Uncomment to use Mailpit: Web UI at http://localhost:8025
-# SMTP_HOST=localhost
-# SMTP_PORT=1025
+# SMTP
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=465
 # SMTP_USER=
 # SMTP_PASS=
-# SMTP_SECURE=false
+# SMTP_SECURE=true
 FROM_EMAIL=noreply@erikcraddock.me
+SMTP_DEV_MODE=true  # true = log magic links to console, false = send via SMTP
 
 # Garage admin API token (must match garage.toml)
 GARAGE_ADMIN_TOKEN=dev-admin-token

--- a/src/auth/magic-link.ts
+++ b/src/auth/magic-link.ts
@@ -7,10 +7,18 @@ import { generateToken, hashToken } from "./crypto";
 const TOKEN_EXPIRY_MINUTES = 15;
 
 /**
- * Check if an email is in the authors allow list
+ * Check if an email is in the authors allow list or is the admin email
  */
 export async function isAuthorizedEmail(email: string): Promise<boolean> {
   const normalizedEmail = email.toLowerCase().trim();
+
+  // Check ADMIN_EMAIL env var first
+  const adminEmail = process.env.ADMIN_EMAIL?.toLowerCase().trim();
+  if (adminEmail && normalizedEmail === adminEmail) {
+    return true;
+  }
+
+  // Check authors table
   const author = db.select().from(authors).where(eq(authors.email, normalizedEmail)).get();
 
   return !!author;
@@ -59,10 +67,10 @@ export async function createMagicLink(email: string): Promise<boolean> {
   const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
   const magicLinkUrl = `${protocol}://${domain}/login/verify?token=${token}`;
 
-  const isProduction = process.env.NODE_ENV === "production";
+  const devMode = process.env.SMTP_DEV_MODE === "true";
 
-  if (isProduction) {
-    // Production: send email via configured SMTP
+  if (!devMode) {
+    // Send email via configured SMTP
     const emailSent = await sendEmail({
       to: normalizedEmail,
       subject: "Your login link",
@@ -79,7 +87,7 @@ export async function createMagicLink(email: string): Promise<boolean> {
       logger.error("auth", "Failed to send magic link email", { email: normalizedEmail });
     }
   } else {
-    // Development: log the link to console
+    // Dev mode: log the link to console instead of sending email
     logger.info("auth", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     logger.info("auth", `Magic link for ${normalizedEmail}:`);
     logger.info("auth", magicLinkUrl);


### PR DESCRIPTION
## Summary
Fixes magic link emails not being sent.

## Changes
- Check `ADMIN_EMAIL` env var in `isAuthorizedEmail()` as fallback (no manual DB seeding required)
- Add `SMTP_DEV_MODE` env var to control email vs console logging
- Update `.env.example` with SMTP config docs

## Testing
- Verified SMTP sends emails when `SMTP_DEV_MODE=false`
- Verified magic links log to console when `SMTP_DEV_MODE=true`
- All 295 tests pass

Fixes #1380