### PR TITLE
fix: allow ADMIN_EMAIL to log in without being in authors table

### DIFF
--- a/drizzle/0002_solid_midnight.sql
+++ b/drizzle/0002_solid_midnight.sql
@@ -1,0 +1,13 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`author_id` integer,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`author_id`) REFERENCES `authors`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_sessions`("id", "author_id", "expires_at", "created_at") SELECT "id", "author_id", "expires_at", "created_at" FROM `sessions`;--> statement-breakpoint
+DROP TABLE `sessions`;--> statement-breakpoint
+ALTER TABLE `__new_sessions` RENAME TO `sessions`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,698 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bc83f931-d178-4af1-bf15-ce986d9c6dfa",
+  "prevId": "ff1d38a2-3563-463a-bd9b-86e73abb3ceb",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1769665508066,
       "tag": "0001_colorful_spirit",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1769668666936,
+      "tag": "0002_solid_midnight",
+      "breakpoints": true
     }
   ]
 }

--- a/src/auth/__tests__/session.test.ts
+++ b/src/auth/__tests__/session.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { createTestDb } from "../../db/test-utils";
+import { authors, sessions } from "../../db/schema";
+import { eq } from "drizzle-orm";
+import type { drizzle } from "drizzle-orm/better-sqlite3";
+import type * as schema from "../../db/schema";
+
+let testDb: ReturnType<typeof drizzle<typeof schema>>;
+
+vi.mock("@/db", async () => {
+  const schema = await import("../../db/schema");
+  return {
+    get db() {
+      return testDb;
+    },
+    ...schema,
+  };
+});
+
+beforeAll(async () => {
+  testDb = createTestDb();
+});
+
+beforeEach(() => {
+  testDb.delete(sessions).run();
+  testDb.delete(authors).run();
+});
+
+describe("createSession", () => {
+  let createSession: typeof import("../session").createSession;
+
+  beforeAll(async () => {
+    const module = await import("../session");
+    createSession = module.createSession;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("creates session with null author_id for admin email", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "admin@example.com");
+
+    const sessionId = await createSession("admin@example.com");
+
+    expect(sessionId).not.toBeNull();
+    const session = testDb.select().from(sessions).where(eq(sessions.id, sessionId!)).get();
+    expect(session).toBeDefined();
+    expect(session!.author_id).toBeNull();
+  });
+
+  it("creates session with author_id for author in database", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "admin@example.com");
+
+    testDb
+      .insert(authors)
+      .values({
+        id: 1,
+        email: "author@example.com",
+        created_at: new Date(),
+      })
+      .run();
+
+    const sessionId = await createSession("author@example.com");
+
+    expect(sessionId).not.toBeNull();
+    const session = testDb.select().from(sessions).where(eq(sessions.id, sessionId!)).get();
+    expect(session).toBeDefined();
+    expect(session!.author_id).toBe(1);
+  });
+
+  it("returns null for non-admin non-author email", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "admin@example.com");
+
+    const sessionId = await createSession("random@example.com");
+
+    expect(sessionId).toBeNull();
+  });
+
+  it("handles admin email case-insensitively", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "Admin@Example.com");
+
+    const sessionId = await createSession("admin@example.com");
+
+    expect(sessionId).not.toBeNull();
+    const session = testDb.select().from(sessions).where(eq(sessions.id, sessionId!)).get();
+    expect(session!.author_id).toBeNull();
+  });
+});
+
+describe("getSession", () => {
+  let createSession: typeof import("../session").createSession;
+  let getSession: typeof import("../session").getSession;
+
+  beforeAll(async () => {
+    const module = await import("../session");
+    createSession = module.createSession;
+    getSession = module.getSession;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns ADMIN_EMAIL for admin sessions", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "admin@example.com");
+
+    const sessionId = await createSession("admin@example.com");
+    const result = await getSession(sessionId!);
+
+    expect(result).not.toBeNull();
+    expect(result!.authorEmail).toBe("admin@example.com");
+    expect(result!.session.author_id).toBeNull();
+  });
+
+  it("returns author email for author sessions", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "admin@example.com");
+
+    testDb
+      .insert(authors)
+      .values({
+        id: 1,
+        email: "author@example.com",
+        created_at: new Date(),
+      })
+      .run();
+
+    const sessionId = await createSession("author@example.com");
+    const result = await getSession(sessionId!);
+
+    expect(result).not.toBeNull();
+    expect(result!.authorEmail).toBe("author@example.com");
+    expect(result!.session.author_id).toBe(1);
+  });
+
+  it("returns null for non-existent session", async () => {
+    const result = await getSession("non-existent-session-id");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for admin session if ADMIN_EMAIL not set", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "admin@example.com");
+    const sessionId = await createSession("admin@example.com");
+
+    // Now unset ADMIN_EMAIL
+    vi.stubEnv("ADMIN_EMAIL", "");
+
+    const result = await getSession(sessionId!);
+    expect(result).toBeNull();
+  });
+});

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -12,14 +12,24 @@ function generateSessionId(): string {
 }
 
 /**
- * Create a new session for an author
+ * Check if email is the admin email from env
+ */
+function isAdminEmail(email: string): boolean {
+  const adminEmail = process.env.ADMIN_EMAIL?.toLowerCase().trim();
+  return !!adminEmail && email.toLowerCase() === adminEmail;
+}
+
+/**
+ * Create a new session
+ * Admin (ADMIN_EMAIL) sessions have null author_id
+ * Author sessions reference the authors table
  */
 export async function createSession(email: string): Promise<string | null> {
-  // Look up author by email
   const author = db.select().from(authors).where(eq(authors.email, email)).get();
 
-  if (!author) {
-    logger.error("auth", "Cannot create session - author not found", { email });
+  // Must be either admin or in authors table
+  if (!author && !isAdminEmail(email)) {
+    logger.error("auth", "Cannot create session - not admin or author", { email });
     return null;
   }
 
@@ -30,7 +40,7 @@ export async function createSession(email: string): Promise<string | null> {
   db.insert(sessions)
     .values({
       id: sessionId,
-      author_id: author.id,
+      author_id: author?.id ?? null,
       expires_at: expiresAt,
       created_at: now,
     })
@@ -42,8 +52,9 @@ export async function createSession(email: string): Promise<string | null> {
 }
 
 /**
- * Get session and author info by session ID
+ * Get session info by session ID
  * Returns null if session doesn't exist or is expired
+ * For admin sessions (author_id null), returns ADMIN_EMAIL from env
  */
 export async function getSession(
   sessionId: string
@@ -66,7 +77,17 @@ export async function getSession(
     return null;
   }
 
-  // Get author
+  // Admin session (no author_id) - get email from env
+  if (session.author_id === null) {
+    const adminEmail = process.env.ADMIN_EMAIL;
+    if (!adminEmail) {
+      logger.error("auth", "Admin session but ADMIN_EMAIL not set");
+      return null;
+    }
+    return { session, authorEmail: adminEmail };
+  }
+
+  // Author session - get email from database
   const author = db.select().from(authors).where(eq(authors.id, session.author_id)).get();
 
   if (!author) {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -107,9 +107,7 @@ export const magicLinks = sqliteTable("magic_links", {
 // Sessions for authenticated users
 export const sessions = sqliteTable("sessions", {
   id: text("id").primaryKey(), // Random token (use crypto.randomUUID())
-  author_id: integer("author_id")
-    .notNull()
-    .references(() => authors.id, { onDelete: "cascade" }),
+  author_id: integer("author_id").references(() => authors.id, { onDelete: "cascade" }), // null for admin
   expires_at: integer("expires_at", { mode: "timestamp" }).notNull(),
   created_at: integer("created_at", { mode: "timestamp" }).notNull(),
 });


### PR DESCRIPTION
## Summary
ADMIN_EMAIL can now log in without needing a record in the authors table.

## Changes
- Make sessions.author_id nullable
- Admin sessions have null author_id
- getSession() returns ADMIN_EMAIL from env for admin sessions
- Authors table remains a login allow-list for non-admin users

## Fixes
Closes #1399