### PR TITLE
feat: switch Fedify from MemoryKvStore to SqliteKvStore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ ADMIN_EMAIL=admin@example.com
 # SQLite
 DATABASE_PATH=./data/erikcraddock.db
 
+# Fedify KV Store (for ActivityPub state persistence)
+FEDIFY_KV_PATH=./data/fedify-kv.db
+
 # S3/Object Storage (Garage in dev)
 # Run `./scripts/setup-garage.sh` after starting docker to get keys
 S3_ENDPOINT=http://localhost:3900

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -2,10 +2,10 @@ import {
   createFederation,
   Person,
   CryptographicKey,
-  MemoryKvStore,
   Follow,
   Undo,
   isActor,
+  type KvStore,
 } from "@fedify/fedify";
 import { getOrCreateKeyPair } from "./keys";
 import { addFollower, removeFollower, getAllFollowers } from "./followers";
@@ -17,6 +17,28 @@ export type FederationContext = void;
 
 // Domain from environment
 const domain = process.env.DOMAIN || "localhost:5000";
+
+// Lazy-initialized KV store (avoids bun:sqlite import at module load time for tests)
+let kvStore: KvStore | null = null;
+
+function getKvStore(): KvStore {
+  if (!kvStore) {
+    // Dynamic import to avoid breaking tests that run in Node
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Database } = require("bun:sqlite");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SqliteKvStore } = require("@fedify/sqlite");
+
+    const kvPath = process.env.FEDIFY_KV_PATH || "./data/fedify-kv.db";
+    const kvDb = new Database(kvPath);
+    kvDb.exec("PRAGMA journal_mode = WAL;");
+    kvStore = new SqliteKvStore(kvDb);
+
+    logger.info("federation", `KV store initialized at ${kvPath}`);
+  }
+  // Non-null assertion: kvStore is assigned in the if block above
+  return kvStore!;
+}
 
 /**
  * Create and configure the Fedify federation instance.
@@ -31,7 +53,7 @@ export function createFedifyFederation() {
   logger.info("federation", `Creating federation for domain: ${domain}`);
 
   const federation = createFederation<FederationContext>({
-    kv: new MemoryKvStore(), // TODO: Switch to SqliteKvStore for production
+    kv: getKvStore(),
   });
 
   // Set up actor dispatcher - handles requests for /users/{identifier}

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -17,6 +17,15 @@ vi.mock("@/db", async () => {
   };
 });
 
+// Mock federation setup to avoid bun:sqlite import in tests
+vi.mock("@/federation/setup", () => ({
+  federation: {
+    createContext: vi.fn(),
+    sendActivity: vi.fn(),
+  },
+  createFedifyFederation: vi.fn(),
+}));
+
 // Mock API key middleware to bypass auth in tests
 vi.mock("@/auth/api-key", async () => {
   const actual = await vi.importActual("@/auth/api-key");


### PR DESCRIPTION
## Summary

Switch Fedify's KV store from in-memory to SQLite for production persistence.

## Problem

The federation setup used `MemoryKvStore` which meant ActivityPub state (pending deliveries, HTTP signature nonces, rate limiting state) was lost on container restarts.

## Solution

Use a **separate SQLite database file** for Fedify's KV store:
- `./data/fedify-kv.db` (configurable via `FEDIFY_KV_PATH`)
- Separate from main app database for isolation
- WAL mode enabled for better concurrent access

## Changes

- `src/federation/setup.ts`: Replace MemoryKvStore with SqliteKvStore using lazy initialization
- `.env.example`: Add `FEDIFY_KV_PATH` environment variable
- `src/routes/__tests__/api.test.tsx`: Add federation mock for Node test compatibility

## Testing

- [x] All existing tests pass
- [x] Dev environment starts successfully
- [x] KV store file created at `./data/fedify-kv.db`
- [x] WAL mode enabled (shm/wal files present)

## Notes

Lazy initialization pattern used to avoid `bun:sqlite` import at module load time, which would break Vitest (runs in Node).

Closes #1407