### PR TITLE
feat(cli): scaffold CLI and implement login flow

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -1,0 +1,29 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "ec",
+      "dependencies": {
+        "yaml": "^2.3.4",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
+
+    "@types/node": ["@types/node@25.1.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA=="],
+
+    "bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "ec",
+  "version": "0.1.0",
+  "description": "CLI for erikcraddock.me content management",
+  "type": "module",
+  "main": "src/index.ts",
+  "bin": {
+    "ec": "src/index.ts"
+  },
+  "scripts": {
+    "dev": "bun run src/index.ts",
+    "build": "bun build src/index.ts --compile --outfile dist/ec",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "yaml": "^2.3.4"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.0.0"
+  }
+}

--- a/cli/src/__tests__/api.test.ts
+++ b/cli/src/__tests__/api.test.ts
@@ -15,7 +15,7 @@ describe("ApiClient", () => {
             { status: 200 }
           )
         )
-      );
+      ) as unknown as typeof fetch;
 
       try {
         const client = new ApiClient("https://example.com/api", "ek_test");
@@ -36,7 +36,7 @@ describe("ApiClient", () => {
             status: 401,
           })
         )
-      );
+      ) as unknown as typeof fetch;
 
       try {
         const client = new ApiClient("https://example.com/api", "bad_key");
@@ -50,7 +50,9 @@ describe("ApiClient", () => {
 
     it("returns error on network failure", async () => {
       const originalFetch = globalThis.fetch;
-      globalThis.fetch = mock(() => Promise.reject(new Error("Network error")));
+      globalThis.fetch = mock(() =>
+        Promise.reject(new Error("Network error"))
+      ) as unknown as typeof fetch;
 
       try {
         const client = new ApiClient("https://example.com/api", "ek_test");
@@ -73,7 +75,7 @@ describe("ApiClient", () => {
             status: 200,
           })
         );
-      });
+      }) as unknown as typeof fetch;
 
       try {
         const client = new ApiClient("https://example.com/api", "ek_mykey123");
@@ -99,7 +101,7 @@ describe("verifyApiKey", () => {
           { status: 200 }
         )
       )
-    );
+    ) as unknown as typeof fetch;
 
     try {
       const result = await verifyApiKey("https://example.com/api", "ek_validkey");
@@ -115,7 +117,7 @@ describe("verifyApiKey", () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(() =>
       Promise.resolve(new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }))
-    );
+    ) as unknown as typeof fetch;
 
     try {
       const result = await verifyApiKey("https://example.com/api", "ek_badkey");
@@ -129,7 +131,9 @@ describe("verifyApiKey", () => {
 
   it("returns failure on network error", async () => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = mock(() => Promise.reject(new Error("Connection refused")));
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error("Connection refused"))
+    ) as unknown as typeof fetch;
 
     try {
       const result = await verifyApiKey("https://example.com/api", "ek_key");
@@ -149,7 +153,7 @@ describe("verifyApiKey", () => {
           status: 200,
         })
       )
-    );
+    ) as unknown as typeof fetch;
 
     try {
       const result = await verifyApiKey("https://example.com/api", "ek_key");

--- a/cli/src/__tests__/api.test.ts
+++ b/cli/src/__tests__/api.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, mock } from "bun:test";
+import { ApiClient, verifyApiKey } from "../lib/api";
+
+describe("ApiClient", () => {
+  describe("ping", () => {
+    it("returns success response on valid ping", async () => {
+      // Mock fetch for this test
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: { status: "ok", authenticated: "test@example.com" },
+            }),
+            { status: 200 }
+          )
+        )
+      );
+
+      try {
+        const client = new ApiClient("https://example.com/api", "ek_test");
+        const result = await client.ping();
+
+        expect(result.data?.status).toBe("ok");
+        expect(result.data?.authenticated).toBe("test@example.com");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("returns error on failed request", async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: "Invalid API key" }), {
+            status: 401,
+          })
+        )
+      );
+
+      try {
+        const client = new ApiClient("https://example.com/api", "bad_key");
+        const result = await client.ping();
+
+        expect(result.error).toBe("Invalid API key");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("returns error on network failure", async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mock(() => Promise.reject(new Error("Network error")));
+
+      try {
+        const client = new ApiClient("https://example.com/api", "ek_test");
+        const result = await client.ping();
+
+        expect(result.error).toContain("Network error");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("sends Authorization header with Bearer token", async () => {
+      const originalFetch = globalThis.fetch;
+      let capturedHeaders: Headers | undefined;
+
+      globalThis.fetch = mock((url: string, options: RequestInit) => {
+        capturedHeaders = new Headers(options.headers);
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: { status: "ok" } }), {
+            status: 200,
+          })
+        );
+      });
+
+      try {
+        const client = new ApiClient("https://example.com/api", "ek_mykey123");
+        await client.ping();
+
+        expect(capturedHeaders?.get("Authorization")).toBe("Bearer ek_mykey123");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+});
+
+describe("verifyApiKey", () => {
+  it("returns success with email for valid key", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: { status: "ok", authenticated: "user@example.com" },
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    try {
+      const result = await verifyApiKey("https://example.com/api", "ek_validkey");
+
+      expect(result.success).toBe(true);
+      expect(result.email).toBe("user@example.com");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns failure for invalid key", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }))
+    );
+
+    try {
+      const result = await verifyApiKey("https://example.com/api", "ek_badkey");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Unauthorized");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns failure on network error", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() => Promise.reject(new Error("Connection refused")));
+
+    try {
+      const result = await verifyApiKey("https://example.com/api", "ek_key");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Connection refused");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("returns failure for unexpected response", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ data: { status: "error" } }), {
+          status: 200,
+        })
+      )
+    );
+
+    try {
+      const result = await verifyApiKey("https://example.com/api", "ek_key");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Unexpected response");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { loadConfig, maskApiKey, getApiUrl, getApiKey } from "../lib/config";
+
+describe("config utilities", () => {
+  describe("maskApiKey", () => {
+    it("masks key showing first 4 and last 4 characters", () => {
+      expect(maskApiKey("ek_1234567890abcdef")).toBe("ek_1...cdef");
+    });
+
+    it("returns **** for short keys", () => {
+      expect(maskApiKey("short")).toBe("****");
+    });
+
+    it("returns **** for 8 character keys", () => {
+      expect(maskApiKey("12345678")).toBe("****");
+    });
+
+    it("masks 9+ character keys properly", () => {
+      expect(maskApiKey("123456789")).toBe("1234...6789");
+    });
+  });
+
+  describe("getApiUrl", () => {
+    const originalEnv = process.env.EC_API_URL;
+
+    afterEach(() => {
+      if (originalEnv) {
+        process.env.EC_API_URL = originalEnv;
+      } else {
+        delete process.env.EC_API_URL;
+      }
+    });
+
+    it("returns override if provided", async () => {
+      const result = await getApiUrl("https://override.com/api");
+      expect(result).toBe("https://override.com/api");
+    });
+
+    it("returns env var if set", async () => {
+      process.env.EC_API_URL = "https://env.com/api";
+      const result = await getApiUrl();
+      expect(result).toBe("https://env.com/api");
+    });
+
+    it("prefers override over env var", async () => {
+      process.env.EC_API_URL = "https://env.com/api";
+      const result = await getApiUrl("https://override.com/api");
+      expect(result).toBe("https://override.com/api");
+    });
+  });
+
+  describe("getApiKey", () => {
+    const originalEnv = process.env.EC_API_KEY;
+
+    afterEach(() => {
+      if (originalEnv) {
+        process.env.EC_API_KEY = originalEnv;
+      } else {
+        delete process.env.EC_API_KEY;
+      }
+    });
+
+    it("returns override if provided", async () => {
+      const result = await getApiKey("ek_override");
+      expect(result).toBe("ek_override");
+    });
+
+    it("returns env var if set", async () => {
+      process.env.EC_API_KEY = "ek_from_env";
+      const result = await getApiKey();
+      expect(result).toBe("ek_from_env");
+    });
+
+    it("prefers override over env var", async () => {
+      process.env.EC_API_KEY = "ek_from_env";
+      const result = await getApiKey("ek_override");
+      expect(result).toBe("ek_override");
+    });
+  });
+});
+
+describe("config file operations", () => {
+  it("loadConfig returns empty object when file does not exist", async () => {
+    // This test uses the real config path which may or may not exist
+    // The function should handle missing files gracefully
+    const config = await loadConfig();
+    expect(typeof config).toBe("object");
+  });
+});

--- a/cli/src/__tests__/parseArgs.test.ts
+++ b/cli/src/__tests__/parseArgs.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "bun:test";
+import { parseArgs } from "../index";
+
+describe("parseArgs", () => {
+  it("returns empty command and options for no args", () => {
+    const result = parseArgs([]);
+    expect(result.command).toEqual([]);
+    expect(result.options).toEqual({});
+  });
+
+  it("parses simple command", () => {
+    const result = parseArgs(["login"]);
+    expect(result.command).toEqual(["login"]);
+    expect(result.options).toEqual({});
+  });
+
+  it("parses command with subcommand", () => {
+    const result = parseArgs(["config", "show"]);
+    expect(result.command).toEqual(["config", "show"]);
+  });
+
+  it("parses --verbose flag", () => {
+    const result = parseArgs(["--verbose", "login"]);
+    expect(result.options.verbose).toBe(true);
+    expect(result.command).toEqual(["login"]);
+  });
+
+  it("parses -v shorthand", () => {
+    const result = parseArgs(["-v", "login"]);
+    expect(result.options.verbose).toBe(true);
+  });
+
+  it("parses --json flag", () => {
+    const result = parseArgs(["post", "list", "--json"]);
+    expect(result.options.json).toBe(true);
+    expect(result.command).toEqual(["post", "list"]);
+  });
+
+  it("parses --api-url with space separator", () => {
+    const result = parseArgs(["--api-url", "https://example.com/api", "login"]);
+    expect(result.options.apiUrl).toBe("https://example.com/api");
+    expect(result.command).toEqual(["login"]);
+  });
+
+  it("parses --api-url with equals separator", () => {
+    const result = parseArgs(["--api-url=https://example.com/api", "login"]);
+    expect(result.options.apiUrl).toBe("https://example.com/api");
+  });
+
+  it("parses --api-key with space separator", () => {
+    const result = parseArgs(["--api-key", "ek_secret123", "login"]);
+    expect(result.options.apiKey).toBe("ek_secret123");
+  });
+
+  it("parses --api-key with equals separator", () => {
+    const result = parseArgs(["--api-key=ek_secret123", "login"]);
+    expect(result.options.apiKey).toBe("ek_secret123");
+  });
+
+  it("parses --help flag", () => {
+    const result = parseArgs(["login", "--help"]);
+    expect(result.options.help).toBe(true);
+    expect(result.command).toEqual(["login"]);
+  });
+
+  it("parses -h shorthand", () => {
+    const result = parseArgs(["config", "-h"]);
+    expect(result.options.help).toBe(true);
+  });
+
+  it("parses multiple flags together", () => {
+    const result = parseArgs([
+      "--verbose",
+      "--api-url=https://example.com/api",
+      "--api-key",
+      "ek_key",
+      "--json",
+      "post",
+      "list",
+    ]);
+    expect(result.options.verbose).toBe(true);
+    expect(result.options.json).toBe(true);
+    expect(result.options.apiUrl).toBe("https://example.com/api");
+    expect(result.options.apiKey).toBe("ek_key");
+    expect(result.command).toEqual(["post", "list"]);
+  });
+
+  it("handles flags after command", () => {
+    const result = parseArgs(["login", "--verbose", "--api-url", "https://test.com"]);
+    expect(result.options.verbose).toBe(true);
+    expect(result.options.apiUrl).toBe("https://test.com");
+    expect(result.command).toEqual(["login"]);
+  });
+
+  it("passes unknown flags to command", () => {
+    const result = parseArgs(["post", "create", "--title", "Hello"]);
+    expect(result.command).toEqual(["post", "create", "--title", "Hello"]);
+  });
+
+  it("handles --api-url without value (edge case)", () => {
+    const result = parseArgs(["--api-url"]);
+    // When --api-url is last, args[i+1] is undefined, so apiUrl won't be set
+    expect(result.options.apiUrl).toBeUndefined();
+  });
+});

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,0 +1,27 @@
+import { loadConfig, getConfigPath, maskApiKey } from "../lib/config";
+import { info } from "../lib/output";
+
+export async function configShow(): Promise<void> {
+  const config = await loadConfig();
+  const configPath = getConfigPath();
+
+  info(`Config file: ${configPath}`);
+  info("");
+
+  if (!config.api_url && !config.api_key) {
+    info("No configuration found. Run 'ec login' to get started.");
+    return;
+  }
+
+  if (config.api_url) {
+    info(`api_url: ${config.api_url}`);
+  } else {
+    info("api_url: (not set)");
+  }
+
+  if (config.api_key) {
+    info(`api_key: ${maskApiKey(config.api_key)}`);
+  } else {
+    info("api_key: (not set)");
+  }
+}

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,0 +1,110 @@
+import { loadConfig, saveConfig } from "../lib/config";
+import { verifyApiKey } from "../lib/api";
+import { success, error, info } from "../lib/output";
+import type { GlobalOptions } from "../types";
+
+async function openBrowser(url: string): Promise<void> {
+  const platform = process.platform;
+
+  let command: string[];
+  if (platform === "darwin") {
+    command = ["open", url];
+  } else if (platform === "win32") {
+    command = ["cmd", "/c", "start", url];
+  } else {
+    command = ["xdg-open", url];
+  }
+
+  const proc = Bun.spawn(command, {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await proc.exited;
+}
+
+async function prompt(message: string): Promise<string> {
+  process.stdout.write(message);
+
+  const reader = Bun.stdin.stream().getReader();
+  const chunks: Uint8Array[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    chunks.push(value);
+
+    // Check if we have a newline
+    const text = Buffer.concat(chunks).toString();
+    if (text.includes("\n")) {
+      reader.releaseLock();
+      return text.trim();
+    }
+  }
+
+  reader.releaseLock();
+  return Buffer.concat(chunks).toString().trim();
+}
+
+export async function login(options: GlobalOptions): Promise<void> {
+  // Get or prompt for API URL
+  let apiUrl = options.apiUrl;
+
+  if (!apiUrl) {
+    const config = await loadConfig();
+    apiUrl = config.api_url || process.env.EC_API_URL;
+  }
+
+  if (!apiUrl) {
+    apiUrl = await prompt("API URL (e.g., https://erikcraddock.me/api): ");
+  }
+
+  if (!apiUrl) {
+    error("API URL is required");
+    process.exit(2);
+  }
+
+  // Normalize URL
+  apiUrl = apiUrl.replace(/\/$/, "");
+
+  // Build auth URL
+  const authUrl = apiUrl.replace(/\/api$/, "") + "/cli/auth";
+
+  info("Opening browser to authenticate...");
+  info("");
+  info(`  ${authUrl}`);
+  info("");
+
+  await openBrowser(authUrl);
+
+  info("After logging in, copy the API key and paste it here.");
+  info("");
+
+  const apiKey = await prompt("API Key: ");
+
+  if (!apiKey) {
+    error("API key is required");
+    process.exit(1);
+  }
+
+  // Verify the key
+  info("");
+  info("Verifying API key...");
+
+  const result = await verifyApiKey(apiUrl, apiKey);
+
+  if (!result.success) {
+    error(`Authentication failed: ${result.error}`);
+    process.exit(1);
+  }
+
+  // Save to config
+  await saveConfig({
+    api_url: apiUrl,
+    api_key: apiKey,
+  });
+
+  info("");
+  success(`Logged in as ${result.email}`);
+  info("  API key stored in ~/.config/ec/config.yaml");
+}

--- a/cli/src/commands/version.ts
+++ b/cli/src/commands/version.ts
@@ -1,0 +1,5 @@
+import pkg from "../../package.json";
+
+export function version(): void {
+  console.log(`ec ${pkg.version}`);
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,7 +4,7 @@ import { configShow } from "./commands/config";
 import { login } from "./commands/login";
 import type { GlobalOptions } from "./types";
 
-function parseArgs(args: string[]): {
+export function parseArgs(args: string[]): {
   command: string[];
   options: GlobalOptions;
 } {
@@ -30,7 +30,7 @@ function parseArgs(args: string[]): {
     } else if (!arg.startsWith("-")) {
       command.push(arg);
     } else if (arg === "--help" || arg === "-h") {
-      command.push("help");
+      options.help = true;
     } else {
       // Unknown flag, add to command for subcommand to handle
       command.push(arg);
@@ -58,6 +58,7 @@ Global Options:
   --json          Output as JSON (where applicable)
   --api-url URL   Override API URL
   --api-key KEY   Override API key
+  --help, -h      Show help for a command
 
 Examples:
   ec login
@@ -66,16 +67,63 @@ Examples:
 `);
 }
 
+function showLoginHelp(): void {
+  console.log(`ec login - Authenticate and store API key
+
+Usage: ec login [options]
+
+Opens a browser to authenticate with erikcraddock.me, then prompts
+you to paste the generated API key.
+
+Options:
+  --api-url URL   Override API URL (default: from config or prompt)
+  --verbose, -v   Show debug output
+  --help, -h      Show this help message
+
+Examples:
+  ec login
+  ec login --api-url https://erikcraddock.me/api
+`);
+}
+
+function showConfigHelp(): void {
+  console.log(`ec config - Manage CLI configuration
+
+Usage: ec config <subcommand> [options]
+
+Subcommands:
+  show            Display current configuration
+
+Options:
+  --help, -h      Show this help message
+
+Configuration is stored in ~/.config/ec/config.yaml
+
+Examples:
+  ec config show
+`);
+}
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const { command, options } = parseArgs(args);
 
-  if (command.length === 0 || command[0] === "help") {
+  if (command.length === 0) {
+    if (options.help) {
+      showHelp();
+      return;
+    }
     showHelp();
     return;
   }
 
   const [cmd, subcmd] = command;
+
+  // Handle help for commands
+  if (cmd === "help") {
+    showHelp();
+    return;
+  }
 
   switch (cmd) {
     case "version":
@@ -84,14 +132,23 @@ async function main(): Promise<void> {
       break;
 
     case "login":
+      if (options.help) {
+        showLoginHelp();
+        return;
+      }
       await login(options);
       break;
 
     case "config":
+      if (options.help) {
+        showConfigHelp();
+        return;
+      }
       if (subcmd === "show" || !subcmd) {
         await configShow();
       } else {
         console.error(`Unknown config command: ${subcmd}`);
+        console.error("Run 'ec config --help' for usage.");
         process.exit(1);
       }
       break;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+import { version } from "./commands/version";
+import { configShow } from "./commands/config";
+import { login } from "./commands/login";
+import type { GlobalOptions } from "./types";
+
+function parseArgs(args: string[]): {
+  command: string[];
+  options: GlobalOptions;
+} {
+  const options: GlobalOptions = {};
+  const command: string[] = [];
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--verbose" || arg === "-v") {
+      options.verbose = true;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--api-url" && args[i + 1]) {
+      options.apiUrl = args[++i];
+    } else if (arg === "--api-key" && args[i + 1]) {
+      options.apiKey = args[++i];
+    } else if (arg.startsWith("--api-url=")) {
+      options.apiUrl = arg.split("=")[1];
+    } else if (arg.startsWith("--api-key=")) {
+      options.apiKey = arg.split("=")[1];
+    } else if (!arg.startsWith("-")) {
+      command.push(arg);
+    } else if (arg === "--help" || arg === "-h") {
+      command.push("help");
+    } else {
+      // Unknown flag, add to command for subcommand to handle
+      command.push(arg);
+    }
+
+    i++;
+  }
+
+  return { command, options };
+}
+
+function showHelp(): void {
+  console.log(`ec - CLI for erikcraddock.me
+
+Usage: ec <command> [options]
+
+Commands:
+  login           Authenticate and store API key
+  config show     Show current configuration
+  version         Show CLI version
+  help            Show this help message
+
+Global Options:
+  --verbose, -v   Enable verbose output
+  --json          Output as JSON (where applicable)
+  --api-url URL   Override API URL
+  --api-key KEY   Override API key
+
+Examples:
+  ec login
+  ec config show
+  ec version
+`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const { command, options } = parseArgs(args);
+
+  if (command.length === 0 || command[0] === "help") {
+    showHelp();
+    return;
+  }
+
+  const [cmd, subcmd] = command;
+
+  switch (cmd) {
+    case "version":
+    case "--version":
+      version();
+      break;
+
+    case "login":
+      await login(options);
+      break;
+
+    case "config":
+      if (subcmd === "show" || !subcmd) {
+        await configShow();
+      } else {
+        console.error(`Unknown config command: ${subcmd}`);
+        process.exit(1);
+      }
+      break;
+
+    default:
+      console.error(`Unknown command: ${cmd}`);
+      console.error("Run 'ec help' for usage.");
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Error:", err.message);
+  process.exit(1);
+});

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -1,0 +1,60 @@
+import type { ApiResponse, PingResponse } from "../types";
+
+export class ApiClient {
+  constructor(
+    private baseUrl: string,
+    private apiKey: string
+  ) {}
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<ApiResponse<T>> {
+    const url = `${this.baseUrl}${path}`;
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+
+    if (body) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        return { error: data.error || `HTTP ${response.status}` };
+      }
+
+      return data;
+    } catch (error) {
+      return { error: String(error) };
+    }
+  }
+
+  async ping(): Promise<ApiResponse<PingResponse>> {
+    return this.request<PingResponse>("GET", "/ping");
+  }
+}
+
+export async function verifyApiKey(
+  apiUrl: string,
+  apiKey: string
+): Promise<{ success: boolean; email?: string; error?: string }> {
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.ping();
+
+  if (result.error) {
+    return { success: false, error: result.error };
+  }
+
+  if (result.data?.status === "ok") {
+    return { success: true, email: result.data.authenticated };
+  }
+
+  return { success: false, error: "Unexpected response" };
+}

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -1,5 +1,6 @@
 import { homedir } from "os";
 import { join } from "path";
+import { mkdir } from "node:fs/promises";
 import { parse, stringify } from "yaml";
 import type { Config } from "../types";
 
@@ -8,6 +9,10 @@ const CONFIG_FILE = join(CONFIG_DIR, "config.yaml");
 
 export function getConfigPath(): string {
   return CONFIG_FILE;
+}
+
+export function getConfigDir(): string {
+  return CONFIG_DIR;
 }
 
 export async function loadConfig(): Promise<Config> {
@@ -21,7 +26,7 @@ export async function loadConfig(): Promise<Config> {
 
 export async function saveConfig(config: Config): Promise<void> {
   // Ensure config directory exists
-  await Bun.write(join(CONFIG_DIR, ".keep"), "");
+  await mkdir(CONFIG_DIR, { recursive: true });
 
   const content = stringify(config);
   await Bun.write(CONFIG_FILE, content);

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -1,0 +1,51 @@
+import { homedir } from "os";
+import { join } from "path";
+import { parse, stringify } from "yaml";
+import type { Config } from "../types";
+
+const CONFIG_DIR = join(homedir(), ".config", "ec");
+const CONFIG_FILE = join(CONFIG_DIR, "config.yaml");
+
+export function getConfigPath(): string {
+  return CONFIG_FILE;
+}
+
+export async function loadConfig(): Promise<Config> {
+  try {
+    const content = await Bun.file(CONFIG_FILE).text();
+    return parse(content) || {};
+  } catch {
+    return {};
+  }
+}
+
+export async function saveConfig(config: Config): Promise<void> {
+  // Ensure config directory exists
+  await Bun.write(join(CONFIG_DIR, ".keep"), "");
+
+  const content = stringify(config);
+  await Bun.write(CONFIG_FILE, content);
+}
+
+export async function getApiUrl(override?: string): Promise<string | null> {
+  if (override) return override;
+
+  if (process.env.EC_API_URL) return process.env.EC_API_URL;
+
+  const config = await loadConfig();
+  return config.api_url || null;
+}
+
+export async function getApiKey(override?: string): Promise<string | null> {
+  if (override) return override;
+
+  if (process.env.EC_API_KEY) return process.env.EC_API_KEY;
+
+  const config = await loadConfig();
+  return config.api_key || null;
+}
+
+export function maskApiKey(key: string): string {
+  if (key.length <= 8) return "****";
+  return key.slice(0, 4) + "..." + key.slice(-4);
+}

--- a/cli/src/lib/output.ts
+++ b/cli/src/lib/output.ts
@@ -1,0 +1,21 @@
+export function success(message: string): void {
+  console.log(`✓ ${message}`);
+}
+
+export function error(message: string): void {
+  console.error(`✗ ${message}`);
+}
+
+export function info(message: string): void {
+  console.log(message);
+}
+
+export function warn(message: string): void {
+  console.log(`⚠ ${message}`);
+}
+
+export function verbose(message: string, isVerbose: boolean): void {
+  if (isVerbose) {
+    console.log(`[debug] ${message}`);
+  }
+}

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -1,0 +1,21 @@
+export interface GlobalOptions {
+  verbose?: boolean;
+  apiUrl?: string;
+  apiKey?: string;
+  json?: boolean;
+}
+
+export interface Config {
+  api_url?: string;
+  api_key?: string;
+}
+
+export interface ApiResponse<T> {
+  data?: T;
+  error?: string;
+}
+
+export interface PingResponse {
+  status: string;
+  authenticated: string;
+}

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -3,6 +3,7 @@ export interface GlobalOptions {
   apiUrl?: string;
   apiKey?: string;
   json?: boolean;
+  help?: boolean;
 }
 
 export interface Config {

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/routes/__tests__/cli-auth.test.tsx
+++ b/src/routes/__tests__/cli-auth.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import * as schema from "../../db/schema";
+
+// Create test database before mocking
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+let testSqlite: InstanceType<typeof Database>;
+
+// Mock the db module to use our test database
+vi.mock("../../db", async () => {
+  const schema = await import("../../db/schema");
+  return {
+    db: testDb,
+    ...schema,
+  };
+});
+
+// Mock email service
+vi.mock("../../services/email", () => ({
+  sendEmail: vi.fn().mockResolvedValue(true),
+}));
+
+beforeAll(async () => {
+  // Create in-memory database for tests
+  testSqlite = new Database(":memory:");
+
+  // Create tables
+  testSqlite.exec(`
+    CREATE TABLE authors (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL UNIQUE,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      author_id INTEGER NOT NULL,
+      expires_at INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE api_keys (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      author_id INTEGER NOT NULL,
+      key_hash TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      last_used_at INTEGER,
+      revoked_at INTEGER
+    );
+
+    CREATE TABLE magic_links (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      email TEXT NOT NULL,
+      token_hash TEXT NOT NULL UNIQUE,
+      expires_at INTEGER NOT NULL,
+      used_at INTEGER
+    );
+
+    CREATE TABLE passkey_challenges (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      challenge TEXT NOT NULL,
+      email TEXT,
+      created_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE passkeys (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      author_id INTEGER NOT NULL,
+      credential_id TEXT NOT NULL UNIQUE,
+      public_key TEXT NOT NULL,
+      counter INTEGER NOT NULL DEFAULT 0,
+      name TEXT,
+      created_at INTEGER NOT NULL
+    );
+  `);
+
+  // Seed a test author
+  testSqlite.exec(`
+    INSERT INTO authors (email, created_at)
+    VALUES ('cli-test@example.com', ${Math.floor(Date.now() / 1000)})
+  `);
+
+  testDb = drizzle(testSqlite, { schema });
+});
+
+afterAll(() => {
+  testSqlite.close();
+});
+
+beforeEach(() => {
+  // Clear tables before each test (keep cli-test author)
+  testSqlite.exec("DELETE FROM magic_links");
+  testSqlite.exec("DELETE FROM sessions");
+  testSqlite.exec("DELETE FROM api_keys");
+  testSqlite.exec("DELETE FROM authors WHERE email != 'cli-test@example.com'");
+});
+
+describe("GET /cli/auth", () => {
+  it("shows login form when not authenticated", async () => {
+    const { auth } = await import("../auth");
+
+    const res = await auth.request("/cli/auth");
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("CLI Authentication");
+    expect(html).toContain("Sign in to generate an API key");
+    expect(html).toContain("Login with Passkey");
+    expect(html).toContain("Send login link");
+  });
+
+  it("generates API key when authenticated", async () => {
+    // Create a valid session - need to get author ID first
+    const author = testSqlite
+      .prepare("SELECT id FROM authors WHERE email = ?")
+      .get("cli-test@example.com") as { id: number };
+    const sessionId = "test-cli-session-12345";
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+    const createdAt = Math.floor(Date.now() / 1000);
+
+    testSqlite.exec(`
+      INSERT INTO sessions (id, author_id, expires_at, created_at)
+      VALUES ('${sessionId}', ${author.id}, ${expiresAt}, ${createdAt})
+    `);
+
+    const { auth } = await import("../auth");
+
+    const res = await auth.request("/cli/auth", {
+      headers: {
+        Cookie: `session=${sessionId}`,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("API Key Generated");
+    expect(html).toContain("Copy this key and paste it into your terminal");
+    expect(html).toContain("ek_"); // API key prefix
+    expect(html).toContain("This key won&#39;t be shown again");
+  });
+});
+
+describe("POST /cli/auth/login", () => {
+  it("sends magic link and shows confirmation", async () => {
+    const { auth } = await import("../auth");
+
+    const formData = new FormData();
+    formData.append("email", "cli-test@example.com");
+
+    const res = await auth.request("/cli/auth/login", {
+      method: "POST",
+      body: formData,
+    });
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Check your email");
+    expect(html).toContain("sent a login link");
+  });
+
+  it("redirects with error for invalid email", async () => {
+    const { auth } = await import("../auth");
+
+    const formData = new FormData();
+    formData.append("email", "not-an-email");
+
+    const res = await auth.request("/cli/auth/login", {
+      method: "POST",
+      body: formData,
+    });
+
+    // Should redirect to /cli/auth?error=email
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain("/cli/auth?error=email");
+  });
+});

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -26,8 +26,10 @@ api.use("*", requireApiKey);
 api.get("/ping", (c) => {
   const auth = c.get("apiAuth");
   return c.json({
-    status: "ok",
-    authenticated: auth.email,
+    data: {
+      status: "ok",
+      authenticated: auth.email,
+    },
   });
 });
 

--- a/src/routes/auth.tsx
+++ b/src/routes/auth.tsx
@@ -4,6 +4,7 @@ import { Layout } from "@/templates/layout";
 import { createMagicLink, verifyMagicLink } from "@/auth/magic-link";
 import { createSession, deleteSession, getSessionCookieOptions } from "@/auth/session";
 import { generatePasskeyAuthOptions, verifyPasskeyAuth } from "@/auth/passkey";
+import { createApiKey, getAuthorByEmail } from "@/auth/api-key";
 import { logger } from "@/utils/logger";
 
 export const auth = new Hono();
@@ -267,6 +268,310 @@ auth.post("/login/passkey", async (c) => {
   setCookie(c, "session", sessionId, getSessionCookieOptions(isProduction));
 
   logger.info("auth", "User logged in via passkey", { email: result.email });
+
+  return c.json({ success: true });
+});
+
+/**
+ * GET /cli/auth - CLI authentication page
+ * Shows login form if not authenticated, generates API key if authenticated
+ */
+auth.get("/cli/auth", async (c) => {
+  const sessionId = getCookie(c, "session");
+
+  // If not authenticated, show login form with redirect back
+  if (!sessionId) {
+    return c.html(
+      <Layout title="CLI Login | erikcraddock.me">
+        <div class="max-w-md mx-auto">
+          <h1 class="text-2xl font-bold mb-2">CLI Authentication</h1>
+          <p class="text-gray-600 dark:text-gray-400 mb-6">
+            Sign in to generate an API key for the CLI.
+          </p>
+
+          {/* Passkey login button */}
+          <button
+            type="button"
+            id="passkey-login"
+            class="w-full py-2 px-4 mb-4 bg-gray-800 hover:bg-gray-900 dark:bg-gray-700 dark:hover:bg-gray-600 text-white font-medium rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors flex items-center justify-center gap-2"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4"
+              />
+            </svg>
+            Login with Passkey
+          </button>
+
+          <div class="relative mb-4">
+            <div class="absolute inset-0 flex items-center">
+              <div class="w-full border-t border-gray-300 dark:border-gray-600"></div>
+            </div>
+            <div class="relative flex justify-center text-sm">
+              <span class="px-2 bg-white dark:bg-gray-900 text-gray-500">or</span>
+            </div>
+          </div>
+
+          <form method="post" action="/cli/auth/login" class="space-y-4">
+            <div>
+              <label
+                for="email"
+                class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Email address
+              </label>
+              <input
+                type="email"
+                id="email"
+                name="email"
+                required
+                placeholder="you@example.com"
+                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-gray-100"
+              />
+            </div>
+
+            <button
+              type="submit"
+              class="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors"
+            >
+              Send login link
+            </button>
+          </form>
+
+          {/* Passkey login script */}
+          <script src="https://unpkg.com/@simplewebauthn/browser@13/dist/bundle/index.umd.min.js"></script>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+              document.getElementById('passkey-login').addEventListener('click', async () => {
+                try {
+                  const optionsRes = await fetch('/login/passkey/options', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                  });
+                  const options = await optionsRes.json();
+                  const credential = await SimpleWebAuthnBrowser.startAuthentication({ optionsJSON: options });
+                  const verifyRes = await fetch('/cli/auth/passkey', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ credential }),
+                  });
+                  const result = await verifyRes.json();
+                  if (result.success) {
+                    window.location.reload();
+                  } else {
+                    alert(result.error || 'Login failed');
+                  }
+                } catch (err) {
+                  if (err.name === 'NotAllowedError') return;
+                  console.error(err);
+                  alert('Login failed. You may not have a passkey registered.');
+                }
+              });
+            `,
+            }}
+          />
+        </div>
+      </Layout>
+    );
+  }
+
+  // User is authenticated - get their email from session
+  const { getSession } = await import("@/auth/session");
+  const sessionData = await getSession(sessionId);
+
+  if (!sessionData) {
+    // Invalid session, redirect to refresh
+    deleteCookie(c, "session", { path: "/" });
+    return c.redirect("/cli/auth");
+  }
+
+  const email = sessionData.authorEmail;
+
+  // Get author to create API key
+  const author = getAuthorByEmail(email);
+  if (!author) {
+    return c.html(
+      <Layout title="Error | erikcraddock.me">
+        <div class="max-w-md mx-auto">
+          <h1 class="text-2xl font-bold mb-4 text-red-600">Error</h1>
+          <p>Author not found. Please contact the administrator.</p>
+        </div>
+      </Layout>
+    );
+  }
+
+  // Generate API key
+  const keyName = `CLI - ${new Date().toISOString().split("T")[0]}`;
+  const { key } = await createApiKey(author.id, keyName);
+
+  logger.info("auth", "CLI API key generated", { email, keyName });
+
+  return c.html(
+    <Layout title="CLI API Key | erikcraddock.me">
+      <div class="max-w-lg mx-auto">
+        <div class="text-center mb-6">
+          <div class="inline-flex items-center justify-center w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full mb-4">
+            <svg
+              class="w-8 h-8 text-green-600 dark:text-green-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </div>
+          <h1 class="text-2xl font-bold mb-2">API Key Generated</h1>
+          <p class="text-gray-600 dark:text-gray-400">
+            Copy this key and paste it into your terminal.
+          </p>
+        </div>
+
+        <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-4 mb-4">
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Your API Key</span>
+            <button
+              id="copy-btn"
+              class="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium"
+            >
+              Copy
+            </button>
+          </div>
+          <code
+            id="api-key"
+            class="block w-full p-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded font-mono text-sm break-all select-all"
+          >
+            {key}
+          </code>
+        </div>
+
+        <div class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4 mb-6">
+          <div class="flex">
+            <svg
+              class="w-5 h-5 text-amber-600 dark:text-amber-400 mt-0.5 mr-3 flex-shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            <div>
+              <p class="font-medium text-amber-800 dark:text-amber-200">
+                This key won't be shown again
+              </p>
+              <p class="text-sm text-amber-700 dark:text-amber-300 mt-1">
+                Make sure to copy it now. If you lose it, you'll need to generate a new one.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="text-center text-sm text-gray-500 dark:text-gray-400">
+          <p>You can close this window after copying the key.</p>
+        </div>
+
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            document.getElementById('copy-btn').addEventListener('click', async () => {
+              const key = document.getElementById('api-key').textContent;
+              await navigator.clipboard.writeText(key);
+              const btn = document.getElementById('copy-btn');
+              btn.textContent = 'Copied!';
+              setTimeout(() => btn.textContent = 'Copy', 2000);
+            });
+          `,
+          }}
+        />
+      </div>
+    </Layout>
+  );
+});
+
+/**
+ * POST /cli/auth/login - Handle CLI auth login form
+ */
+auth.post("/cli/auth/login", async (c) => {
+  const body = await c.req.parseBody();
+  const email = body.email;
+
+  if (typeof email !== "string" || !email.includes("@")) {
+    return c.redirect("/cli/auth?error=email");
+  }
+
+  logger.debug("auth", "CLI login attempt", { email });
+
+  // Create magic link that redirects back to /cli/auth
+  await createMagicLink(email);
+
+  return c.html(
+    <Layout title="Check Your Email | erikcraddock.me">
+      <div class="max-w-md mx-auto text-center">
+        <div class="inline-flex items-center justify-center w-16 h-16 bg-blue-100 dark:bg-blue-900/30 rounded-full mb-4">
+          <svg
+            class="w-8 h-8 text-blue-600 dark:text-blue-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+            />
+          </svg>
+        </div>
+        <h1 class="text-2xl font-bold mb-2">Check your email</h1>
+        <p class="text-gray-600 dark:text-gray-400 mb-4">
+          We've sent a login link to your email. Click it to continue.
+        </p>
+        <p class="text-sm text-gray-500 dark:text-gray-500">
+          After clicking the link, return to this page to get your API key.
+        </p>
+      </div>
+    </Layout>
+  );
+});
+
+/**
+ * POST /cli/auth/passkey - Verify passkey for CLI auth
+ */
+auth.post("/cli/auth/passkey", async (c) => {
+  const body = await c.req.json();
+  const { credential } = body;
+
+  const result = await verifyPasskeyAuth(credential);
+
+  if (!result.success || !result.email) {
+    return c.json({ success: false, error: result.error || "Authentication failed" });
+  }
+
+  // Create session
+  const sessionId = await createSession(result.email);
+
+  if (!sessionId) {
+    return c.json({ success: false, error: "Failed to create session" });
+  }
+
+  // Set session cookie
+  const isProduction = process.env.NODE_ENV === "production";
+  setCookie(c, "session", sessionId, getSessionCookieOptions(isProduction));
+
+  logger.info("auth", "User logged in via passkey for CLI", { email: result.email });
 
   return c.json({ success: true });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,10 +5,12 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    include: ["src/**/*.test.{ts,tsx}"],
+    exclude: ["**/node_modules/**", "**/dist/**", "cli/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],
-      exclude: ["node_modules/", "dist/", "**/*.test.ts"],
+      exclude: ["node_modules/", "dist/", "**/*.test.ts", "cli/**"],
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
Implements CLI scaffold and login flow for the `ec` CLI tool.

## Changes

### CLI (`cli/` directory)
- Project scaffold with TypeScript/Bun
- `ec login` - opens browser to authenticate, prompts for API key
- `ec config show` - displays current configuration  
- `ec version` - shows CLI version
- Global flags: `--verbose`, `--api-url`, `--api-key`, `--json`
- Config stored at `~/.config/ec/config.yaml`

### Web UI
- `/cli/auth` page for CLI authentication
- Shows login form (magic email or passkey)
- After auth, generates API key with copy button
- Displays "key won't be shown again" warning

## Testing
- `ec help` - shows usage
- `ec version` - shows 0.1.0
- `ec config show` - shows config status
- `/cli/auth` renders login form (unauthenticated)
- All 295 existing tests pass

## Plan
See: docs/cli-plans/01-scaffold-and-login.md

Implements #1383