### PR TITLE
fix: magic link redirect for CLI auth flow

### DIFF
--- a/src/auth/magic-link.ts
+++ b/src/auth/magic-link.ts
@@ -28,8 +28,10 @@ export async function isAuthorizedEmail(email: string): Promise<boolean> {
  * Create a magic link for the given email.
  * Returns true if email was sent (or logged in dev), false if email not authorized.
  * Always appears successful to caller to avoid leaking valid emails.
+ * @param email - The email address to send the magic link to
+ * @param redirectTo - Optional URL to redirect to after verification (default: /admin)
  */
-export async function createMagicLink(email: string): Promise<boolean> {
+export async function createMagicLink(email: string, redirectTo?: string): Promise<boolean> {
   const normalizedEmail = email.toLowerCase().trim();
 
   // Check if email is authorized
@@ -65,7 +67,8 @@ export async function createMagicLink(email: string): Promise<boolean> {
   // Build the magic link URL
   const domain = process.env.DOMAIN || "localhost:5000";
   const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-  const magicLinkUrl = `${protocol}://${domain}/login/verify?token=${token}`;
+  const redirectParam = redirectTo ? `&redirect=${encodeURIComponent(redirectTo)}` : "";
+  const magicLinkUrl = `${protocol}://${domain}/login/verify?token=${token}${redirectParam}`;
 
   const devMode = process.env.SMTP_DEV_MODE === "true";
 

--- a/src/routes/__tests__/auth.test.tsx
+++ b/src/routes/__tests__/auth.test.tsx
@@ -314,6 +314,63 @@ describe("GET /login/verify", () => {
     const sessions = testSqlite.prepare("SELECT * FROM sessions").all();
     expect(sessions).toHaveLength(1);
   });
+
+  it("redirects to specified path when valid redirect param provided", async () => {
+    const { hashToken } = await import("../../auth/crypto");
+    const { auth } = await import("../auth");
+
+    const token = "redirect-test-token";
+    const tokenHash = await hashToken(token);
+    const expiresAt = nowSeconds() + 15 * 60;
+
+    testSqlite.exec(`
+      INSERT INTO magic_links (email, token_hash, expires_at) 
+      VALUES ('session-test@example.com', '${tokenHash}', ${expiresAt})
+    `);
+
+    const res = await auth.request(`/login/verify?token=${token}&redirect=/cli/auth`);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/cli/auth");
+  });
+
+  it("falls back to /admin for absolute URL redirect (open redirect protection)", async () => {
+    const { hashToken } = await import("../../auth/crypto");
+    const { auth } = await import("../auth");
+
+    const token = "open-redirect-test-token";
+    const tokenHash = await hashToken(token);
+    const expiresAt = nowSeconds() + 15 * 60;
+
+    testSqlite.exec(`
+      INSERT INTO magic_links (email, token_hash, expires_at) 
+      VALUES ('session-test@example.com', '${tokenHash}', ${expiresAt})
+    `);
+
+    const res = await auth.request(`/login/verify?token=${token}&redirect=https://evil.com`);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/admin");
+  });
+
+  it("falls back to /admin for protocol-relative URL redirect", async () => {
+    const { hashToken } = await import("../../auth/crypto");
+    const { auth } = await import("../auth");
+
+    const token = "protocol-relative-test-token";
+    const tokenHash = await hashToken(token);
+    const expiresAt = nowSeconds() + 15 * 60;
+
+    testSqlite.exec(`
+      INSERT INTO magic_links (email, token_hash, expires_at) 
+      VALUES ('session-test@example.com', '${tokenHash}', ${expiresAt})
+    `);
+
+    const res = await auth.request(`/login/verify?token=${token}&redirect=//evil.com`);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/admin");
+  });
 });
 
 describe("POST /logout", () => {

--- a/src/routes/auth.tsx
+++ b/src/routes/auth.tsx
@@ -169,6 +169,7 @@ auth.post("/login", async (c) => {
  */
 auth.get("/login/verify", async (c) => {
   const token = c.req.query("token");
+  const redirectTo = c.req.query("redirect");
 
   if (!token) {
     logger.debug("auth", "No token provided");
@@ -197,7 +198,10 @@ auth.get("/login/verify", async (c) => {
 
   logger.info("auth", "User logged in", { email });
 
-  return c.redirect("/admin");
+  // Redirect to specified URL or default to /admin
+  // Only allow relative paths to prevent open redirect vulnerability
+  const safeRedirect = redirectTo?.startsWith("/") ? redirectTo : "/admin";
+  return c.redirect(safeRedirect);
 });
 
 /**
@@ -515,7 +519,7 @@ auth.post("/cli/auth/login", async (c) => {
   logger.debug("auth", "CLI login attempt", { email });
 
   // Create magic link that redirects back to /cli/auth
-  await createMagicLink(email);
+  await createMagicLink(email, "/cli/auth");
 
   return c.html(
     <Layout title="Check Your Email | erikcraddock.me">
@@ -540,7 +544,7 @@ auth.post("/cli/auth/login", async (c) => {
           We've sent a login link to your email. Click it to continue.
         </p>
         <p class="text-sm text-gray-500 dark:text-gray-500">
-          After clicking the link, return to this page to get your API key.
+          After clicking the link, you'll be redirected back here to get your API key.
         </p>
       </div>
     </Layout>

--- a/src/routes/auth.tsx
+++ b/src/routes/auth.tsx
@@ -200,7 +200,9 @@ auth.get("/login/verify", async (c) => {
 
   // Redirect to specified URL or default to /admin
   // Only allow relative paths to prevent open redirect vulnerability
-  const safeRedirect = redirectTo?.startsWith("/") ? redirectTo : "/admin";
+  // Reject protocol-relative URLs (//evil.com) and absolute URLs
+  const isRelativePath = redirectTo && redirectTo.startsWith("/") && !redirectTo.startsWith("//");
+  const safeRedirect = isRelativePath ? redirectTo : "/admin";
   return c.redirect(safeRedirect);
 });
 


### PR DESCRIPTION
## Summary
Fixes the broken CLI login flow where magic link always redirected to `/admin` instead of back to `/cli/auth` to show the API key.

## Changes
- Add optional `redirectTo` param to `createMagicLink()`
- Pass `redirect=/cli/auth` when sending magic link from CLI auth
- Verify endpoint uses redirect param (with open redirect protection)
- Update 'check email' message to reflect auto-redirect

## Testing
- Tested full flow in browser: /cli/auth → magic link → redirect back → API key displayed
- All 299 server tests pass
- All 35 CLI tests pass

## Task
Fixes #1383