### PR TITLE
feat: CLI sources and tags management

### DIFF
--- a/cli/src/commands/source/create.ts
+++ b/cli/src/commands/source/create.ts
@@ -1,0 +1,109 @@
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+interface CreateOptions {
+  name?: string;
+  url?: string;
+  feedUrl?: string;
+}
+
+function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolean } {
+  const options: CreateOptions = {};
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--name" && args[i + 1]) {
+      options.name = args[++i];
+    } else if (arg.startsWith("--name=")) {
+      options.name = arg.split("=").slice(1).join("=");
+    } else if (arg === "--url" && args[i + 1]) {
+      options.url = args[++i];
+    } else if (arg.startsWith("--url=")) {
+      options.url = arg.split("=").slice(1).join("=");
+    } else if (arg === "--feed-url" && args[i + 1]) {
+      options.feedUrl = args[++i];
+    } else if (arg.startsWith("--feed-url=")) {
+      options.feedUrl = arg.split("=").slice(1).join("=");
+    }
+
+    i++;
+  }
+
+  return { options, help };
+}
+
+function showCreateHelp(): void {
+  console.log(`ec source create - Create a new source
+
+Usage: ec source create --name <name> --url <url> [options]
+
+Required:
+  --name <name>       Source name
+  --url <url>         Source URL
+
+Options:
+  --feed-url <url>    RSS/Atom feed URL (optional)
+  --json              Output as JSON
+  --help, -h          Show this help message
+
+Examples:
+  ec source create --name "Hacker News" --url "https://news.ycombinator.com"
+  ec source create --name "Hacker News" --url "https://news.ycombinator.com" --feed-url "https://news.ycombinator.com/rss"
+`);
+}
+
+export async function create(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { options, help } = parseCreateArgs(args);
+
+  if (help) {
+    showCreateHelp();
+    return;
+  }
+
+  if (!options.name) {
+    console.error("❌ --name is required.");
+    console.error("Usage: ec source create --name <name> --url <url>");
+    process.exit(1);
+  }
+
+  if (!options.url) {
+    console.error("❌ --url is required.");
+    console.error("Usage: ec source create --name <name> --url <url>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.createSource({
+    name: options.name,
+    url: options.url,
+    feed_url: options.feedUrl,
+  });
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const source = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(source, null, 2));
+  } else {
+    console.log(`✅ Source created with ID: ${source.id}`);
+  }
+}

--- a/cli/src/commands/source/delete.ts
+++ b/cli/src/commands/source/delete.ts
@@ -1,0 +1,121 @@
+import * as readline from "readline";
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+interface DeleteOptions {
+  force?: boolean;
+}
+
+function parseDeleteArgs(args: string[]): {
+  id: number | null;
+  options: DeleteOptions;
+  help: boolean;
+} {
+  let id: number | null = null;
+  const options: DeleteOptions = {};
+  let help = false;
+
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--force" || arg === "-f") {
+      options.force = true;
+    } else if (!arg.startsWith("-") && id === null) {
+      const parsed = parseInt(arg, 10);
+      if (!isNaN(parsed)) {
+        id = parsed;
+      }
+    }
+  }
+
+  return { id, options, help };
+}
+
+function showDeleteHelp(): void {
+  console.log(`ec source delete - Delete a source
+
+Usage: ec source delete <id> [options]
+
+Arguments:
+  <id>              Source ID
+
+Options:
+  --force, -f       Skip confirmation prompt
+  --help, -h        Show this help message
+
+Examples:
+  ec source delete 1
+  ec source delete 1 --force
+`);
+}
+
+async function confirm(prompt: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+    });
+  });
+}
+
+export async function deleteSource(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { id, options, help } = parseDeleteArgs(args);
+
+  if (help) {
+    showDeleteHelp();
+    return;
+  }
+
+  if (id === null) {
+    console.error("❌ Source ID is required.");
+    console.error("Usage: ec source delete <id>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+
+  // First, fetch the source to show its name in the confirmation
+  const sourceResult = await client.getSource(id);
+
+  if (sourceResult.error) {
+    console.error(`❌ Error: ${sourceResult.error}`);
+    process.exit(1);
+  }
+
+  const source = sourceResult.data!;
+
+  // Confirm deletion unless --force is used
+  if (!options.force) {
+    const confirmed = await confirm(
+      `Delete source '${source.name}'? This may affect linked posts. [y/N] `
+    );
+    if (!confirmed) {
+      console.log("Cancelled.");
+      return;
+    }
+  }
+
+  const result = await client.deleteSource(id);
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  console.log(`✅ Source '${source.name}' deleted.`);
+}

--- a/cli/src/commands/source/edit.ts
+++ b/cli/src/commands/source/edit.ts
@@ -1,0 +1,125 @@
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+interface EditOptions {
+  name?: string;
+  url?: string;
+  feedUrl?: string | null;
+}
+
+function parseEditArgs(args: string[]): { id: number | null; options: EditOptions; help: boolean } {
+  let id: number | null = null;
+  const options: EditOptions = {};
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--name" && args[i + 1]) {
+      options.name = args[++i];
+    } else if (arg.startsWith("--name=")) {
+      options.name = arg.split("=").slice(1).join("=");
+    } else if (arg === "--url" && args[i + 1]) {
+      options.url = args[++i];
+    } else if (arg.startsWith("--url=")) {
+      options.url = arg.split("=").slice(1).join("=");
+    } else if (arg === "--feed-url" && args[i + 1]) {
+      options.feedUrl = args[++i];
+    } else if (arg.startsWith("--feed-url=")) {
+      options.feedUrl = arg.split("=").slice(1).join("=");
+    } else if (arg === "--no-feed-url") {
+      options.feedUrl = null;
+    } else if (!arg.startsWith("-") && id === null) {
+      const parsed = parseInt(arg, 10);
+      if (!isNaN(parsed)) {
+        id = parsed;
+      }
+    }
+
+    i++;
+  }
+
+  return { id, options, help };
+}
+
+function showEditHelp(): void {
+  console.log(`ec source edit - Edit an existing source
+
+Usage: ec source edit <id> [options]
+
+Arguments:
+  <id>                Source ID
+
+Options:
+  --name <name>       Update source name
+  --url <url>         Update source URL
+  --feed-url <url>    Update RSS/Atom feed URL
+  --no-feed-url       Remove feed URL
+  --json              Output as JSON
+  --help, -h          Show this help message
+
+Examples:
+  ec source edit 1 --name "HN"
+  ec source edit 1 --url "https://hn.algolia.com"
+  ec source edit 1 --feed-url "https://hnrss.org/frontpage"
+  ec source edit 1 --no-feed-url
+`);
+}
+
+export async function edit(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { id, options, help } = parseEditArgs(args);
+
+  if (help) {
+    showEditHelp();
+    return;
+  }
+
+  if (id === null) {
+    console.error("❌ Source ID is required.");
+    console.error("Usage: ec source edit <id> [options]");
+    process.exit(1);
+  }
+
+  // Check if any update options were provided
+  const hasUpdates =
+    options.name !== undefined || options.url !== undefined || options.feedUrl !== undefined;
+
+  if (!hasUpdates) {
+    console.error("❌ No update options provided.");
+    console.error("Specify at least one of: --name, --url, --feed-url, --no-feed-url");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.updateSource(id, {
+    name: options.name,
+    url: options.url,
+    feed_url: options.feedUrl,
+  });
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const source = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(source, null, 2));
+  } else {
+    console.log(`✅ Source ${source.id} updated.`);
+  }
+}

