### PR TITLE
feat(cli): Add link and note commands

### DIFF
--- a/cli/examples/README.md
+++ b/cli/examples/README.md
@@ -1,6 +1,14 @@
 # CLI Examples
 
-Sample markdown files for testing file-based post creation.
+Sample markdown files for testing file-based content creation.
+
+## Content Types
+
+| Type     | Purpose                             | Required Fields      |
+| -------- | ----------------------------------- | -------------------- |
+| **Post** | Long-form blog articles             | title, slug, content |
+| **Link** | Share external URLs with commentary | url, slug, content   |
+| **Note** | Quick thoughts, status updates      | slug, content        |
 
 ## Files
 
@@ -14,13 +22,18 @@ ec post create --file examples/simple.md
 
 ### with-images.md
 
-A post with local image references. Images are uploaded automatically.
+A post with local image references and banner. Images are uploaded automatically.
 
 ```bash
-# Copy sample image first
-cp examples/sample-image.jpg ./hero.jpg
-
 ec post create --file examples/with-images.md
+```
+
+### link.md
+
+A link to an external article with your commentary.
+
+```bash
+ec link create --file examples/link.md
 ```
 
 ### note.md
@@ -28,33 +41,58 @@ ec post create --file examples/with-images.md
 A quick note (no title required).
 
 ```bash
-ec post create --file examples/note.md
+ec note create --file examples/note.md
 ```
 
-## Workflow Example
+## Workflow Examples
 
-1. Create a post from file:
+### Posts
 
-   ```bash
-   ec post create --file examples/simple.md
-   ```
+```bash
+# Create a post from file
+ec post create --file examples/simple.md
 
-2. Pull it back to edit:
+# Pull it back to edit
+ec post pull example-post
 
-   ```bash
-   ec post pull example-post
-   ```
+# Edit the downloaded file, then update
+ec post edit example-post --file example-post.md
 
-3. Edit the downloaded file, then update:
+# Publish when ready
+ec post publish example-post
+```
 
-   ```bash
-   ec post edit example-post --file example-post.md
-   ```
+### Links
 
-4. Publish when ready:
-   ```bash
-   ec post publish example-post
-   ```
+```bash
+# Create a link from CLI
+ec link create --url "https://example.com" --slug cool-article --content "Great read"
+
+# Or from file
+ec link create --file examples/link.md
+
+# List all links
+ec link list
+
+# Publish
+ec link publish cool-article
+```
+
+### Notes
+
+```bash
+# Create a quick note
+ec note create --slug shipped --content "Just deployed v2.0 🚀"
+
+# Or from file
+ec note create --file examples/note.md
+
+# List notes
+ec note list
+
+# Publish
+ec note publish shipped
+```
 
 ## Image Handling
 
