### PR TITLE
feat: CLI release infrastructure

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,78 @@
+name: CLI Release
+
+on:
+  push:
+    tags:
+      - "cli-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: linux-x64
+            os: ubuntu-latest
+          - target: darwin-x64
+            os: macos-latest
+          - target: darwin-arm64
+            os: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: cd cli && bun install
+
+      - name: Run tests
+        run: cd cli && bun test
+
+      - name: Build binary
+        run: |
+          cd cli
+          bun build ./src/index.ts \
+            --compile \
+            --target=bun-${{ matrix.target }} \
+            --outfile=ec
+
+      - name: Package binary
+        run: |
+          cd cli
+          tar -czvf ec-${{ matrix.target }}.tar.gz ec
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ec-${{ matrix.target }}
+          path: cli/ec-${{ matrix.target }}.tar.gz
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**/*.tar.gz
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ data/
 
 # S3/MinIO local data
 .minio/
+cli/dist/

--- a/cli/scripts/build.sh
+++ b/cli/scripts/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Build EC CLI binaries for distribution
+set -e
+
+cd "$(dirname "$0")/.."
+
+VERSION=$(jq -r '.version' package.json)
+TARGETS=("linux-x64" "darwin-x64" "darwin-arm64")
+
+echo "Building EC CLI v$VERSION"
+echo ""
+
+mkdir -p dist
+
+for target in "${TARGETS[@]}"; do
+  echo "Building for $target..."
+  bun build ./src/index.ts \
+    --compile \
+    --target=bun-$target \
+    --outfile=dist/ec-$target
+done
+
+echo ""
+echo "Creating archives..."
+
+cd dist
+for target in "${TARGETS[@]}"; do
+  # Extract just the binary name for the archive
+  tar -czvf ec-$target.tar.gz ec-$target
+done
+
+echo ""
+echo "Built EC CLI v$VERSION:"
+ls -lh *.tar.gz

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# EC CLI installer
+# Usage: curl -fsSL https://raw.githubusercontent.com/evcraddock/erikcraddock.me/main/install.sh | bash
+
+set -e
+
+REPO="evcraddock/erikcraddock.me"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+BINARY_NAME="ec"
+
+# Detect OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$OS" in
+    linux)
+        case "$ARCH" in
+            x86_64) TARGET="linux-x64" ;;
+            *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+        esac
+        ;;
+    darwin)
+        case "$ARCH" in
+            x86_64) TARGET="darwin-x64" ;;
+            arm64) TARGET="darwin-arm64" ;;
+            *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+        esac
+        ;;
+    *)
+        echo "Unsupported OS: $OS"
+        exit 1
+        ;;
+esac
+
+# Get latest CLI release version (filter for cli-v* tags)
+echo "Fetching latest CLI release..."
+LATEST=$(curl -fsSL "https://api.github.com/repos/$REPO/releases" | \
+    grep '"tag_name":' | \
+    grep 'cli-v' | \
+    head -1 | \
+    sed -E 's/.*"(cli-v[^"]+)".*/\1/')
+
+if [ -z "$LATEST" ]; then
+    echo "Error: No CLI releases found."
+    echo "Check https://github.com/$REPO/releases for available releases."
+    exit 1
+fi
+
+echo "Installing EC CLI $LATEST for $TARGET..."
+
+# Download and extract
+URL="https://github.com/$REPO/releases/download/$LATEST/ec-$TARGET.tar.gz"
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+echo "Downloading from $URL..."
+if ! curl -fsSL "$URL" -o "$TEMP_DIR/ec.tar.gz"; then
+    echo "Error: Failed to download release."
+    echo "URL: $URL"
+    exit 1
+fi
+
+tar -xzf "$TEMP_DIR/ec.tar.gz" -C "$TEMP_DIR"
+
+# Install
+mkdir -p "$INSTALL_DIR"
+mv "$TEMP_DIR/ec" "$INSTALL_DIR/$BINARY_NAME"
+chmod +x "$INSTALL_DIR/$BINARY_NAME"
+
+echo ""
+echo "✅ Installed $BINARY_NAME to $INSTALL_DIR/$BINARY_NAME"
+
+# Check if in PATH
+if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
+    echo ""
+    echo "⚠️  $INSTALL_DIR is not in your PATH."
+    echo "   Add it with:"
+    echo ""
+    echo "   export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo ""
+    echo "   Or add to your shell profile (~/.bashrc, ~/.zshrc, etc.)"
+fi
+
+echo ""
+echo "Run '$BINARY_NAME version' to verify installation."
+echo "Run '$BINARY_NAME login' to get started."


### PR DESCRIPTION
## Summary

Set up build, release workflow, and install script for the CLI, completing Task #1389.

## Changes

### Build Script (`cli/scripts/build.sh`)
- Compiles standalone binaries using Bun's `--compile` flag
- Targets: linux-x64, darwin-x64, darwin-arm64
- Creates tar.gz archives for distribution
- Version is embedded from package.json at compile time

### GitHub Actions (`.github/workflows/cli-release.yml`)
- Triggers on `cli-v*` tags
- Build matrix runs on appropriate runners (ubuntu/macos)
- Runs tests before building
- Creates GitHub Release with all platform binaries

### Install Script (`install.sh`)
- One-liner installation: `curl -fsSL .../install.sh | bash`
- Auto-detects OS and architecture
- Downloads latest `cli-v*` release
- Installs to `~/.local/bin` (configurable via `INSTALL_DIR`)
- Warns if install directory not in PATH

## Usage

### Local build
```bash
cli/scripts/build.sh
./cli/dist/ec-linux-x64 version
```

### Creating a release
```bash
cd cli && npm version patch
git add cli/package.json
git commit -m "chore(cli): bump version to 0.1.1"
git tag cli-v0.1.1
git push origin main cli-v0.1.1
# GitHub Actions builds and creates release
```

### User installation
```bash
curl -fsSL https://raw.githubusercontent.com/evcraddock/erikcraddock.me/main/install.sh | bash
```

## Testing

- ✅ Build script tested locally - produces working binaries
- ✅ `ec version` shows embedded version (0.1.0)
- ✅ Install script syntax validated
- Workflow will be tested on first `cli-v*` tag push

## Task

Closes #1389