--- a/cli/src/commands/source/index.ts
+++ b/cli/src/commands/source/index.ts
@@ -1,0 +1,70 @@
+import type { GlobalOptions } from "../../types";
+import { list } from "./list";
+import { show } from "./show";
+import { create } from "./create";
+import { edit } from "./edit";
+import { deleteSource } from "./delete";
+
+export function showSourceHelp(): void {
+  console.log(`ec source - Manage sources
+
+Usage: ec source <command> [options]
+
+Commands:
+  list              List all sources
+  show <id>         Show source details
+  create            Create a new source
+  edit <id>         Edit an existing source
+  delete <id>       Delete a source
+
+Options:
+  --help, -h        Show help for a command
+
+Examples:
+  ec source list
+  ec source show 1
+  ec source create --name "Hacker News" --url "https://news.ycombinator.com"
+  ec source edit 1 --name "HN"
+  ec source delete 1
+`);
+}
+
+export async function sourceCommand(args: string[], options: GlobalOptions): Promise<void> {
+  if (args.length === 0) {
+    showSourceHelp();
+    return;
+  }
+
+  const [subcmd, ...rest] = args;
+
+  if (options.help) {
+    rest.push("--help");
+  }
+
+  switch (subcmd) {
+    case "list":
+      await list(rest, options);
+      break;
+
+    case "show":
+      await show(rest, options);
+      break;
+
+    case "create":
+      await create(rest, options);
+      break;
+
+    case "edit":
+      await edit(rest, options);
+      break;
+
+    case "delete":
+      await deleteSource(rest, options);
+      break;
+
+    default:
+      console.error(`Unknown source command: ${subcmd}`);
+      console.error("Run 'ec source --help' for usage.");
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/source/list.ts
+++ b/cli/src/commands/source/list.ts
@@ -1,0 +1,101 @@
+import type { GlobalOptions, Source } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function parseListArgs(args: string[]): { help: boolean } {
+  let help = false;
+
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    }
+  }
+
+  return { help };
+}
+
+function showListHelp(): void {
+  console.log(`ec source list - List all sources
+
+Usage: ec source list [options]
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec source list
+  ec source list --json
+`);
+}
+
+function formatTable(sources: Source[]): void {
+  if (sources.length === 0) {
+    console.log("No sources found.");
+    return;
+  }
+
+  // Calculate column widths
+  const idWidth = Math.max(2, ...sources.map((s) => String(s.id).length));
+  const nameWidth = Math.min(30, Math.max(4, ...sources.map((s) => s.name.length)));
+  const urlWidth = Math.min(50, Math.max(3, ...sources.map((s) => s.url.length)));
+
+  // Header
+  const header = ["ID".padEnd(idWidth), "NAME".padEnd(nameWidth), "URL".padEnd(urlWidth)].join(
+    "  "
+  );
+
+  console.log(header);
+
+  // Rows
+  for (const source of sources) {
+    const row = [
+      String(source.id).padEnd(idWidth),
+      truncate(source.name, nameWidth).padEnd(nameWidth),
+      truncate(source.url, urlWidth).padEnd(urlWidth),
+    ].join("  ");
+
+    console.log(row);
+  }
+
+  console.log(`\nTotal: ${sources.length} sources`);
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 3) + "...";
+}
+
+export async function list(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { help } = parseListArgs(args);
+
+  if (help) {
+    showListHelp();
+    return;
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.listSources();
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const sources = result.data || [];
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(sources, null, 2));
+  } else {
+    formatTable(sources);
+  }
+}