@@ -67,3 +105,41 @@ You can also reference existing images by ID:
 ```
 
 This fetches the URL for image #42 from the server.
+
+## Frontmatter Reference
+
+### Post Frontmatter
+
+```yaml
+---
+title: My Post Title
+slug: my-post-slug
+type: article
+tags: [tech, programming]
+excerpt: A short summary
+banner: ./hero.png
+---
+```
+
+### Link Frontmatter
+
+```yaml
+---
+url: https://example.com/article
+slug: link-slug
+title: Optional Title
+tags: [tech]
+excerpt: Optional summary
+source: 1 # Source ID (e.g., Hacker News)
+---
+```
+
+### Note Frontmatter
+
+```yaml
+---
+slug: note-slug
+---
+```
+
+Notes are minimal - just a slug and content.

--- a/cli/examples/link.md
+++ b/cli/examples/link.md
@@ -1,0 +1,15 @@
+---
+url: https://example.com/interesting-article
+slug: interesting-read
+title: An Interesting Article
+tags: [tech, programming]
+excerpt: Great insights on software architecture
+---
+
+Really enjoyed this article. The author makes great points about:
+
+1. Keeping things simple
+2. Favoring composition over inheritance
+3. Writing tests first
+
+Worth a read if you're into software design.

--- a/cli/examples/note.md
+++ b/cli/examples/note.md
@@ -1,13 +1,7 @@
 ---
-slug: quick-thought
-type: note
-tags: [thought]
+slug: quick-update
 ---
 
-Just a quick note to self. Notes don't require a title - they're for short, informal posts.
+Just shipped a new feature! 🚀
 
-Perfect for:
-
-- Quick thoughts
-- Links with brief commentary
-- Status updates
+The CLI now supports creating posts from markdown files with frontmatter.

--- a/cli/src/commands/link/create.ts
+++ b/cli/src/commands/link/create.ts
@@ -1,0 +1,251 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+import { parseMarkdown } from "../../lib/markdown";
+import { detectImages, processImages, rewriteContent } from "../../lib/images";
+
+interface CreateOptions {
+  file?: string;
+  url?: string;
+  title?: string;
+  slug?: string;
+  content?: string;
+  excerpt?: string;
+  tags?: string[];
+  source?: string;
+}
+
+function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolean } {
+  const options: CreateOptions = {};
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--file" && args[i + 1]) {
+      options.file = args[++i];
+    } else if (arg.startsWith("--file=")) {
+      options.file = arg.split("=").slice(1).join("=");
+    } else if (arg === "--url" && args[i + 1]) {
+      options.url = args[++i];
+    } else if (arg.startsWith("--url=")) {
+      options.url = arg.split("=").slice(1).join("=");
+    } else if (arg === "--title" && args[i + 1]) {
+      options.title = args[++i];
+    } else if (arg.startsWith("--title=")) {
+      options.title = arg.split("=").slice(1).join("=");
+    } else if (arg === "--slug" && args[i + 1]) {
+      options.slug = args[++i];
+    } else if (arg.startsWith("--slug=")) {
+      options.slug = arg.split("=").slice(1).join("=");
+    } else if (arg === "--content" && args[i + 1]) {
+      options.content = args[++i];
+    } else if (arg.startsWith("--content=")) {
+      options.content = arg.split("=").slice(1).join("=");
+    } else if (arg === "--excerpt" && args[i + 1]) {
+      options.excerpt = args[++i];
+    } else if (arg.startsWith("--excerpt=")) {
+      options.excerpt = arg.split("=").slice(1).join("=");
+    } else if (arg === "--tags" && args[i + 1]) {
+      options.tags = args[++i].split(",").map((t) => t.trim());
+    } else if (arg.startsWith("--tags=")) {
+      options.tags = arg
+        .split("=")
+        .slice(1)
+        .join("=")
+        .split(",")
+        .map((t) => t.trim());
+    } else if (arg === "--source" && args[i + 1]) {
+      options.source = args[++i];
+    } else if (arg.startsWith("--source=")) {
+      options.source = arg.split("=").slice(1).join("=");
+    }
+
+    i++;
+  }
+
+  return { options, help };
+}
+
+function showCreateHelp(): void {
+  console.log(`ec link create - Create a new link
+
+Usage: ec link create [options]
+       ec link create --file <path>
+
+Options:
+  --file <path>       Create from markdown file with frontmatter
+  --url <url>         External URL (required)
+  --slug <slug>       URL slug (required, lowercase letters, numbers, hyphens)
+  --content <text>    Your commentary in markdown (required unless --file)
+  --title <title>     Optional title
+  --excerpt <text>    Short excerpt/summary
+  --tags <tags>       Comma-separated list of tags
+  --source <id>       Source ID (e.g., Hacker News, Reddit)
+  --json              Output as JSON
+  --help, -h          Show this help message
+
+File-based creation:
+  When using --file, frontmatter fields (url, slug, title, tags, excerpt, source, banner)
+  are extracted from the markdown file. Command-line options override frontmatter.
+
+Examples:
+  ec link create --url "https://example.com" --slug cool-article --content "Worth reading"
+  ec link create --file link.md
+  ec link create --url "https://..." --slug my-link --content "..." --source 1
+`);
+}
+
+export async function create(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { options, help } = parseCreateArgs(args);
+
+  if (help) {
+    showCreateHelp();
+    return;
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+
+  // Determine values from file or options
+  let url = options.url;
+  let title = options.title;
+  let slug = options.slug;
+  let content = options.content;
+  let excerpt = options.excerpt;
+  let tags = options.tags;
+  let source = options.source;
+  let banner: string | undefined;
+  let bannerImageId: number | undefined;
+
+  if (options.file) {
+    // File-based creation
+    const filePath = path.resolve(options.file);
+
+    if (!fs.existsSync(filePath)) {
+      console.error(`❌ File not found: ${options.file}`);
+      process.exit(1);
+    }
+
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    const basePath = path.dirname(filePath);
+    const { frontmatter, content: bodyContent } = parseMarkdown(fileContent);
+
+    // Use frontmatter values, allow CLI overrides
+    url = options.url ?? frontmatter.url;
+    title = options.title ?? frontmatter.title;
+    slug = options.slug ?? frontmatter.slug;
+    excerpt = options.excerpt ?? frontmatter.excerpt;
+    source = options.source ?? frontmatter.source;
+    banner = frontmatter.banner;
+
+    // Merge tags: CLI tags override, or use frontmatter
+    tags = options.tags ?? frontmatter.tags;
+
+    // Process images
+    const imageRefs = detectImages(banner, bodyContent, basePath);
+    const localImages = imageRefs.filter((r) => r.type === "local" || r.type === "id");
+
+    if (localImages.length > 0) {
+      if (!slug) {
+        console.error("❌ Slug is required before uploading images.");
+        console.error("   Add 'slug:' to frontmatter or use --slug option.");
+        process.exit(1);
+      }
+
+      console.log(`📤 Processing ${localImages.length} image(s)...`);
+
+      try {
+        const { urlMap, idMap } = await processImages(imageRefs, slug, client);
+
+        // Rewrite content
+        content = rewriteContent(bodyContent, urlMap);
+
+        // Get banner image ID if banner was processed
+        if (banner && idMap.has(banner)) {
+          bannerImageId = idMap.get(banner);
+        }
+      } catch (error) {
+        console.error(`❌ Image processing failed: ${error}`);
+        process.exit(1);
+      }
+    } else {
+      content = bodyContent;
+    }
+  }
+
+  // Validate required fields
+  if (!url) {
+    console.error("❌ Missing required option: --url");
+    console.error("   Or add 'url:' to frontmatter when using --file");
+    process.exit(1);
+  }
+
+  if (!slug) {
+    console.error("❌ Missing required option: --slug");
+    console.error("   Or add 'slug:' to frontmatter when using --file");
+    process.exit(1);
+  }
+
+  if (!content) {
+    console.error("❌ Missing required option: --content");
+    console.error("   Or provide content in markdown file when using --file");
+    process.exit(1);
+  }
+
+  // Parse source ID if provided
+  const sourceId = source ? parseInt(source, 10) : undefined;
+  if (source && (isNaN(sourceId!) || sourceId! <= 0)) {
+    console.error("❌ Invalid source ID. Must be a positive integer.");
+    process.exit(1);
+  }
+
+  const result = await client.createPost({
+    type: "link",
+    slug,
+    url,
+    title,
+    content,
+    excerpt,
+    tags,
+    source_id: sourceId,
+    banner_image_id: bannerImageId,
+  });
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+  } else {
+    console.log(`✅ Link created: ${post.slug}`);
+    console.log(`   URL: ${url}`);
+    if (post.title) {
+      console.log(`   Title: ${post.title}`);
+    }
+    console.log(`   Status: draft`);
+    if (post.tags.length > 0) {
+      console.log(`   Tags: ${post.tags.join(", ")}`);
+    }
+    if (options.file) {
+      console.log(`   Source: ${options.file}`);
+    }
+  }
+}

--- a/cli/src/commands/link/delete.ts
+++ b/cli/src/commands/link/delete.ts
@@ -1,0 +1,109 @@
+import * as readline from "readline";
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function showDeleteHelp(): void {
+  console.log(`ec link delete - Delete a link
+
+Usage: ec link delete <slug> [options]
+
+Arguments:
+  slug              The link slug to delete
+
+Options:
+  --force, -f       Skip confirmation prompt
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec link delete old-link
+  ec link delete old-link --force
+`);
+}
+
+function confirm(prompt: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+    });
+  });
+}
+
+export async function del(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  // Check for help flag
+  if (args.includes("--help") || args.includes("-h")) {
+    showDeleteHelp();
+    return;
+  }
+
+  // Parse args
+  const force = args.includes("--force") || args.includes("-f");
+  const slug = args.find((arg) => !arg.startsWith("-"));
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec link delete <slug>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+
+  // Verify link exists first
+  const existing = await client.getPost(slug);
+  if (existing.error) {
+    if (existing.error.includes("404") || existing.error.includes("not found")) {
+      console.error(`❌ Link not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${existing.error}`);
+    }
+    process.exit(1);
+  }
+
+  // Confirm deletion
+  if (!force) {
+    const link = existing.data!;
+    console.log(`About to delete link: ${slug}`);
+    if (link.title) {
+      console.log(`  Title: ${link.title}`);
+    }
+    if (link.url) {
+      console.log(`  URL: ${link.url}`);
+    }
+    console.log("");
+
+    const confirmed = await confirm("Are you sure? (y/N): ");
+    if (!confirmed) {
+      console.log("Cancelled.");
+      return;
+    }
+  }
+
+  const result = await client.deletePost(slug);
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify({ success: true, slug }, null, 2));
+  } else {
+    console.log(`✅ Deleted: ${slug}`);
+  }
+}

--- a/cli/src/commands/link/edit.ts
+++ b/cli/src/commands/link/edit.ts
@@ -1,0 +1,235 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+import { parseMarkdown } from "../../lib/markdown";
+import { detectImages, processImages, rewriteContent } from "../../lib/images";
+
+interface EditOptions {
+  file?: string;
+  url?: string;
+  title?: string;
+  content?: string;
+  excerpt?: string;
+  tags?: string[];
+  source?: string;
+}
+
+function parseEditArgs(args: string[]): { slug?: string; options: EditOptions; help: boolean } {
+  const options: EditOptions = {};
+  let slug: string | undefined;
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--file" && args[i + 1]) {
+      options.file = args[++i];
+    } else if (arg.startsWith("--file=")) {
+      options.file = arg.split("=").slice(1).join("=");
+    } else if (arg === "--url" && args[i + 1]) {
+      options.url = args[++i];
+    } else if (arg.startsWith("--url=")) {
+      options.url = arg.split("=").slice(1).join("=");
+    } else if (arg === "--title" && args[i + 1]) {
+      options.title = args[++i];
+    } else if (arg.startsWith("--title=")) {
+      options.title = arg.split("=").slice(1).join("=");
+    } else if (arg === "--content" && args[i + 1]) {
+      options.content = args[++i];
+    } else if (arg.startsWith("--content=")) {
+      options.content = arg.split("=").slice(1).join("=");
+    } else if (arg === "--excerpt" && args[i + 1]) {
+      options.excerpt = args[++i];
+    } else if (arg.startsWith("--excerpt=")) {
+      options.excerpt = arg.split("=").slice(1).join("=");
+    } else if (arg === "--tags" && args[i + 1]) {
+      options.tags = args[++i].split(",").map((t) => t.trim());
+    } else if (arg.startsWith("--tags=")) {
+      options.tags = arg
+        .split("=")
+        .slice(1)
+        .join("=")
+        .split(",")
+        .map((t) => t.trim());
+    } else if (arg === "--source" && args[i + 1]) {
+      options.source = args[++i];
+    } else if (arg.startsWith("--source=")) {
+      options.source = arg.split("=").slice(1).join("=");
+    } else if (!arg.startsWith("-") && !slug) {
+      slug = arg;
+    }
+
+    i++;
+  }
+
+  return { slug, options, help };
+}
+
+function showEditHelp(): void {
+  console.log(`ec link edit - Edit an existing link
+
+Usage: ec link edit <slug> [options]
+       ec link edit <slug> --file <path>
+
+Arguments:
+  slug                The link slug to edit
+
+Options:
+  --file <path>       Update from markdown file with frontmatter
+  --url <url>         Update external URL
+  --title <title>     Update title
+  --content <text>    Update commentary
+  --excerpt <text>    Update excerpt
+  --tags <tags>       Replace tags (comma-separated)
+  --source <id>       Update source ID
+  --json              Output as JSON
+  --help, -h          Show this help message
+
+File-based editing:
+  When using --file, content and frontmatter fields are extracted from the
+  markdown file. The slug in the file is ignored (uses command argument).
+  Local images are uploaded and URLs rewritten.
+
+Examples:
+  ec link edit my-link --url "https://new-url.com"
+  ec link edit my-link --file updated.md
+  ec link edit my-link --tags tech,programming
+`);
+}
+
+export async function edit(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { slug, options, help } = parseEditArgs(args);
+
+  if (help) {
+    showEditHelp();
+    return;
+  }
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec link edit <slug> [options]");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+
+  // Build update payload
+  let url = options.url;
+  let title = options.title;
+  let content = options.content;
+  let excerpt = options.excerpt;
+  let tags = options.tags;
+  let source = options.source;
+
+  if (options.file) {
+    // File-based editing
+    const filePath = path.resolve(options.file);
+
+    if (!fs.existsSync(filePath)) {
+      console.error(`❌ File not found: ${options.file}`);
+      process.exit(1);
+    }
+
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    const basePath = path.dirname(filePath);
+    const { frontmatter, content: bodyContent } = parseMarkdown(fileContent);
+
+    // Use frontmatter values (CLI overrides if provided)
+    url = options.url ?? frontmatter.url;
+    title = options.title ?? frontmatter.title;
+    excerpt = options.excerpt ?? frontmatter.excerpt;
+    tags = options.tags ?? frontmatter.tags;
+    source = options.source ?? frontmatter.source;
+
+    // Process images
+    const banner = frontmatter.banner;
+    const imageRefs = detectImages(banner, bodyContent, basePath);
+    const localImages = imageRefs.filter((r) => r.type === "local" || r.type === "id");
+
+    if (localImages.length > 0) {
+      console.log(`📤 Processing ${localImages.length} image(s)...`);
+
+      try {
+        const { urlMap } = await processImages(imageRefs, slug, client);
+        content = rewriteContent(bodyContent, urlMap);
+      } catch (error) {
+        console.error(`❌ Image processing failed: ${error}`);
+        process.exit(1);
+      }
+    } else {
+      content = bodyContent;
+    }
+  }
+
+  // Check if any update options provided
+  if (!url && !title && !content && !excerpt && !tags && !source) {
+    console.error("❌ No update options provided.");
+    console.error("Use --file, --url, --title, --content, --excerpt, --tags, or --source.");
+    process.exit(1);
+  }
+
+  // Parse source ID if provided
+  let sourceId: number | undefined;
+  if (source) {
+    sourceId = parseInt(source, 10);
+    if (isNaN(sourceId) || sourceId <= 0) {
+      console.error("❌ Invalid source ID. Must be a positive integer.");
+      process.exit(1);
+    }
+  }
+
+  const updateData: {
+    url?: string;
+    title?: string;
+    content?: string;
+    excerpt?: string;
+    tags?: string[];
+    source_id?: number;
+  } = {};
+
+  if (url !== undefined) updateData.url = url;
+  if (title !== undefined) updateData.title = title;
+  if (content !== undefined) updateData.content = content;
+  if (excerpt !== undefined) updateData.excerpt = excerpt;
+  if (tags !== undefined) updateData.tags = tags;
+  if (sourceId !== undefined) updateData.source_id = sourceId;
+
+  const result = await client.updatePost(slug, updateData);
+
+  if (result.error) {
+    if (result.error.includes("404") || result.error.includes("not found")) {
+      console.error(`❌ Link not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+  } else {
+    console.log(`✅ Link updated: ${post.slug}`);
+    if (url) console.log(`   URL: ${url}`);
+    if (title) console.log(`   Title: ${post.title}`);
+    if (content) console.log(`   Content updated`);
+    if (excerpt) console.log(`   Excerpt: ${post.excerpt}`);
+    if (tags) console.log(`   Tags: ${post.tags.join(", ") || "(none)"}`);
+    if (options.file) console.log(`   Source: ${options.file}`);
+  }
+}

--- a/cli/src/commands/link/index.ts
+++ b/cli/src/commands/link/index.ts
@@ -1,0 +1,77 @@
+import type { GlobalOptions } from "../../types";
+import { list } from "./list";
+import { show } from "./show";
+import { create } from "./create";
+import { edit } from "./edit";
+import { del } from "./delete";
+import { publish } from "./publish";
+import { unpublish } from "./unpublish";
+import { pull } from "./pull";
+
+function showHelp(): void {
+  console.log(`ec link - Manage links (linkblog)
+
+Usage: ec link <command> [options]
+
+Commands:
+  list                List links
+  show <slug>         Show link details
+  create              Create a new link
+  edit <slug>         Edit an existing link
+  delete <slug>       Delete a link
+  publish <slug>      Publish a link
+  unpublish <slug>    Unpublish a link
+  pull <slug>         Download link as markdown file
+
+Options:
+  --json              Output as JSON (where applicable)
+  --help, -h          Show help for a command
+
+Examples:
+  ec link list
+  ec link create --url "https://..." --slug my-link --content "Commentary"
+  ec link show my-link
+  ec link publish my-link
+  ec link pull my-link
+`);
+}
+
+export async function linkCommand(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const [subcommand, ...rest] = args;
+
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    showHelp();
+    return;
+  }
+
+  switch (subcommand) {
+    case "list":
+      await list(rest, globalOptions);
+      break;
+    case "show":
+      await show(rest, globalOptions);
+      break;
+    case "create":
+      await create(rest, globalOptions);
+      break;
+    case "edit":
+      await edit(rest, globalOptions);
+      break;
+    case "delete":
+      await del(rest, globalOptions);
+      break;
+    case "publish":
+      await publish(rest, globalOptions);
+      break;
+    case "unpublish":
+      await unpublish(rest, globalOptions);
+      break;
+    case "pull":
+      await pull(rest, globalOptions);
+      break;
+    default:
+      console.error(`Unknown link command: ${subcommand}`);
+      console.error("Run 'ec link --help' for usage.");
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/link/list.ts
+++ b/cli/src/commands/link/list.ts
@@ -1,0 +1,150 @@
+import type { GlobalOptions, PostListItem } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+interface ListOptions {
+  limit?: number;
+  tag?: string;
+  status?: string;
+}
+
+function parseListArgs(args: string[]): { options: ListOptions; help: boolean } {
+  const options: ListOptions = {};
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--limit" && args[i + 1]) {
+      options.limit = parseInt(args[++i], 10);
+    } else if (arg.startsWith("--limit=")) {
+      options.limit = parseInt(arg.split("=")[1], 10);
+    } else if (arg === "--tag" && args[i + 1]) {
+      options.tag = args[++i];
+    } else if (arg.startsWith("--tag=")) {
+      options.tag = arg.split("=")[1];
+    } else if (arg === "--status" && args[i + 1]) {
+      options.status = args[++i];
+    } else if (arg.startsWith("--status=")) {
+      options.status = arg.split("=")[1];
+    }
+
+    i++;
+  }
+
+  return { options, help };
+}
+
+function showListHelp(): void {
+  console.log(`ec link list - List links
+
+Usage: ec link list [options]
+
+Options:
+  --limit <n>       Maximum number of links (default: 50, max: 100)
+  --tag <tag>       Filter by tag slug
+  --status <status> Filter by status: draft, published, all (default: all)
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec link list
+  ec link list --limit 10
+  ec link list --status published
+  ec link list --tag tech
+`);
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "-";
+  const date = new Date(dateStr);
+  return date.toISOString().split("T")[0];
+}
+
+function truncate(str: string | null, maxLen: number): string {
+  if (!str) return "-";
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 3) + "...";
+}
+
+function formatTable(posts: PostListItem[]): void {
+  if (posts.length === 0) {
+    console.log("No links found.");
+    return;
+  }
+
+  // Calculate column widths
+  const slugWidth = Math.max(4, ...posts.map((p) => p.slug.length));
+  const titleWidth = Math.min(40, Math.max(5, ...posts.map((p) => (p.title || "-").length)));
+  const statusWidth = 9; // "published" is 9 chars
+  const dateWidth = 10; // YYYY-MM-DD
+
+  // Header
+  const header = [
+    "SLUG".padEnd(Math.min(slugWidth, 30)),
+    "TITLE".padEnd(titleWidth),
+    "STATUS".padEnd(statusWidth),
+    "DATE".padEnd(dateWidth),
+  ].join("  ");
+
+  console.log(header);
+
+  // Rows
+  for (const post of posts) {
+    const status = post.published_at ? "published" : "draft";
+    const date = formatDate(post.published_at);
+
+    const row = [
+      truncate(post.slug, 30).padEnd(Math.min(slugWidth, 30)),
+      truncate(post.title, titleWidth).padEnd(titleWidth),
+      status.padEnd(statusWidth),
+      date.padEnd(dateWidth),
+    ].join("  ");
+
+    console.log(row);
+  }
+
+  console.log(`\nTotal: ${posts.length} links`);
+}
+
+export async function list(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { options, help } = parseListArgs(args);
+
+  if (help) {
+    showListHelp();
+    return;
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.listPosts({
+    limit: options.limit,
+    tag: options.tag,
+    status: options.status || "all",
+    type: "link",
+  });
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const posts = result.data || [];
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(posts, null, 2));
+  } else {
+    formatTable(posts);
+  }
+}