--- a/cli/src/commands/source/show.ts
+++ b/cli/src/commands/source/show.ts
@@ -1,0 +1,86 @@
+import type { GlobalOptions, Source } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function parseShowArgs(args: string[]): { id: number | null; help: boolean } {
+  let id: number | null = null;
+  let help = false;
+
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (!arg.startsWith("-") && id === null) {
+      const parsed = parseInt(arg, 10);
+      if (!isNaN(parsed)) {
+        id = parsed;
+      }
+    }
+  }
+
+  return { id, help };
+}
+
+function showShowHelp(): void {
+  console.log(`ec source show - Show source details
+
+Usage: ec source show <id> [options]
+
+Arguments:
+  <id>              Source ID
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec source show 1
+  ec source show 1 --json
+`);
+}
+
+function formatSource(source: Source): void {
+  console.log(`ID:        ${source.id}`);
+  console.log(`Name:      ${source.name}`);
+  console.log(`URL:       ${source.url}`);
+  console.log(`Feed URL:  ${source.feed_url || "-"}`);
+}
+
+export async function show(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { id, help } = parseShowArgs(args);
+
+  if (help) {
+    showShowHelp();
+    return;
+  }
+
+  if (id === null) {
+    console.error("❌ Source ID is required.");
+    console.error("Usage: ec source show <id>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.getSource(id);
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const source = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(source, null, 2));
+  } else {
+    formatSource(source);
+  }
+}