--- a/cli/src/commands/link/publish.ts
+++ b/cli/src/commands/link/publish.ts
@@ -1,0 +1,69 @@
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function showPublishHelp(): void {
+  console.log(`ec link publish - Publish a link
+
+Usage: ec link publish <slug> [options]
+
+Arguments:
+  slug              The link slug to publish
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec link publish my-link
+`);
+}
+
+export async function publish(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  // Check for help flag
+  if (args.includes("--help") || args.includes("-h")) {
+    showPublishHelp();
+    return;
+  }
+
+  // Get slug from args
+  const slug = args.find((arg) => !arg.startsWith("-"));
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec link publish <slug>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.publishPost(slug);
+
+  if (result.error) {
+    if (result.error.includes("404") || result.error.includes("not found")) {
+      console.error(`❌ Link not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+  } else {
+    console.log(`✅ Published: ${post.slug}`);
+    if (post.url) {
+      console.log(`   URL: ${post.url}`);
+    }
+  }
+}

--- a/cli/src/commands/link/pull.ts
+++ b/cli/src/commands/link/pull.ts
@@ -1,0 +1,137 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+import { generateMarkdown, type PostFrontmatter } from "../../lib/markdown";
+
+interface PullOptions {
+  output?: string;
+}
+
+function parsePullArgs(args: string[]): { slug?: string; options: PullOptions; help: boolean } {
+  const options: PullOptions = {};
+  let slug: string | undefined;
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--output" && args[i + 1]) {
+      options.output = args[++i];
+    } else if (arg.startsWith("--output=")) {
+      options.output = arg.split("=").slice(1).join("=");
+    } else if (arg === "-o" && args[i + 1]) {
+      options.output = args[++i];
+    } else if (!arg.startsWith("-") && !slug) {
+      slug = arg;
+    }
+
+    i++;
+  }
+
+  return { slug, options, help };
+}
+
+function showPullHelp(): void {
+  console.log(`ec link pull - Download a link as markdown
+
+Usage: ec link pull <slug> [options]
+
+Arguments:
+  slug                The link slug to download
+
+Options:
+  --output, -o <path> Output file path (default: <slug>.md)
+  --json              Output link data as JSON instead of markdown
+  --help, -h          Show this help message
+
+Examples:
+  ec link pull my-link
+  ec link pull my-link --output ./links/article.md
+  ec link pull my-link -o link.md
+`);
+}
+
+export async function pull(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { slug, options, help } = parsePullArgs(args);
+
+  if (help) {
+    showPullHelp();
+    return;
+  }
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec link pull <slug>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.getPost(slug);
+
+  if (result.error) {
+    if (result.error.includes("404") || result.error.includes("not found")) {
+      console.error(`❌ Link not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+    return;
+  }
+
+  // Generate frontmatter with link-specific fields
+  const frontmatter: PostFrontmatter = {
+    slug: post.slug,
+    type: post.type,
+    url: post.url || undefined,
+    title: post.title || undefined,
+    source: post.source_id ? String(post.source_id) : undefined,
+    status: post.published_at ? "published" : "draft",
+    tags: post.tags.length > 0 ? post.tags : undefined,
+    excerpt: post.excerpt || undefined,
+    created: post.created_at.split("T")[0],
+  };
+
+  const markdown = generateMarkdown(frontmatter, post.content);
+
+  // Determine output path
+  const outputPath = options.output || `${slug}.md`;
+  const resolvedPath = path.resolve(outputPath);
+
+  // Ensure directory exists
+  const dir = path.dirname(resolvedPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  // Write file
+  fs.writeFileSync(resolvedPath, markdown, "utf-8");
+
+  console.log(`✅ Downloaded: ${outputPath}`);
+  if (post.url) {
+    console.log(`   URL: ${post.url}`);
+  }
+  if (post.title) {
+    console.log(`   Title: ${post.title}`);
+  }
+  console.log(`   Status: ${post.published_at ? "published" : "draft"}`);
+}

--- a/cli/src/commands/link/show.ts
+++ b/cli/src/commands/link/show.ts
@@ -1,0 +1,98 @@
+import type { GlobalOptions, Post } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function showShowHelp(): void {
+  console.log(`ec link show - Show link details
+
+Usage: ec link show <slug> [options]
+
+Arguments:
+  slug              The link slug to show
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec link show interesting-article
+  ec link show interesting-article --json
+`);
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "-";
+  const date = new Date(dateStr);
+  return date.toISOString().replace("T", " ").slice(0, 19);
+}
+
+function formatLink(post: Post): void {
+  const status = post.published_at ? "published" : "draft";
+
+  console.log(`URL:       ${post.url || "(no url)"}`);
+  if (post.title) {
+    console.log(`Title:     ${post.title}`);
+  }
+  console.log(`Slug:      ${post.slug}`);
+  console.log(`Status:    ${status}`);
+  console.log(`Created:   ${formatDate(post.created_at)}`);
+  console.log(`Updated:   ${formatDate(post.updated_at)}`);
+  if (post.published_at) {
+    console.log(`Published: ${formatDate(post.published_at)}`);
+  }
+  if (post.tags.length > 0) {
+    console.log(`Tags:      ${post.tags.join(", ")}`);
+  }
+  if (post.excerpt) {
+    console.log(`Excerpt:   ${post.excerpt}`);
+  }
+  console.log("");
+  console.log("---");
+  console.log(post.content);
+}
+
+export async function show(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  // Check for help flag
+  if (args.includes("--help") || args.includes("-h")) {
+    showShowHelp();
+    return;
+  }
+
+  // Get slug from args (first non-flag argument)
+  const slug = args.find((arg) => !arg.startsWith("-"));
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec link show <slug>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.getPost(slug);
+
+  if (result.error) {
+    if (result.error.includes("404") || result.error.includes("not found")) {
+      console.error(`❌ Link not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+  } else {
+    formatLink(post);
+  }
+}

--- a/cli/src/commands/link/unpublish.ts
+++ b/cli/src/commands/link/unpublish.ts
@@ -1,0 +1,66 @@
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function showUnpublishHelp(): void {
+  console.log(`ec link unpublish - Unpublish a link
+
+Usage: ec link unpublish <slug> [options]
+
+Arguments:
+  slug              The link slug to unpublish
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec link unpublish my-link
+`);
+}
+
+export async function unpublish(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  // Check for help flag
+  if (args.includes("--help") || args.includes("-h")) {
+    showUnpublishHelp();
+    return;
+  }
+
+  // Get slug from args
+  const slug = args.find((arg) => !arg.startsWith("-"));
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec link unpublish <slug>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.unpublishPost(slug);
+
+  if (result.error) {
+    if (result.error.includes("404") || result.error.includes("not found")) {
+      console.error(`❌ Link not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+  } else {
+    console.log(`✅ Unpublished: ${post.slug}`);
+  }
+}

--- a/cli/src/commands/note/create.ts
+++ b/cli/src/commands/note/create.ts
@@ -1,0 +1,178 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+import { parseMarkdown } from "../../lib/markdown";
+import { detectImages, processImages, rewriteContent } from "../../lib/images";
+
+interface CreateOptions {
+  file?: string;
+  slug?: string;
+  content?: string;
+}
+
+function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolean } {
+  const options: CreateOptions = {};
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--file" && args[i + 1]) {
+      options.file = args[++i];
+    } else if (arg.startsWith("--file=")) {
+      options.file = arg.split("=").slice(1).join("=");
+    } else if (arg === "--slug" && args[i + 1]) {
+      options.slug = args[++i];
+    } else if (arg.startsWith("--slug=")) {
+      options.slug = arg.split("=").slice(1).join("=");
+    } else if (arg === "--content" && args[i + 1]) {
+      options.content = args[++i];
+    } else if (arg.startsWith("--content=")) {
+      options.content = arg.split("=").slice(1).join("=");
+    }
+
+    i++;
+  }
+
+  return { options, help };
+}
+
+function showCreateHelp(): void {
+  console.log(`ec note create - Create a new note
+
+Usage: ec note create [options]
+       ec note create --file <path>
+
+Options:
+  --file <path>       Create from markdown file with frontmatter
+  --slug <slug>       URL slug (required, lowercase letters, numbers, hyphens)
+  --content <text>    Note content in markdown (required unless --file)
+  --json              Output as JSON
+  --help, -h          Show this help message
+
+File-based creation:
+  When using --file, the slug is extracted from frontmatter.
+  Command-line options override frontmatter values.
+
+Examples:
+  ec note create --slug quick-thought --content "Just a quick thought"
+  ec note create --file note.md
+`);
+}
+
+export async function create(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { options, help } = parseCreateArgs(args);
+
+  if (help) {
+    showCreateHelp();
+    return;
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+
+  // Determine values from file or options
+  let slug = options.slug;
+  let content = options.content;
+  let banner: string | undefined;
+  let bannerImageId: number | undefined;
+
+  if (options.file) {
+    // File-based creation
+    const filePath = path.resolve(options.file);
+
+    if (!fs.existsSync(filePath)) {
+      console.error(`❌ File not found: ${options.file}`);
+      process.exit(1);
+    }
+
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    const basePath = path.dirname(filePath);
+    const { frontmatter, content: bodyContent } = parseMarkdown(fileContent);
+
+    // Use frontmatter values, allow CLI overrides
+    slug = options.slug ?? frontmatter.slug;
+    banner = frontmatter.banner;
+
+    // Process images
+    const imageRefs = detectImages(banner, bodyContent, basePath);
+    const localImages = imageRefs.filter((r) => r.type === "local" || r.type === "id");
+
+    if (localImages.length > 0) {
+      if (!slug) {
+        console.error("❌ Slug is required before uploading images.");
+        console.error("   Add 'slug:' to frontmatter or use --slug option.");
+        process.exit(1);
+      }
+
+      console.log(`📤 Processing ${localImages.length} image(s)...`);
+
+      try {
+        const { urlMap, idMap } = await processImages(imageRefs, slug, client);
+
+        // Rewrite content
+        content = rewriteContent(bodyContent, urlMap);
+
+        // Get banner image ID if banner was processed
+        if (banner && idMap.has(banner)) {
+          bannerImageId = idMap.get(banner);
+        }
+      } catch (error) {
+        console.error(`❌ Image processing failed: ${error}`);
+        process.exit(1);
+      }
+    } else {
+      content = bodyContent;
+    }
+  }
+
+  // Validate required fields
+  if (!slug) {
+    console.error("❌ Missing required option: --slug");
+    console.error("   Or add 'slug:' to frontmatter when using --file");
+    process.exit(1);
+  }
+
+  if (!content) {
+    console.error("❌ Missing required option: --content");
+    console.error("   Or provide content in markdown file when using --file");
+    process.exit(1);
+  }
+
+  const result = await client.createPost({
+    type: "note",
+    slug,
+    content,
+    banner_image_id: bannerImageId,
+  });
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+  } else {
+    console.log(`✅ Note created: ${post.slug}`);
+    console.log(`   Status: draft`);
+    if (options.file) {
+      console.log(`   Source: ${options.file}`);
+    }
+  }
+}

--- a/cli/src/commands/note/delete.ts
+++ b/cli/src/commands/note/delete.ts
@@ -1,0 +1,109 @@
+import * as readline from "readline";
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function showDeleteHelp(): void {
+  console.log(`ec note delete - Delete a note
+
+Usage: ec note delete <slug> [options]
+
+Arguments:
+  slug              The note slug to delete
+
+Options:
+  --force, -f       Skip confirmation prompt
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec note delete old-note
+  ec note delete old-note --force
+`);
+}
+
+function confirm(prompt: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+    });
+  });
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 3) + "...";
+}
+
+export async function del(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  // Check for help flag
+  if (args.includes("--help") || args.includes("-h")) {
+    showDeleteHelp();
+    return;
+  }
+
+  // Parse args
+  const force = args.includes("--force") || args.includes("-f");
+  const slug = args.find((arg) => !arg.startsWith("-"));
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec note delete <slug>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+
+  // Verify note exists first
+  const existing = await client.getPost(slug);
+  if (existing.error) {
+    if (existing.error.includes("404") || existing.error.includes("not found")) {
+      console.error(`❌ Note not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${existing.error}`);
+    }
+    process.exit(1);
+  }
+
+  // Confirm deletion
+  if (!force) {
+    const note = existing.data!;
+    console.log(`About to delete note: ${slug}`);
+    console.log(`  Content: ${truncate(note.content, 60)}`);
+    console.log("");
+
+    const confirmed = await confirm("Are you sure? (y/N): ");
+    if (!confirmed) {
+      console.log("Cancelled.");
+      return;
+    }
+  }
+
+  const result = await client.deletePost(slug);
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify({ success: true, slug }, null, 2));
+  } else {
+    console.log(`✅ Deleted: ${slug}`);
+  }
+}

--- a/cli/src/commands/note/edit.ts
+++ b/cli/src/commands/note/edit.ts
@@ -1,0 +1,160 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+import { parseMarkdown } from "../../lib/markdown";
+import { detectImages, processImages, rewriteContent } from "../../lib/images";
+
+interface EditOptions {
+  file?: string;
+  content?: string;
+}
+
+function parseEditArgs(args: string[]): { slug?: string; options: EditOptions; help: boolean } {
+  const options: EditOptions = {};
+  let slug: string | undefined;
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--file" && args[i + 1]) {
+      options.file = args[++i];
+    } else if (arg.startsWith("--file=")) {
+      options.file = arg.split("=").slice(1).join("=");
+    } else if (arg === "--content" && args[i + 1]) {
+      options.content = args[++i];
+    } else if (arg.startsWith("--content=")) {
+      options.content = arg.split("=").slice(1).join("=");
+    } else if (!arg.startsWith("-") && !slug) {
+      slug = arg;
+    }
+
+    i++;
+  }
+
+  return { slug, options, help };
+}
+
+function showEditHelp(): void {
+  console.log(`ec note edit - Edit an existing note
+
+Usage: ec note edit <slug> [options]
+       ec note edit <slug> --file <path>
+
+Arguments:
+  slug                The note slug to edit
+
+Options:
+  --file <path>       Update from markdown file
+  --content <text>    Update content
+  --json              Output as JSON
+  --help, -h          Show this help message
+
+File-based editing:
+  When using --file, content is extracted from the markdown file.
+  The slug in the file is ignored (uses command argument).
+  Local images are uploaded and URLs rewritten.
+
+Examples:
+  ec note edit my-note --content "Updated content"
+  ec note edit my-note --file updated.md
+`);
+}
+
+export async function edit(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { slug, options, help } = parseEditArgs(args);
+
+  if (help) {
+    showEditHelp();
+    return;
+  }
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec note edit <slug> [options]");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+
+  // Build update payload
+  let content = options.content;
+
+  if (options.file) {
+    // File-based editing
+    const filePath = path.resolve(options.file);
+
+    if (!fs.existsSync(filePath)) {
+      console.error(`❌ File not found: ${options.file}`);
+      process.exit(1);
+    }
+
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    const basePath = path.dirname(filePath);
+    const { frontmatter, content: bodyContent } = parseMarkdown(fileContent);
+
+    // Process images
+    const banner = frontmatter.banner;
+    const imageRefs = detectImages(banner, bodyContent, basePath);
+    const localImages = imageRefs.filter((r) => r.type === "local" || r.type === "id");
+
+    if (localImages.length > 0) {
+      console.log(`📤 Processing ${localImages.length} image(s)...`);
+
+      try {
+        const { urlMap } = await processImages(imageRefs, slug, client);
+        content = rewriteContent(bodyContent, urlMap);
+      } catch (error) {
+        console.error(`❌ Image processing failed: ${error}`);
+        process.exit(1);
+      }
+    } else {
+      content = bodyContent;
+    }
+  }
+
+  // Check if any update options provided
+  if (!content) {
+    console.error("❌ No update options provided.");
+    console.error("Use --file or --content.");
+    process.exit(1);
+  }
+
+  const updateData: { content?: string } = {};
+  if (content !== undefined) updateData.content = content;
+
+  const result = await client.updatePost(slug, updateData);
+
+  if (result.error) {
+    if (result.error.includes("404") || result.error.includes("not found")) {
+      console.error(`❌ Note not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+  } else {
+    console.log(`✅ Note updated: ${post.slug}`);
+    if (content) console.log(`   Content updated`);
+    if (options.file) console.log(`   Source: ${options.file}`);
+  }
+}

--- a/cli/src/commands/note/index.ts
+++ b/cli/src/commands/note/index.ts
@@ -1,0 +1,77 @@
+import type { GlobalOptions } from "../../types";
+import { list } from "./list";
+import { show } from "./show";
+import { create } from "./create";
+import { edit } from "./edit";
+import { del } from "./delete";
+import { publish } from "./publish";
+import { unpublish } from "./unpublish";
+import { pull } from "./pull";
+
+function showHelp(): void {
+  console.log(`ec note - Manage notes
+
+Usage: ec note <command> [options]
+
+Commands:
+  list                List notes
+  show <slug>         Show note details
+  create              Create a new note
+  edit <slug>         Edit an existing note
+  delete <slug>       Delete a note
+  publish <slug>      Publish a note
+  unpublish <slug>    Unpublish a note
+  pull <slug>         Download note as markdown file
+
+Options:
+  --json              Output as JSON (where applicable)
+  --help, -h          Show help for a command
+
+Examples:
+  ec note list
+  ec note create --slug quick-thought --content "Just a quick thought"
+  ec note show quick-thought
+  ec note publish quick-thought
+  ec note pull quick-thought
+`);
+}
+
+export async function noteCommand(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const [subcommand, ...rest] = args;
+
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    showHelp();
+    return;
+  }
+
+  switch (subcommand) {
+    case "list":
+      await list(rest, globalOptions);
+      break;
+    case "show":
+      await show(rest, globalOptions);
+      break;
+    case "create":
+      await create(rest, globalOptions);
+      break;
+    case "edit":
+      await edit(rest, globalOptions);
+      break;
+    case "delete":
+      await del(rest, globalOptions);
+      break;
+    case "publish":
+      await publish(rest, globalOptions);
+      break;
+    case "unpublish":
+      await unpublish(rest, globalOptions);
+      break;
+    case "pull":
+      await pull(rest, globalOptions);
+      break;
+    default:
+      console.error(`Unknown note command: ${subcommand}`);
+      console.error("Run 'ec note --help' for usage.");
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/note/list.ts
+++ b/cli/src/commands/note/list.ts
@@ -1,0 +1,142 @@
+import type { GlobalOptions, PostListItem } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+interface ListOptions {
+  limit?: number;
+  status?: string;
+}
+
+function parseListArgs(args: string[]): { options: ListOptions; help: boolean } {
+  const options: ListOptions = {};
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--limit" && args[i + 1]) {
+      options.limit = parseInt(args[++i], 10);
+    } else if (arg.startsWith("--limit=")) {
+      options.limit = parseInt(arg.split("=")[1], 10);
+    } else if (arg === "--status" && args[i + 1]) {
+      options.status = args[++i];
+    } else if (arg.startsWith("--status=")) {
+      options.status = arg.split("=")[1];
+    }
+
+    i++;
+  }
+
+  return { options, help };
+}
+
+function showListHelp(): void {
+  console.log(`ec note list - List notes
+
+Usage: ec note list [options]
+
+Options:
+  --limit <n>       Maximum number of notes (default: 50, max: 100)
+  --status <status> Filter by status: draft, published, all (default: all)
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec note list
+  ec note list --limit 10
+  ec note list --status published
+`);
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "-";
+  const date = new Date(dateStr);
+  return date.toISOString().split("T")[0];
+}
+
+function truncate(str: string | null, maxLen: number): string {
+  if (!str) return "-";
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 3) + "...";
+}
+
+function formatTable(posts: PostListItem[]): void {
+  if (posts.length === 0) {
+    console.log("No notes found.");
+    return;
+  }
+
+  // Calculate column widths
+  const slugWidth = Math.max(4, ...posts.map((p) => p.slug.length));
+  const excerptWidth = 40;
+  const statusWidth = 9;
+  const dateWidth = 10;
+
+  // Header
+  const header = [
+    "SLUG".padEnd(Math.min(slugWidth, 30)),
+    "EXCERPT".padEnd(excerptWidth),
+    "STATUS".padEnd(statusWidth),
+    "DATE".padEnd(dateWidth),
+  ].join("  ");
+
+  console.log(header);
+
+  // Rows
+  for (const post of posts) {
+    const status = post.published_at ? "published" : "draft";
+    const date = formatDate(post.published_at);
+
+    const row = [
+      truncate(post.slug, 30).padEnd(Math.min(slugWidth, 30)),
+      truncate(post.excerpt, excerptWidth).padEnd(excerptWidth),
+      status.padEnd(statusWidth),
+      date.padEnd(dateWidth),
+    ].join("  ");
+
+    console.log(row);
+  }
+
+  console.log(`\nTotal: ${posts.length} notes`);
+}
+
+export async function list(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { options, help } = parseListArgs(args);
+
+  if (help) {
+    showListHelp();
+    return;
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.listPosts({
+    limit: options.limit,
+    status: options.status || "all",
+    type: "note",
+  });
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const posts = result.data || [];
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(posts, null, 2));
+  } else {
+    formatTable(posts);
+  }
+}

--- a/cli/src/commands/note/publish.ts
+++ b/cli/src/commands/note/publish.ts
@@ -1,0 +1,66 @@
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function showPublishHelp(): void {
+  console.log(`ec note publish - Publish a note
+
+Usage: ec note publish <slug> [options]
+
+Arguments:
+  slug              The note slug to publish
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec note publish my-note
+`);
+}
+
+export async function publish(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  // Check for help flag
+  if (args.includes("--help") || args.includes("-h")) {
+    showPublishHelp();
+    return;
+  }
+
+  // Get slug from args
+  const slug = args.find((arg) => !arg.startsWith("-"));
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec note publish <slug>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.publishPost(slug);
+
+  if (result.error) {
+    if (result.error.includes("404") || result.error.includes("not found")) {
+      console.error(`❌ Note not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+  } else {
+    console.log(`✅ Published: ${post.slug}`);
+  }
+}

--- a/cli/src/commands/note/pull.ts
+++ b/cli/src/commands/note/pull.ts
@@ -1,0 +1,126 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+import { generateMarkdown, type PostFrontmatter } from "../../lib/markdown";
+
+interface PullOptions {
+  output?: string;
+}
+
+function parsePullArgs(args: string[]): { slug?: string; options: PullOptions; help: boolean } {
+  const options: PullOptions = {};
+  let slug: string | undefined;
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--output" && args[i + 1]) {
+      options.output = args[++i];
+    } else if (arg.startsWith("--output=")) {
+      options.output = arg.split("=").slice(1).join("=");
+    } else if (arg === "-o" && args[i + 1]) {
+      options.output = args[++i];
+    } else if (!arg.startsWith("-") && !slug) {
+      slug = arg;
+    }
+
+    i++;
+  }
+
+  return { slug, options, help };
+}
+
+function showPullHelp(): void {
+  console.log(`ec note pull - Download a note as markdown
+
+Usage: ec note pull <slug> [options]
+
+Arguments:
+  slug                The note slug to download
+
+Options:
+  --output, -o <path> Output file path (default: <slug>.md)
+  --json              Output note data as JSON instead of markdown
+  --help, -h          Show this help message
+
+Examples:
+  ec note pull my-note
+  ec note pull my-note --output ./notes/thought.md
+  ec note pull my-note -o note.md
+`);
+}
+
+export async function pull(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { slug, options, help } = parsePullArgs(args);
+
+  if (help) {
+    showPullHelp();
+    return;
+  }
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec note pull <slug>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.getPost(slug);
+
+  if (result.error) {
+    if (result.error.includes("404") || result.error.includes("not found")) {
+      console.error(`❌ Note not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+    return;
+  }
+
+  // Generate frontmatter (minimal for notes)
+  const frontmatter: PostFrontmatter = {
+    slug: post.slug,
+    type: post.type,
+    status: post.published_at ? "published" : "draft",
+    created: post.created_at.split("T")[0],
+  };
+
+  const markdown = generateMarkdown(frontmatter, post.content);
+
+  // Determine output path
+  const outputPath = options.output || `${slug}.md`;
+  const resolvedPath = path.resolve(outputPath);
+
+  // Ensure directory exists
+  const dir = path.dirname(resolvedPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  // Write file
+  fs.writeFileSync(resolvedPath, markdown, "utf-8");
+
+  console.log(`✅ Downloaded: ${outputPath}`);
+  console.log(`   Status: ${post.published_at ? "published" : "draft"}`);
+}

--- a/cli/src/commands/note/show.ts
+++ b/cli/src/commands/note/show.ts
@@ -1,0 +1,88 @@
+import type { GlobalOptions, Post } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function showShowHelp(): void {
+  console.log(`ec note show - Show note details
+
+Usage: ec note show <slug> [options]
+
+Arguments:
+  slug              The note slug to show
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec note show quick-thought
+  ec note show quick-thought --json
+`);
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "-";
+  const date = new Date(dateStr);
+  return date.toISOString().replace("T", " ").slice(0, 19);
+}
+
+function formatNote(post: Post): void {
+  const status = post.published_at ? "published" : "draft";
+
+  console.log(`Slug:      ${post.slug}`);
+  console.log(`Status:    ${status}`);
+  console.log(`Created:   ${formatDate(post.created_at)}`);
+  console.log(`Updated:   ${formatDate(post.updated_at)}`);
+  if (post.published_at) {
+    console.log(`Published: ${formatDate(post.published_at)}`);
+  }
+  console.log("");
+  console.log("---");
+  console.log(post.content);
+}
+
+export async function show(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  // Check for help flag
+  if (args.includes("--help") || args.includes("-h")) {
+    showShowHelp();
+    return;
+  }
+
+  // Get slug from args (first non-flag argument)
+  const slug = args.find((arg) => !arg.startsWith("-"));
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec note show <slug>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.getPost(slug);
+
+  if (result.error) {
+    if (result.error.includes("404") || result.error.includes("not found")) {
+      console.error(`❌ Note not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+  } else {
+    formatNote(post);
+  }
+}

--- a/cli/src/commands/note/unpublish.ts
+++ b/cli/src/commands/note/unpublish.ts
@@ -1,0 +1,66 @@
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function showUnpublishHelp(): void {
+  console.log(`ec note unpublish - Unpublish a note
+
+Usage: ec note unpublish <slug> [options]
+
+Arguments:
+  slug              The note slug to unpublish
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec note unpublish my-note
+`);
+}
+
+export async function unpublish(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  // Check for help flag
+  if (args.includes("--help") || args.includes("-h")) {
+    showUnpublishHelp();
+    return;
+  }
+
+  // Get slug from args
+  const slug = args.find((arg) => !arg.startsWith("-"));
+
+  if (!slug) {
+    console.error("❌ Missing slug argument.");
+    console.error("Usage: ec note unpublish <slug>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.unpublishPost(slug);
+
+  if (result.error) {
+    if (result.error.includes("404") || result.error.includes("not found")) {
+      console.error(`❌ Note not found: ${slug}`);
+    } else {
+      console.error(`❌ Error: ${result.error}`);
+    }
+    process.exit(1);
+  }
+
+  const post = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(post, null, 2));
+  } else {
+    console.log(`✅ Unpublished: ${post.slug}`);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3,6 +3,8 @@ import { version } from "./commands/version";
 import { configShow } from "./commands/config";
 import { login } from "./commands/login";
 import { postCommand, showPostHelp } from "./commands/post";
+import { linkCommand } from "./commands/link";
+import { noteCommand } from "./commands/note";
 import type { GlobalOptions } from "./types";
 
 export function parseArgs(args: string[]): {
@@ -52,6 +54,8 @@ Commands:
   login           Authenticate and store API key
   config show     Show current configuration
   post            Manage posts (list, show, create, edit, delete, publish)
+  link            Manage links (list, show, create, edit, delete, publish)
+  note            Manage notes (list, show, create, edit, delete, publish)
   version         Show CLI version
   help            Show this help message
 
@@ -67,6 +71,8 @@ Examples:
   ec config show
   ec post list
   ec post create --title "My Post" --slug my-post --content "Hello"
+  ec link create --url "https://..." --slug my-link --content "Commentary"
+  ec note create --slug quick-thought --content "Just a thought"
   ec version
 `);
 }
@@ -163,6 +169,14 @@ async function main(): Promise<void> {
         return;
       }
       await postCommand(command.slice(1), options);
+      break;
+
+    case "link":
+      await linkCommand(command.slice(1), options);
+      break;
+
+    case "note":
+      await noteCommand(command.slice(1), options);
       break;
 
     default:

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -74,6 +74,8 @@ export class ApiClient {
     title?: string;
     content: string;
     excerpt?: string;
+    url?: string;
+    source_id?: number;
     tags?: string[];
     banner_image_id?: number;
   }): Promise<ApiResponse<Post>> {
@@ -86,7 +88,10 @@ export class ApiClient {
       title?: string;
       content?: string;
       excerpt?: string;
+      url?: string;
+      source_id?: number;
       tags?: string[];
+      banner_image_id?: number;
     }
   ): Promise<ApiResponse<Post>> {
     return this.request<Post>("PUT", `/posts/by-slug/${encodeURIComponent(slug)}`, data);

--- a/cli/src/lib/markdown.ts
+++ b/cli/src/lib/markdown.ts
@@ -11,6 +11,8 @@ export interface PostFrontmatter {
   status?: string;
   created?: string;
   type?: string;
+  url?: string;
+  source?: string;
 }
 
 export interface ParsedMarkdown {
@@ -154,6 +156,12 @@ export function generateMarkdown(frontmatter: PostFrontmatter, content: string):
   }
   if (frontmatter.type) {
     lines.push(`type: ${frontmatter.type}`);
+  }
+  if (frontmatter.url) {
+    lines.push(`url: ${frontmatter.url}`);
+  }
+  if (frontmatter.source) {
+    lines.push(`source: ${frontmatter.source}`);
   }
   if (frontmatter.status) {
     lines.push(`status: ${frontmatter.status}`);

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -38,6 +38,8 @@ export interface Post {
   title: string | null;
   content: string;
   excerpt: string | null;
+  url: string | null;
+  source_id: number | null;
   published_at: string | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary
Adds CLI commands for managing links (linkblog) and notes.

## Changes
- `ec link list/show/create/edit/delete/publish/unpublish/pull`
- `ec note list/show/create/edit/delete/publish/unpublish/pull`
- Support `--file` option for both (same as posts)
- Frontmatter support for `url` and `source` fields (links)
- Example files for link.md and note.md
- Updated README with usage examples

## Content Type Comparison
| Type | Required | Optional |
|------|----------|----------|
| Post | title, slug, content | tags, excerpt, banner |
| Link | url, slug, content | title, tags, excerpt, source |
| Note | slug, content | banner |

## Testing
- All 166 server tests pass
- All 75 CLI tests pass
- Manually tested create/list/show/pull/delete for links and notes

## Task
Closes #1386