--- a/cli/src/commands/tag/index.ts
+++ b/cli/src/commands/tag/index.ts
@@ -1,0 +1,43 @@
+import type { GlobalOptions } from "../../types";
+import { list } from "./list";
+
+export function showTagHelp(): void {
+  console.log(`ec tag - Manage tags
+
+Usage: ec tag <command> [options]
+
+Commands:
+  list              List all tags with post counts
+
+Options:
+  --help, -h        Show help for a command
+
+Examples:
+  ec tag list
+  ec tag list --json
+`);
+}
+
+export async function tagCommand(args: string[], options: GlobalOptions): Promise<void> {
+  if (args.length === 0) {
+    showTagHelp();
+    return;
+  }
+
+  const [subcmd, ...rest] = args;
+
+  if (options.help) {
+    rest.push("--help");
+  }
+
+  switch (subcmd) {
+    case "list":
+      await list(rest, options);
+      break;
+
+    default:
+      console.error(`Unknown tag command: ${subcmd}`);
+      console.error("Run 'ec tag --help' for usage.");
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/tag/list.ts
+++ b/cli/src/commands/tag/list.ts
@@ -1,0 +1,97 @@
+import type { GlobalOptions, TagWithCount } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function parseListArgs(args: string[]): { help: boolean } {
+  let help = false;
+
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    }
+  }
+
+  return { help };
+}
+
+function showListHelp(): void {
+  console.log(`ec tag list - List all tags with post counts
+
+Usage: ec tag list [options]
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec tag list
+  ec tag list --json
+`);
+}
+
+function formatTable(tags: TagWithCount[]): void {
+  if (tags.length === 0) {
+    console.log("No tags found.");
+    return;
+  }
+
+  // Calculate column widths
+  const tagWidth = Math.min(30, Math.max(3, ...tags.map((t) => t.slug.length)));
+  const countWidth = Math.max(5, ...tags.map((t) => String(t.count).length));
+
+  // Header
+  const header = ["TAG".padEnd(tagWidth), "COUNT".padStart(countWidth)].join("  ");
+
+  console.log(header);
+
+  // Rows
+  for (const tag of tags) {
+    const row = [
+      truncate(tag.slug, tagWidth).padEnd(tagWidth),
+      String(tag.count).padStart(countWidth),
+    ].join("  ");
+
+    console.log(row);
+  }
+
+  console.log(`\nTotal: ${tags.length} tags`);
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 3) + "...";
+}
+
+export async function list(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { help } = parseListArgs(args);
+
+  if (help) {
+    showListHelp();
+    return;
+  }
+
+  const config = await loadConfig();
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.listTags();
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const tags = result.data || [];
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(tags, null, 2));
+  } else {
+    formatTable(tags);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -5,6 +5,8 @@ import { login } from "./commands/login";
 import { postCommand, showPostHelp } from "./commands/post";
 import { linkCommand } from "./commands/link";
 import { noteCommand } from "./commands/note";
+import { sourceCommand, showSourceHelp } from "./commands/source";
+import { tagCommand, showTagHelp } from "./commands/tag";
 import type { GlobalOptions } from "./types";
 
 export function parseArgs(args: string[]): {
@@ -56,6 +58,8 @@ Commands:
   post            Manage posts (list, show, create, edit, delete, publish)
   link            Manage links (list, show, create, edit, delete, publish)
   note            Manage notes (list, show, create, edit, delete, publish)
+  source          Manage sources (list, show, create, edit, delete)
+  tag             Manage tags (list)
   version         Show CLI version
   help            Show this help message
 
@@ -73,6 +77,8 @@ Examples:
   ec post create --title "My Post" --slug my-post --content "Hello"
   ec link create --url "https://..." --slug my-link --content "Commentary"
   ec note create --slug quick-thought --content "Just a thought"
+  ec source list
+  ec tag list
   ec version
 `);
 }
@@ -177,6 +183,22 @@ async function main(): Promise<void> {
 
     case "note":
       await noteCommand(command.slice(1), options);
+      break;
+
+    case "source":
+      if (options.help && !subcmd) {
+        showSourceHelp();
+        return;
+      }
+      await sourceCommand(command.slice(1), options);
+      break;
+
+    case "tag":
+      if (options.help && !subcmd) {
+        showTagHelp();
+        return;
+      }
+      await tagCommand(command.slice(1), options);
       break;
 
     default:

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -1,6 +1,14 @@
 import * as fs from "fs";
 import * as path from "path";
-import type { ApiResponse, PingResponse, PostListItem, Post, Media } from "../types";
+import type {
+  ApiResponse,
+  PingResponse,
+  PostListItem,
+  Post,
+  Media,
+  Source,
+  TagWithCount,
+} from "../types";
 
 export class ApiClient {
   constructor(
@@ -148,6 +156,45 @@ export class ApiClient {
     } catch (error) {
       return { error: String(error) };
     }
+  }
+
+  // Source methods
+
+  async listSources(): Promise<ApiResponse<Source[]>> {
+    return this.request<Source[]>("GET", "/sources");
+  }
+
+  async getSource(id: number): Promise<ApiResponse<Source>> {
+    return this.request<Source>("GET", `/sources/${id}`);
+  }
+
+  async createSource(data: {
+    name: string;
+    url: string;
+    feed_url?: string;
+  }): Promise<ApiResponse<Source>> {
+    return this.request<Source>("POST", "/sources", data);
+  }
+
+  async updateSource(
+    id: number,
+    data: {
+      name?: string;
+      url?: string;
+      feed_url?: string | null;
+    }
+  ): Promise<ApiResponse<Source>> {
+    return this.request<Source>("PUT", `/sources/${id}`, data);
+  }
+
+  async deleteSource(id: number): Promise<ApiResponse<{ success: boolean }>> {
+    return this.request<{ success: boolean }>("DELETE", `/sources/${id}`);
+  }
+
+  // Tag methods
+
+  async listTags(): Promise<ApiResponse<TagWithCount[]>> {
+    return this.request<TagWithCount[]>("GET", "/tags");
   }
 }
 

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -55,3 +55,17 @@ export interface Media {
   created_at: string;
   url: string;
 }
+
+export interface Source {
+  id: number;
+  name: string;
+  url: string;
+  feed_url: string | null;
+}
+
+export interface TagWithCount {
+  id: number;
+  name: string;
+  slug: string;
+  count: number;
+}

--- a/integration-tests/cli-source/README.md
+++ b/integration-tests/cli-source/README.md
@@ -1,0 +1,23 @@
+# CLI Source Integration Tests
+
+Manual integration tests for the `ec source` CLI commands.
+
+## Prerequisites
+
+1. Dev environment running: `make dev`
+2. CLI configured with API key (see `cli-auth` skill)
+
+### Verify setup
+
+```bash
+make dev-status
+cd cli && bun run src/index.ts config show
+```
+
+## Tests
+
+- [list.md](list.md) - List sources
+- [show.md](show.md) - Show source details
+- [create.md](create.md) - Create a source
+- [edit.md](edit.md) - Edit source fields
+- [delete.md](delete.md) - Delete with confirmation

--- a/integration-tests/cli-source/create.md
+++ b/integration-tests/cli-source/create.md
@@ -1,0 +1,54 @@
+# Test: Create Source
+
+Test creating sources with various options.
+
+## Create Basic Source
+
+```bash
+cd cli
+bun run src/index.ts source create --name "Test Source" --url "https://example.com"
+```
+
+**Expected:** Success message with source ID.
+
+## Create with Feed URL
+
+```bash
+bun run src/index.ts source create --name "Hacker News" --url "https://news.ycombinator.com" --feed-url "https://news.ycombinator.com/rss"
+```
+
+**Expected:** Success message with source ID.
+
+## Create with JSON Output
+
+```bash
+bun run src/index.ts source create --name "JSON Test" --url "https://json.example.com" --json
+```
+
+**Expected:** JSON object with id, name, url, feed_url fields.
+
+## Error: Missing Name
+
+```bash
+bun run src/index.ts source create --url "https://example.com"
+```
+
+**Expected:** Error message about missing --name.
+
+## Error: Missing URL
+
+```bash
+bun run src/index.ts source create --name "Test"
+```
+
+**Expected:** Error message about missing --url.
+
+## Cleanup
+
+```bash
+# List sources to get IDs
+bun run src/index.ts source list
+
+# Delete test sources (replace IDs as needed)
+bun run src/index.ts source delete <id> --force
+```

--- a/integration-tests/cli-source/delete.md
+++ b/integration-tests/cli-source/delete.md
@@ -1,0 +1,70 @@
+# Test: Delete Source
+
+Test deleting sources with confirmation.
+
+## Setup
+
+```bash
+cd cli
+
+# Create test sources
+bun run src/index.ts source create --name "Delete Test 1" --url "https://delete1.example.com" --json
+bun run src/index.ts source create --name "Delete Test 2" --url "https://delete2.example.com" --json
+```
+
+Note the IDs from the output.
+
+## Delete with Confirmation
+
+```bash
+bun run src/index.ts source delete <id1>
+```
+
+**Expected:** Prompt: "Delete source 'Delete Test 1'? This may affect linked posts. [y/N]"
+
+Type `y` and press Enter.
+
+**Expected:** Success message "Source 'Delete Test 1' deleted."
+
+## Delete with Force Flag
+
+```bash
+bun run src/index.ts source delete <id2> --force
+```
+
+**Expected:** No prompt, immediate success message.
+
+## Cancel Deletion
+
+```bash
+# Create another source
+bun run src/index.ts source create --name "Cancel Test" --url "https://cancel.example.com" --json
+bun run src/index.ts source delete <id>
+```
+
+**Expected:** Prompt appears.
+
+Type `n` and press Enter.
+
+**Expected:** "Cancelled." message.
+
+```bash
+bun run src/index.ts source show <id>
+```
+
+**Expected:** Source still exists.
+
+## Error: Non-existent ID
+
+```bash
+bun run src/index.ts source delete 99999 --force
+```
+
+**Expected:** Error message "Source not found".
+
+## Cleanup
+
+```bash
+# Delete any remaining test sources
+bun run src/index.ts source list --json | jq -r '.[].id' | xargs -I {} bun run src/index.ts source delete {} --force
+```

--- a/integration-tests/cli-source/edit.md
+++ b/integration-tests/cli-source/edit.md
@@ -1,0 +1,94 @@
+# Test: Edit Source
+
+Test editing source fields.
+
+## Setup
+
+```bash
+cd cli
+
+# Create a test source
+bun run src/index.ts source create --name "Edit Test" --url "https://edit.example.com" --json
+```
+
+Note the ID from the output.
+
+## Edit Name
+
+```bash
+bun run src/index.ts source edit <id> --name "Updated Name"
+```
+
+**Expected:** Success message.
+
+```bash
+bun run src/index.ts source show <id>
+```
+
+**Expected:** Name shows "Updated Name".
+
+## Edit URL
+
+```bash
+bun run src/index.ts source edit <id> --url "https://updated.example.com"
+```
+
+**Expected:** Success message.
+
+## Add Feed URL
+
+```bash
+bun run src/index.ts source edit <id> --feed-url "https://updated.example.com/feed"
+```
+
+**Expected:** Success message.
+
+```bash
+bun run src/index.ts source show <id>
+```
+
+**Expected:** Feed URL shows the new value.
+
+## Remove Feed URL
+
+```bash
+bun run src/index.ts source edit <id> --no-feed-url
+```
+
+**Expected:** Success message.
+
+```bash
+bun run src/index.ts source show <id>
+```
+
+**Expected:** Feed URL shows "-".
+
+## Edit with JSON Output
+
+```bash
+bun run src/index.ts source edit <id> --name "JSON Edit" --json
+```
+
+**Expected:** JSON object with updated source.
+
+## Error: No Updates Provided
+
+```bash
+bun run src/index.ts source edit <id>
+```
+
+**Expected:** Error message about no update options provided.
+
+## Error: Non-existent ID
+
+```bash
+bun run src/index.ts source edit 99999 --name "Test"
+```
+
+**Expected:** Error message "Source not found".
+
+## Cleanup
+
+```bash
+bun run src/index.ts source delete <id> --force
+```

--- a/integration-tests/cli-source/list.md
+++ b/integration-tests/cli-source/list.md
@@ -1,0 +1,44 @@
+# Test: List Sources
+
+Test listing sources.
+
+## Setup
+
+```bash
+cd cli
+
+# Create test sources
+bun run src/index.ts source create --name "Source One" --url "https://one.example.com"
+bun run src/index.ts source create --name "Source Two" --url "https://two.example.com" --feed-url "https://two.example.com/feed"
+```
+
+## List All Sources
+
+```bash
+bun run src/index.ts source list
+```
+
+**Expected:** Table with ID, NAME, URL columns showing both sources.
+
+## List as JSON
+
+```bash
+bun run src/index.ts source list --json
+```
+
+**Expected:** JSON array of source objects with id, name, url, feed_url fields.
+
+## Empty List
+
+```bash
+# After cleanup, verify empty list
+bun run src/index.ts source list
+```
+
+**Expected:** "No sources found." message.
+
+## Cleanup
+
+```bash
+bun run src/index.ts source list --json | jq -r '.[].id' | xargs -I {} bun run src/index.ts source delete {} --force
+```

--- a/integration-tests/cli-source/show.md
+++ b/integration-tests/cli-source/show.md
@@ -1,0 +1,57 @@
+# Test: Show Source
+
+Test showing source details.
+
+## Setup
+
+```bash
+cd cli
+
+# Create a test source and capture ID
+bun run src/index.ts source create --name "Show Test" --url "https://show.example.com" --feed-url "https://show.example.com/rss" --json
+```
+
+Note the ID from the output.
+
+## Show Source Details
+
+```bash
+bun run src/index.ts source show <id>
+```
+
+**Expected:** Formatted output with:
+
+- ID: <id>
+- Name: Show Test
+- URL: https://show.example.com
+- Feed URL: https://show.example.com/rss
+
+## Show as JSON
+
+```bash
+bun run src/index.ts source show <id> --json
+```
+
+**Expected:** JSON object with all source fields.
+
+## Error: Non-existent ID
+
+```bash
+bun run src/index.ts source show 99999
+```
+
+**Expected:** Error message "Source not found".
+
+## Error: Missing ID
+
+```bash
+bun run src/index.ts source show
+```
+
+**Expected:** Error message about missing source ID.
+
+## Cleanup
+
+```bash
+bun run src/index.ts source delete <id> --force
+```

--- a/integration-tests/cli-tag/README.md
+++ b/integration-tests/cli-tag/README.md
@@ -1,0 +1,19 @@
+# CLI Tag Integration Tests
+
+Manual integration tests for the `ec tag` CLI commands.
+
+## Prerequisites
+
+1. Dev environment running: `make dev`
+2. CLI configured with API key (see `cli-auth` skill)
+
+### Verify setup
+
+```bash
+make dev-status
+cd cli && bun run src/index.ts config show
+```
+
+## Tests
+
+- [list.md](list.md) - List tags with counts

--- a/integration-tests/cli-tag/list.md
+++ b/integration-tests/cli-tag/list.md
@@ -1,0 +1,53 @@
+# Test: List Tags
+
+Test listing tags with post counts.
+
+## Setup
+
+```bash
+cd cli
+
+# Create posts with tags to have meaningful counts
+bun run src/index.ts post create --title "Tag Test 1" --slug tag-test-1 --content "Content" --tags tech,testing
+bun run src/index.ts post create --title "Tag Test 2" --slug tag-test-2 --content "Content" --tags tech,demo
+bun run src/index.ts post create --title "Tag Test 3" --slug tag-test-3 --content "Content" --tags demo
+```
+
+## List All Tags
+
+```bash
+bun run src/index.ts tag list
+```
+
+**Expected:** Table with TAG and COUNT columns:
+
+- Tags sorted by count descending
+- "tech" should have count 2
+- "demo" should have count 2
+- "testing" should have count 1
+
+## List as JSON
+
+```bash
+bun run src/index.ts tag list --json
+```
+
+**Expected:** JSON array of tag objects with id, name, slug, count fields.
+
+## Empty Tags
+
+If no posts exist with tags:
+
+```bash
+bun run src/index.ts tag list
+```
+
+**Expected:** Either "No tags found." or empty table.
+
+## Cleanup
+
+```bash
+bun run src/index.ts post delete tag-test-1 --force
+bun run src/index.ts post delete tag-test-2 --force
+bun run src/index.ts post delete tag-test-3 --force
+```

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { createTestDb } from "../../db/test-utils";
-import { posts } from "../../db/schema";
+import { posts, sources, tags, postTags } from "../../db/schema";
 import { eq } from "drizzle-orm";
 import type { drizzle } from "drizzle-orm/better-sqlite3";
 import type * as schema from "../../db/schema";
@@ -497,5 +497,255 @@ describe("GET /api/posts - status filter", () => {
     const json = await res.json();
     expect(json.data[0]).toHaveProperty("slug");
     expect(json.data[0].slug).toBe("published-post");
+  });
+});
+
+describe("PUT /api/sources/:id", () => {
+  let api: typeof import("../api").api;
+
+  beforeAll(async () => {
+    const module = await import("../api");
+    api = module.api;
+  });
+
+  beforeEach(() => {
+    testDb.delete(sources).run();
+  });
+
+  it("updates source name", async () => {
+    const source = testDb
+      .insert(sources)
+      .values({ name: "Original", url: "https://example.com" })
+      .returning()
+      .get();
+
+    const res = await api.request(`/sources/${source.id}`, {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Updated" }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.name).toBe("Updated");
+    expect(json.data.url).toBe("https://example.com");
+  });
+
+  it("updates source url", async () => {
+    const source = testDb
+      .insert(sources)
+      .values({ name: "Test", url: "https://old.com" })
+      .returning()
+      .get();
+
+    const res = await api.request(`/sources/${source.id}`, {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://new.com" }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.url).toBe("https://new.com");
+  });
+
+  it("updates feed_url to null", async () => {
+    const source = testDb
+      .insert(sources)
+      .values({ name: "Test", url: "https://example.com", feed_url: "https://example.com/feed" })
+      .returning()
+      .get();
+
+    const res = await api.request(`/sources/${source.id}`, {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ feed_url: null }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.feed_url).toBeNull();
+  });
+
+  it("returns 404 for non-existent source", async () => {
+    const res = await api.request("/sources/99999", {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Test" }),
+    });
+
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("Source not found");
+  });
+
+  it("rejects empty name", async () => {
+    const source = testDb
+      .insert(sources)
+      .values({ name: "Test", url: "https://example.com" })
+      .returning()
+      .get();
+
+    const res = await api.request(`/sources/${source.id}`, {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "" }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Name cannot be empty");
+  });
+
+  it("rejects invalid source ID", async () => {
+    const res = await api.request("/sources/invalid", {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Test" }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Invalid source ID");
+  });
+});
+
+describe("DELETE /api/sources/:id", () => {
+  let api: typeof import("../api").api;
+
+  beforeAll(async () => {
+    const module = await import("../api");
+    api = module.api;
+  });
+
+  beforeEach(() => {
+    testDb.delete(sources).run();
+  });
+
+  it("deletes source", async () => {
+    const source = testDb
+      .insert(sources)
+      .values({ name: "Delete Me", url: "https://example.com" })
+      .returning()
+      .get();
+
+    const res = await api.request(`/sources/${source.id}`, {
+      method: "DELETE",
+      headers: authHeader,
+    });
+
+    expect(res.status).toBe(204);
+
+    // Verify deleted
+    const deleted = testDb.select().from(sources).where(eq(sources.id, source.id)).get();
+    expect(deleted).toBeUndefined();
+  });
+
+  it("returns 404 for non-existent source", async () => {
+    const res = await api.request("/sources/99999", {
+      method: "DELETE",
+      headers: authHeader,
+    });
+
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("Source not found");
+  });
+
+  it("rejects invalid source ID", async () => {
+    const res = await api.request("/sources/invalid", {
+      method: "DELETE",
+      headers: authHeader,
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Invalid source ID");
+  });
+});
+
+describe("GET /api/tags", () => {
+  let api: typeof import("../api").api;
+
+  beforeAll(async () => {
+    const module = await import("../api");
+    api = module.api;
+  });
+
+  beforeEach(() => {
+    testDb.delete(postTags).run();
+    testDb.delete(tags).run();
+    testDb.delete(posts).run();
+  });
+
+  it("returns empty array when no tags", async () => {
+    const res = await api.request("/tags", { headers: authHeader });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data).toEqual([]);
+  });
+
+  it("returns tags with counts", async () => {
+    // Create tags
+    const tag1 = testDb.insert(tags).values({ name: "Tech", slug: "tech" }).returning().get();
+    const tag2 = testDb.insert(tags).values({ name: "Rust", slug: "rust" }).returning().get();
+
+    // Create posts
+    const post1 = testDb
+      .insert(posts)
+      .values({
+        slug: "post-1",
+        type: "article",
+        title: "Post 1",
+        content: "Content",
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .returning()
+      .get();
+
+    const post2 = testDb
+      .insert(posts)
+      .values({
+        slug: "post-2",
+        type: "article",
+        title: "Post 2",
+        content: "Content",
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .returning()
+      .get();
+
+    // Tag posts: tag1 has 2 posts, tag2 has 1 post
+    testDb.insert(postTags).values({ post_id: post1.id, tag_id: tag1.id }).run();
+    testDb.insert(postTags).values({ post_id: post2.id, tag_id: tag1.id }).run();
+    testDb.insert(postTags).values({ post_id: post1.id, tag_id: tag2.id }).run();
+
+    const res = await api.request("/tags", { headers: authHeader });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data).toHaveLength(2);
+
+    // Should be ordered by count descending
+    expect(json.data[0].slug).toBe("tech");
+    expect(json.data[0].count).toBe(2);
+    expect(json.data[1].slug).toBe("rust");
+    expect(json.data[1].count).toBe(1);
+  });
+
+  it("returns tags with zero count", async () => {
+    // Create a tag with no posts
+    testDb.insert(tags).values({ name: "Unused", slug: "unused" }).run();
+
+    const res = await api.request("/tags", { headers: authHeader });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data).toHaveLength(1);
+    expect(json.data[0].slug).toBe("unused");
+    expect(json.data[0].count).toBe(0);
   });
 });

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -14,7 +14,14 @@ import {
   PostStatus,
 } from "@/services/posts";
 import { createMedia, deleteMedia, getMedia, isAllowedMimeType } from "@/services/media";
-import { listSources, getSource, createSource } from "@/services/sources";
+import {
+  listSources,
+  getSource,
+  createSource,
+  updateSource,
+  deleteSource,
+} from "@/services/sources";
+import { listTags } from "@/services/tags";
 import { federatePost } from "@/federation/publish";
 
 export const api = new Hono();
@@ -491,6 +498,73 @@ api.post("/sources", async (c) => {
   } catch (error) {
     return c.json({ error: String(error) }, 400);
   }
+});
+
+/**
+ * PUT /api/sources/:id - Update source
+ */
+api.put("/sources/:id", async (c) => {
+  const id = parseInt(c.req.param("id"), 10);
+
+  if (isNaN(id)) {
+    return c.json({ error: "Invalid source ID" }, 400);
+  }
+
+  const body = await c.req.json();
+  const { name, url, feed_url } = body;
+
+  // Validate name if provided
+  if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
+    return c.json({ error: "Name cannot be empty" }, 400);
+  }
+
+  // Validate url if provided
+  if (url !== undefined && (typeof url !== "string" || url.trim().length === 0)) {
+    return c.json({ error: "URL cannot be empty" }, 400);
+  }
+
+  try {
+    const source = updateSource(id, {
+      name: name?.trim(),
+      url: url?.trim(),
+      feed_url: feed_url !== undefined ? feed_url?.trim() || null : undefined,
+    });
+
+    if (!source) {
+      return c.json({ error: "Source not found" }, 404);
+    }
+
+    return c.json({ data: source });
+  } catch (error) {
+    return c.json({ error: String(error) }, 400);
+  }
+});
+
+/**
+ * DELETE /api/sources/:id - Delete source
+ */
+api.delete("/sources/:id", (c) => {
+  const id = parseInt(c.req.param("id"), 10);
+
+  if (isNaN(id)) {
+    return c.json({ error: "Invalid source ID" }, 400);
+  }
+
+  const deleted = deleteSource(id);
+
+  if (!deleted) {
+    return c.json({ error: "Source not found" }, 404);
+  }
+
+  return c.body(null, 204);
+});
+
+/**
+ * GET /api/tags - List all tags with counts
+ */
+api.get("/tags", (c) => {
+  const tags = listTags();
+  return c.json({ data: tags });
 });
 
 /**

--- a/src/services/sources.ts
+++ b/src/services/sources.ts
@@ -46,3 +46,52 @@ export function createSource(input: CreateSourceInput): Source {
 
   return source;
 }
+
+export interface UpdateSourceInput {
+  name?: string;
+  url?: string;
+  feed_url?: string | null;
+}
+
+/**
+ * Update an existing source
+ */
+export function updateSource(id: number, input: UpdateSourceInput): Source | null {
+  const existing = getSource(id);
+  if (!existing) {
+    return null;
+  }
+
+  const updates: Partial<{ name: string; url: string; feed_url: string | null }> = {};
+
+  if (input.name !== undefined) {
+    updates.name = input.name;
+  }
+  if (input.url !== undefined) {
+    updates.url = input.url;
+  }
+  if (input.feed_url !== undefined) {
+    updates.feed_url = input.feed_url;
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return existing;
+  }
+
+  const source = db.update(sources).set(updates).where(eq(sources.id, id)).returning().get();
+
+  return source ?? null;
+}
+
+/**
+ * Delete a source by ID
+ */
+export function deleteSource(id: number): boolean {
+  const existing = getSource(id);
+  if (!existing) {
+    return false;
+  }
+
+  db.delete(sources).where(eq(sources.id, id)).run();
+  return true;
+}

--- a/src/services/tags.ts
+++ b/src/services/tags.ts
@@ -1,0 +1,29 @@
+import { sql } from "drizzle-orm";
+import { db, tags, postTags } from "@/db";
+
+export interface TagWithCount {
+  id: number;
+  name: string;
+  slug: string;
+  count: number;
+}
+
+/**
+ * List all tags with their post counts
+ */
+export function listTags(): TagWithCount[] {
+  const result = db
+    .select({
+      id: tags.id,
+      name: tags.name,
+      slug: tags.slug,
+      count: sql<number>`count(${postTags.post_id})`.as("count"),
+    })
+    .from(tags)
+    .leftJoin(postTags, sql`${tags.id} = ${postTags.tag_id}`)
+    .groupBy(tags.id)
+    .orderBy(sql`count DESC`)
+    .all();
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Implements source management and tag listing for the CLI, completing Task #1387.

## Changes

### API Layer
- Add `updateSource()` and `deleteSource()` to `src/services/sources.ts`
- Create `src/services/tags.ts` with `listTags()` function
- Add `PUT /api/sources/:id` endpoint
- Add `DELETE /api/sources/:id` endpoint
- Add `GET /api/tags` endpoint
- Comprehensive tests for all new endpoints (12 new tests)

### CLI
- Add `Source` and `TagWithCount` types
- Extend API client with source and tag methods
- Implement `ec source list` - List all sources
- Implement `ec source show <id>` - Show source details
- Implement `ec source create --name --url [--feed-url]` - Create source
- Implement `ec source edit <id> [--name] [--url] [--feed-url]` - Edit source
- Implement `ec source delete <id>` - Delete source (with confirmation)
- Implement `ec tag list` - List tags with post counts

## Testing

- All 178 tests pass
- Manual CLI testing verified:
  - `ec source list` / `--json`
  - `ec source show 1`
  - `ec source create`
  - `ec source edit`
  - `ec source delete --force`
  - `ec tag list` / `--json`

## Task

Closes #1387