### PR TITLE
feat(cli): add --config flag to specify alternate config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ data/
 # S3/MinIO local data
 .minio/
 cli/dist/
+
+# CLI dev config (contains API key)
+cli/dev-config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,40 @@ For streaming logs (blocks terminal):
 make dev-logs      # Ctrl+C to stop
 ```
 
+## CLI Development
+
+The `ec` CLI is in the `cli/` directory. When running CLI commands against the local dev server, use the dev config file.
+
+### Setup
+
+```bash
+# Copy the example config
+cp cli/dev-config.yaml.example cli/dev-config.yaml
+
+# Login to get an API key
+bun cli/src/index.ts login --config cli/dev-config.yaml --api-url http://localhost:5000/api
+```
+
+### Running CLI Commands
+
+Always use `--config cli/dev-config.yaml` when testing against the local dev server:
+
+```bash
+bun cli/src/index.ts --config cli/dev-config.yaml post list
+bun cli/src/index.ts --config cli/dev-config.yaml post create --title "Test" --slug test
+```
+
+Or set the environment variable once per session:
+
+```bash
+export EC_CONFIG=cli/dev-config.yaml
+bun cli/src/index.ts post list
+```
+
+### Integration Tests
+
+CLI integration tests are in `integration-tests/cli-*/`. These tests assume `EC_CONFIG=cli/dev-config.yaml` is set or `--config cli/dev-config.yaml` is used.
+
 ## Task Lifecycle
 
 - **Starting**: ALWAYS run `task-start-preflight` skill first

--- a/cli/dev-config.yaml.example
+++ b/cli/dev-config.yaml.example
@@ -1,0 +1,9 @@
+# CLI configuration for local development
+# Copy to dev-config.yaml and fill in your API key:
+#   cp dev-config.yaml.example dev-config.yaml
+#
+# Get an API key by logging in:
+#   bun src/index.ts login --api-url http://localhost:5000/api
+
+api_url: http://localhost:5000/api
+api_key: <your-dev-api-key>

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -1,7 +1,44 @@
 import { describe, it, expect, afterEach } from "bun:test";
-import { loadConfig, maskApiKey, getApiUrl, getApiKey } from "../lib/config";
+import { loadConfig, maskApiKey, getApiUrl, getApiKey, getConfigPath } from "../lib/config";
+import { homedir } from "os";
+import { join } from "path";
 
 describe("config utilities", () => {
+  describe("getConfigPath", () => {
+    const originalEnv = process.env.EC_CONFIG;
+
+    afterEach(() => {
+      if (originalEnv) {
+        process.env.EC_CONFIG = originalEnv;
+      } else {
+        delete process.env.EC_CONFIG;
+      }
+    });
+
+    it("returns override if provided", () => {
+      const result = getConfigPath("/custom/path/config.yaml");
+      expect(result).toBe("/custom/path/config.yaml");
+    });
+
+    it("returns env var if set", () => {
+      process.env.EC_CONFIG = "/from/env/config.yaml";
+      const result = getConfigPath();
+      expect(result).toBe("/from/env/config.yaml");
+    });
+
+    it("prefers override over env var", () => {
+      process.env.EC_CONFIG = "/from/env/config.yaml";
+      const result = getConfigPath("/override/config.yaml");
+      expect(result).toBe("/override/config.yaml");
+    });
+
+    it("returns default path when no override or env var", () => {
+      delete process.env.EC_CONFIG;
+      const result = getConfigPath();
+      expect(result).toBe(join(homedir(), ".config", "ec", "config.yaml"));
+    });
+  });
+
   describe("maskApiKey", () => {
     it("masks key showing first 4 and last 4 characters", () => {
       expect(maskApiKey("ek_1234567890abcdef")).toBe("ek_1...cdef");

--- a/cli/src/__tests__/parseArgs.test.ts
+++ b/cli/src/__tests__/parseArgs.test.ts
@@ -36,6 +36,17 @@ describe("parseArgs", () => {
     expect(result.command).toEqual(["post", "list"]);
   });
 
+  it("parses --config with space separator", () => {
+    const result = parseArgs(["--config", "./dev-config.yaml", "post", "list"]);
+    expect(result.options.configPath).toBe("./dev-config.yaml");
+    expect(result.command).toEqual(["post", "list"]);
+  });
+
+  it("parses --config with equals separator", () => {
+    const result = parseArgs(["--config=/path/to/config.yaml", "login"]);
+    expect(result.options.configPath).toBe("/path/to/config.yaml");
+  });
+
   it("parses --api-url with space separator", () => {
     const result = parseArgs(["--api-url", "https://example.com/api", "login"]);
     expect(result.options.apiUrl).toBe("https://example.com/api");

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,9 +1,10 @@
 import { loadConfig, getConfigPath, maskApiKey } from "../lib/config";
 import { info } from "../lib/output";
+import type { GlobalOptions } from "../types";
 
-export async function configShow(): Promise<void> {
-  const config = await loadConfig();
-  const configPath = getConfigPath();
+export async function configShow(globalOptions: GlobalOptions = {}): Promise<void> {
+  const config = await loadConfig(globalOptions.configPath);
+  const configPath = getConfigPath(globalOptions.configPath);
 
   info(`Config file: ${configPath}`);
   info("");

--- a/cli/src/commands/image/delete.ts
+++ b/cli/src/commands/image/delete.ts
@@ -78,7 +78,7 @@ export async function deleteImage(args: string[], globalOptions: GlobalOptions):
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/image/upload.ts
+++ b/cli/src/commands/image/upload.ts
@@ -135,7 +135,7 @@ export async function upload(args: string[], globalOptions: GlobalOptions): Prom
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/link/create.ts
+++ b/cli/src/commands/link/create.ts
@@ -109,7 +109,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     return;
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/link/delete.ts
+++ b/cli/src/commands/link/delete.ts
@@ -53,7 +53,7 @@ export async function del(args: string[], globalOptions: GlobalOptions): Promise
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/link/edit.ts
+++ b/cli/src/commands/link/edit.ts
@@ -116,7 +116,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/link/list.ts
+++ b/cli/src/commands/link/list.ts
@@ -118,7 +118,7 @@ export async function list(args: string[], globalOptions: GlobalOptions): Promis
     return;
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/link/publish.ts
+++ b/cli/src/commands/link/publish.ts
@@ -35,7 +35,7 @@ export async function publish(args: string[], globalOptions: GlobalOptions): Pro
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/link/pull.ts
+++ b/cli/src/commands/link/pull.ts
@@ -70,7 +70,7 @@ export async function pull(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/link/show.ts
+++ b/cli/src/commands/link/show.ts
@@ -67,7 +67,7 @@ export async function show(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/link/unpublish.ts
+++ b/cli/src/commands/link/unpublish.ts
@@ -35,7 +35,7 @@ export async function unpublish(args: string[], globalOptions: GlobalOptions): P
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,4 +1,4 @@
-import { loadConfig, saveConfig } from "../lib/config";
+import { loadConfig, saveConfig, getConfigPath } from "../lib/config";
 import { verifyApiKey } from "../lib/api";
 import { success, error, info } from "../lib/output";
 import type { GlobalOptions } from "../types";
@@ -51,7 +51,7 @@ export async function login(options: GlobalOptions): Promise<void> {
   let apiUrl = options.apiUrl;
 
   if (!apiUrl) {
-    const config = await loadConfig();
+    const config = await loadConfig(options.configPath);
     apiUrl = config.api_url || process.env.EC_API_URL;
   }
 
@@ -99,12 +99,15 @@ export async function login(options: GlobalOptions): Promise<void> {
   }
 
   // Save to config
-  await saveConfig({
-    api_url: apiUrl,
-    api_key: apiKey,
-  });
+  await saveConfig(
+    {
+      api_url: apiUrl,
+      api_key: apiKey,
+    },
+    options.configPath
+  );
 
   info("");
   success(`Logged in as ${result.email}`);
-  info("  API key stored in ~/.config/ec/config.yaml");
+  info(`  API key stored in ${getConfigPath(options.configPath)}`);
 }

--- a/cli/src/commands/note/create.ts
+++ b/cli/src/commands/note/create.ts
@@ -73,7 +73,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     return;
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/note/delete.ts
+++ b/cli/src/commands/note/delete.ts
@@ -58,7 +58,7 @@ export async function del(args: string[], globalOptions: GlobalOptions): Promise
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/note/edit.ts
+++ b/cli/src/commands/note/edit.ts
@@ -80,7 +80,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/note/list.ts
+++ b/cli/src/commands/note/list.ts
@@ -111,7 +111,7 @@ export async function list(args: string[], globalOptions: GlobalOptions): Promis
     return;
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/note/publish.ts
+++ b/cli/src/commands/note/publish.ts
@@ -35,7 +35,7 @@ export async function publish(args: string[], globalOptions: GlobalOptions): Pro
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/note/pull.ts
+++ b/cli/src/commands/note/pull.ts
@@ -70,7 +70,7 @@ export async function pull(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/note/show.ts
+++ b/cli/src/commands/note/show.ts
@@ -57,7 +57,7 @@ export async function show(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/note/unpublish.ts
+++ b/cli/src/commands/note/unpublish.ts
@@ -35,7 +35,7 @@ export async function unpublish(args: string[], globalOptions: GlobalOptions): P
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/post/create.ts
+++ b/cli/src/commands/post/create.ts
@@ -106,7 +106,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     return;
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/post/delete.ts
+++ b/cli/src/commands/post/delete.ts
@@ -66,7 +66,7 @@ export async function deletePost(args: string[], globalOptions: GlobalOptions): 
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/post/edit.ts
+++ b/cli/src/commands/post/edit.ts
@@ -104,7 +104,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/post/list.ts
+++ b/cli/src/commands/post/list.ts
@@ -125,7 +125,7 @@ export async function list(args: string[], globalOptions: GlobalOptions): Promis
     return;
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/post/publish.ts
+++ b/cli/src/commands/post/publish.ts
@@ -46,7 +46,7 @@ export async function publish(args: string[], globalOptions: GlobalOptions): Pro
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/post/pull.ts
+++ b/cli/src/commands/post/pull.ts
@@ -70,7 +70,7 @@ export async function pull(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/post/show.ts
+++ b/cli/src/commands/post/show.ts
@@ -65,7 +65,7 @@ export async function show(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/post/unpublish.ts
+++ b/cli/src/commands/post/unpublish.ts
@@ -46,7 +46,7 @@ export async function unpublish(args: string[], globalOptions: GlobalOptions): P
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/source/create.ts
+++ b/cli/src/commands/source/create.ts
@@ -78,7 +78,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/source/delete.ts
+++ b/cli/src/commands/source/delete.ts
@@ -78,7 +78,7 @@ export async function deleteSource(args: string[], globalOptions: GlobalOptions)
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/source/edit.ts
+++ b/cli/src/commands/source/edit.ts
@@ -94,7 +94,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/source/list.ts
+++ b/cli/src/commands/source/list.ts
@@ -74,7 +74,7 @@ export async function list(args: string[], globalOptions: GlobalOptions): Promis
     return;
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/source/show.ts
+++ b/cli/src/commands/source/show.ts
@@ -59,7 +59,7 @@ export async function show(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/commands/tag/list.ts
+++ b/cli/src/commands/tag/list.ts
@@ -70,7 +70,7 @@ export async function list(args: string[], globalOptions: GlobalOptions): Promis
     return;
   }
 
-  const config = await loadConfig();
+  const config = await loadConfig(globalOptions.configPath);
   const apiUrl = globalOptions.apiUrl || config.api_url;
   const apiKey = globalOptions.apiKey || config.api_key;
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -25,6 +25,10 @@ export function parseArgs(args: string[]): {
       options.verbose = true;
     } else if (arg === "--json") {
       options.json = true;
+    } else if (arg === "--config" && args[i + 1]) {
+      options.configPath = args[++i];
+    } else if (arg.startsWith("--config=")) {
+      options.configPath = arg.split("=")[1];
     } else if (arg === "--api-url" && args[i + 1]) {
       options.apiUrl = args[++i];
     } else if (arg === "--api-key" && args[i + 1]) {
@@ -68,6 +72,7 @@ Commands:
 Global Options:
   --verbose, -v   Enable verbose output
   --json          Output as JSON (where applicable)
+  --config PATH   Use alternate config file (default: ~/.config/ec/config.yaml)
   --api-url URL   Override API URL
   --api-key KEY   Override API key
   --help, -h      Show help for a command
@@ -164,7 +169,7 @@ async function main(): Promise<void> {
         return;
       }
       if (subcmd === "show" || !subcmd) {
-        await configShow();
+        await configShow(options);
       } else {
         console.error(`Unknown config command: ${subcmd}`);
         console.error("Run 'ec config --help' for usage.");

--- a/cli/src/lib/config.ts
+++ b/cli/src/lib/config.ts
@@ -1,52 +1,65 @@
 import { homedir } from "os";
-import { join } from "path";
+import { join, dirname } from "path";
 import { mkdir } from "node:fs/promises";
 import { parse, stringify } from "yaml";
 import type { Config } from "../types";
 
-const CONFIG_DIR = join(homedir(), ".config", "ec");
-const CONFIG_FILE = join(CONFIG_DIR, "config.yaml");
+const DEFAULT_CONFIG_DIR = join(homedir(), ".config", "ec");
+const DEFAULT_CONFIG_FILE = join(DEFAULT_CONFIG_DIR, "config.yaml");
 
-export function getConfigPath(): string {
-  return CONFIG_FILE;
+/**
+ * Get the config file path, checking (in order):
+ * 1. Explicit override parameter
+ * 2. EC_CONFIG environment variable
+ * 3. Default: ~/.config/ec/config.yaml
+ */
+export function getConfigPath(override?: string): string {
+  if (override) return override;
+  if (process.env.EC_CONFIG) return process.env.EC_CONFIG;
+  return DEFAULT_CONFIG_FILE;
 }
 
-export function getConfigDir(): string {
-  return CONFIG_DIR;
+export function getConfigDir(configPath?: string): string {
+  const path = getConfigPath(configPath);
+  return dirname(path);
 }
 
-export async function loadConfig(): Promise<Config> {
+export async function loadConfig(configPath?: string): Promise<Config> {
   try {
-    const content = await Bun.file(CONFIG_FILE).text();
+    const path = getConfigPath(configPath);
+    const content = await Bun.file(path).text();
     return parse(content) || {};
   } catch {
     return {};
   }
 }
 
-export async function saveConfig(config: Config): Promise<void> {
+export async function saveConfig(config: Config, configPath?: string): Promise<void> {
+  const path = getConfigPath(configPath);
+  const dir = dirname(path);
+
   // Ensure config directory exists
-  await mkdir(CONFIG_DIR, { recursive: true });
+  await mkdir(dir, { recursive: true });
 
   const content = stringify(config);
-  await Bun.write(CONFIG_FILE, content);
+  await Bun.write(path, content);
 }
 
-export async function getApiUrl(override?: string): Promise<string | null> {
+export async function getApiUrl(override?: string, configPath?: string): Promise<string | null> {
   if (override) return override;
 
   if (process.env.EC_API_URL) return process.env.EC_API_URL;
 
-  const config = await loadConfig();
+  const config = await loadConfig(configPath);
   return config.api_url || null;
 }
 
-export async function getApiKey(override?: string): Promise<string | null> {
+export async function getApiKey(override?: string, configPath?: string): Promise<string | null> {
   if (override) return override;
 
   if (process.env.EC_API_KEY) return process.env.EC_API_KEY;
 
-  const config = await loadConfig();
+  const config = await loadConfig(configPath);
   return config.api_key || null;
 }
 

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -1,5 +1,6 @@
 export interface GlobalOptions {
   verbose?: boolean;
+  configPath?: string;
   apiUrl?: string;
   apiKey?: string;
   json?: boolean;

--- a/integration-tests/cli-image/README.md
+++ b/integration-tests/cli-image/README.md
@@ -5,14 +5,19 @@ Manual integration tests for the `ec image` CLI commands.
 ## Prerequisites
 
 1. Dev environment running: `make dev`
-2. CLI configured with API key (see `cli-auth` skill)
+2. CLI dev config set up:
+   ```bash
+   cp cli/dev-config.yaml.example cli/dev-config.yaml
+   # Then login to get API key:
+   cd cli && bun src/index.ts --config dev-config.yaml login --api-url http://localhost:5000/api
+   ```
 3. A test image file available (e.g., `test.jpg`)
 
 ### Verify setup
 
 ```bash
 make dev-status
-cd cli && bun run src/index.ts config show
+cd cli && bun src/index.ts --config dev-config.yaml config show
 ```
 
 ### Create test image (if needed)

--- a/integration-tests/cli-image/delete.md
+++ b/integration-tests/cli-image/delete.md
@@ -11,8 +11,8 @@ cd cli
 convert -size 100x100 xc:green /tmp/test-delete.jpg
 
 # Upload test images
-bun run src/index.ts image upload /tmp/test-delete.jpg --json
-bun run src/index.ts image upload /tmp/test-delete.jpg --key "delete-test-2.jpg" --json
+bun src/index.ts --config dev-config.yaml image upload /tmp/test-delete.jpg --json
+bun src/index.ts --config dev-config.yaml image upload /tmp/test-delete.jpg --key "delete-test-2.jpg" --json
 ```
 
 Note the IDs from the output.
@@ -20,7 +20,7 @@ Note the IDs from the output.
 ## Delete with Confirmation
 
 ```bash
-bun run src/index.ts image delete <id1>
+bun src/index.ts --config dev-config.yaml image delete <id1>
 ```
 
 **Expected:** Prompt: "Delete image <id1> (test-delete.jpg)? [y/N]"
@@ -32,7 +32,7 @@ Type `y` and press Enter.
 ## Delete with --yes Flag
 
 ```bash
-bun run src/index.ts image delete <id2> --yes
+bun src/index.ts --config dev-config.yaml image delete <id2> --yes
 ```
 
 **Expected:** No prompt, immediate success message.
@@ -41,9 +41,9 @@ bun run src/index.ts image delete <id2> --yes
 
 ```bash
 # Upload another image
-bun run src/index.ts image upload /tmp/test-delete.jpg --key "delete-test-cancel.jpg" --json
+bun src/index.ts --config dev-config.yaml image upload /tmp/test-delete.jpg --key "delete-test-cancel.jpg" --json
 
-bun run src/index.ts image delete <id>
+bun src/index.ts --config dev-config.yaml image delete <id>
 ```
 
 **Expected:** Prompt appears.
@@ -62,7 +62,7 @@ curl -I <url>
 ## Error: Non-existent ID
 
 ```bash
-bun run src/index.ts image delete 99999 --yes 2>&1; echo "Exit: $?"
+bun src/index.ts --config dev-config.yaml image delete 99999 --yes 2>&1; echo "Exit: $?"
 ```
 
 **Expected:** Error message "Media not found" and exit code 1.
@@ -70,7 +70,7 @@ bun run src/index.ts image delete 99999 --yes 2>&1; echo "Exit: $?"
 ## Error: Missing ID
 
 ```bash
-bun run src/index.ts image delete 2>&1; echo "Exit: $?"
+bun src/index.ts --config dev-config.yaml image delete 2>&1; echo "Exit: $?"
 ```
 
 **Expected:** Error message "Image ID is required" and exit code 1.
@@ -79,5 +79,5 @@ bun run src/index.ts image delete 2>&1; echo "Exit: $?"
 
 ```bash
 # Delete any remaining test images
-bun run src/index.ts image delete <remaining-id> --yes
+bun src/index.ts --config dev-config.yaml image delete <remaining-id> --yes
 ```

--- a/integration-tests/cli-image/upload.md
+++ b/integration-tests/cli-image/upload.md
@@ -14,7 +14,7 @@ convert -size 100x100 xc:blue /tmp/test-upload.jpg
 ## Basic Upload
 
 ```bash
-bun run src/index.ts image upload /tmp/test-upload.jpg
+bun src/index.ts --config dev-config.yaml image upload /tmp/test-upload.jpg
 ```
 
 **Expected:**
@@ -29,7 +29,7 @@ bun run src/index.ts image upload /tmp/test-upload.jpg
 ## Upload with Alt Text
 
 ```bash
-bun run src/index.ts image upload /tmp/test-upload.jpg --alt "A blue square"
+bun src/index.ts --config dev-config.yaml image upload /tmp/test-upload.jpg --alt "A blue square"
 ```
 
 **Expected:** Success message with ID and URL.
@@ -37,7 +37,7 @@ bun run src/index.ts image upload /tmp/test-upload.jpg --alt "A blue square"
 ## Upload with Custom Key
 
 ```bash
-bun run src/index.ts image upload /tmp/test-upload.jpg --key "test/custom-key.jpg"
+bun src/index.ts --config dev-config.yaml image upload /tmp/test-upload.jpg --key "test/custom-key.jpg"
 ```
 
 **Expected:** Key shows `test/custom-key.jpg`.
@@ -46,10 +46,10 @@ bun run src/index.ts image upload /tmp/test-upload.jpg --key "test/custom-key.jp
 
 ```bash
 # First create a test post
-bun run src/index.ts post create --title "Image Test" --slug image-test --content "Test"
+bun src/index.ts --config dev-config.yaml post create --title "Image Test" --slug image-test --content "Test"
 
 # Upload with --post
-bun run src/index.ts image upload /tmp/test-upload.jpg --post image-test
+bun src/index.ts --config dev-config.yaml image upload /tmp/test-upload.jpg --post image-test
 ```
 
 **Expected:** Key shows `posts/image-test/test-upload.jpg`.
@@ -57,7 +57,7 @@ bun run src/index.ts image upload /tmp/test-upload.jpg --post image-test
 ## Upload with Post and Custom Key
 
 ```bash
-bun run src/index.ts image upload /tmp/test-upload.jpg --post image-test --key banner.jpg
+bun src/index.ts --config dev-config.yaml image upload /tmp/test-upload.jpg --post image-test --key banner.jpg
 ```
 
 **Expected:** Key shows `posts/image-test/banner.jpg`.
@@ -65,7 +65,7 @@ bun run src/index.ts image upload /tmp/test-upload.jpg --post image-test --key b
 ## Upload with JSON Output
 
 ```bash
-bun run src/index.ts image upload /tmp/test-upload.jpg --json
+bun src/index.ts --config dev-config.yaml image upload /tmp/test-upload.jpg --json
 ```
 
 **Expected:** JSON object with id, url, key, filename, mime_type fields.
@@ -73,7 +73,7 @@ bun run src/index.ts image upload /tmp/test-upload.jpg --json
 ## Error: File Not Found
 
 ```bash
-bun run src/index.ts image upload /nonexistent/file.jpg 2>&1; echo "Exit: $?"
+bun src/index.ts --config dev-config.yaml image upload /nonexistent/file.jpg 2>&1; echo "Exit: $?"
 ```
 
 **Expected:** Error message "File not found" and exit code 1.
@@ -82,7 +82,7 @@ bun run src/index.ts image upload /nonexistent/file.jpg 2>&1; echo "Exit: $?"
 
 ```bash
 echo "test" > /tmp/test.txt
-bun run src/index.ts image upload /tmp/test.txt 2>&1; echo "Exit: $?"
+bun src/index.ts --config dev-config.yaml image upload /tmp/test.txt 2>&1; echo "Exit: $?"
 ```
 
 **Expected:** Error message about unsupported format and exit code 1.
@@ -90,7 +90,7 @@ bun run src/index.ts image upload /tmp/test.txt 2>&1; echo "Exit: $?"
 ## Error: Missing File Argument
 
 ```bash
-bun run src/index.ts image upload 2>&1; echo "Exit: $?"
+bun src/index.ts --config dev-config.yaml image upload 2>&1; echo "Exit: $?"
 ```
 
 **Expected:** Error message "File path is required" and exit code 1.
@@ -109,8 +109,8 @@ curl -I <url>
 
 ```bash
 # Delete test post
-bun run src/index.ts post delete image-test --force
+bun src/index.ts --config dev-config.yaml post delete image-test --force
 
 # Note image IDs from uploads and delete them
-bun run src/index.ts image delete <id> --yes
+bun src/index.ts --config dev-config.yaml image delete <id> --yes
 ```

--- a/integration-tests/cli-link/README.md
+++ b/integration-tests/cli-link/README.md
@@ -5,13 +5,18 @@ Manual integration tests for the `ec link` CLI commands.
 ## Prerequisites
 
 1. Dev environment running: `make dev`
-2. CLI configured with API key (see `cli-auth` skill)
+2. CLI dev config set up:
+   ```bash
+   cp cli/dev-config.yaml.example cli/dev-config.yaml
+   # Then login to get API key:
+   cd cli && bun src/index.ts --config dev-config.yaml login --api-url http://localhost:5000/api
+   ```
 
 ### Verify setup
 
 ```bash
 make dev-status
-cd cli && bun run src/index.ts config show
+cd cli && bun src/index.ts --config dev-config.yaml config show
 ```
 
 ## Tests

--- a/integration-tests/cli-link/create-basic.md
+++ b/integration-tests/cli-link/create-basic.md
@@ -6,7 +6,7 @@ Create a simple link with required fields only.
 
 ```bash
 cd cli
-bun run src/index.ts link create \
+bun src/index.ts --config dev-config.yaml link create \
   --url "https://example.com/interesting-article" \
   --slug test-link \
   --content "This is an interesting article worth reading."
@@ -23,7 +23,7 @@ bun run src/index.ts link create \
 ## Verify
 
 ```bash
-bun run src/index.ts link show test-link
+bun src/index.ts --config dev-config.yaml link show test-link
 ```
 
 **Expected:**
@@ -42,5 +42,5 @@ This is an interesting article worth reading.
 ## Cleanup
 
 ```bash
-bun run src/index.ts link delete test-link --force
+bun src/index.ts --config dev-config.yaml link delete test-link --force
 ```

--- a/integration-tests/cli-link/create-errors.md
+++ b/integration-tests/cli-link/create-errors.md
@@ -6,7 +6,7 @@ Test error handling for invalid inputs.
 
 ```bash
 cd cli
-bun run src/index.ts link create --slug test --content "Test"
+bun src/index.ts --config dev-config.yaml link create --slug test --content "Test"
 ```
 
 **Expected:**
@@ -19,7 +19,7 @@ bun run src/index.ts link create --slug test --content "Test"
 ## Missing Slug
 
 ```bash
-bun run src/index.ts link create --url "https://example.com" --content "Test"
+bun src/index.ts --config dev-config.yaml link create --url "https://example.com" --content "Test"
 ```
 
 **Expected:**
@@ -32,7 +32,7 @@ bun run src/index.ts link create --url "https://example.com" --content "Test"
 ## Missing Content
 
 ```bash
-bun run src/index.ts link create --url "https://example.com" --slug test
+bun src/index.ts --config dev-config.yaml link create --url "https://example.com" --slug test
 ```
 
 **Expected:**
@@ -45,7 +45,7 @@ bun run src/index.ts link create --url "https://example.com" --slug test
 ## Invalid Source ID
 
 ```bash
-bun run src/index.ts link create \
+bun src/index.ts --config dev-config.yaml link create \
   --url "https://example.com" \
   --slug test \
   --content "Test" \
@@ -61,7 +61,7 @@ bun run src/index.ts link create \
 ## File Not Found
 
 ```bash
-bun run src/index.ts link create --file /nonexistent/file.md
+bun src/index.ts --config dev-config.yaml link create --file /nonexistent/file.md
 ```
 
 **Expected:**

--- a/integration-tests/cli-link/create-from-file.md
+++ b/integration-tests/cli-link/create-from-file.md
@@ -30,7 +30,7 @@ EOF
 
 ```bash
 cd cli
-bun run src/index.ts link create --file /tmp/test-link.md
+bun src/index.ts --config dev-config.yaml link create --file /tmp/test-link.md
 ```
 
 ## Expected Output
@@ -47,7 +47,7 @@ bun run src/index.ts link create --file /tmp/test-link.md
 ## Verify
 
 ```bash
-bun run src/index.ts link show hn-discussion
+bun src/index.ts --config dev-config.yaml link show hn-discussion
 ```
 
 **Expected:** Shows URL, title, tags, and content from the file.
@@ -55,7 +55,7 @@ bun run src/index.ts link show hn-discussion
 ## Pull and Verify Roundtrip
 
 ```bash
-bun run src/index.ts link pull hn-discussion -o /tmp/pulled-link.md
+bun src/index.ts --config dev-config.yaml link pull hn-discussion -o /tmp/pulled-link.md
 cat /tmp/pulled-link.md
 ```
 
@@ -64,6 +64,6 @@ cat /tmp/pulled-link.md
 ## Cleanup
 
 ```bash
-bun run src/index.ts link delete hn-discussion --force
+bun src/index.ts --config dev-config.yaml link delete hn-discussion --force
 rm /tmp/test-link.md /tmp/pulled-link.md
 ```

--- a/integration-tests/cli-link/delete.md
+++ b/integration-tests/cli-link/delete.md
@@ -6,7 +6,7 @@ Test deleting links with confirmation.
 
 ```bash
 cd cli
-bun run src/index.ts link create \
+bun src/index.ts --config dev-config.yaml link create \
   --url "https://example.com/to-delete" \
   --slug delete-test-link \
   --content "Link to delete" \
@@ -16,7 +16,7 @@ bun run src/index.ts link create \
 ## Delete with Confirmation (Cancel)
 
 ```bash
-echo "n" | bun run src/index.ts link delete delete-test-link
+echo "n" | bun src/index.ts --config dev-config.yaml link delete delete-test-link
 ```
 
 **Expected:**
@@ -32,7 +32,7 @@ Are you sure? (y/N): Cancelled.
 ## Verify Still Exists
 
 ```bash
-bun run src/index.ts link show delete-test-link
+bun src/index.ts --config dev-config.yaml link show delete-test-link
 ```
 
 **Expected:** Shows the link details.
@@ -40,7 +40,7 @@ bun run src/index.ts link show delete-test-link
 ## Delete with Confirmation (Confirm)
 
 ```bash
-echo "y" | bun run src/index.ts link delete delete-test-link
+echo "y" | bun src/index.ts --config dev-config.yaml link delete delete-test-link
 ```
 
 **Expected:**
@@ -56,7 +56,7 @@ Are you sure? (y/N): ✅ Deleted: delete-test-link
 ## Verify Deleted
 
 ```bash
-bun run src/index.ts link show delete-test-link
+bun src/index.ts --config dev-config.yaml link show delete-test-link
 ```
 
 **Expected:**
@@ -69,13 +69,13 @@ bun run src/index.ts link show delete-test-link
 
 ```bash
 # Create another link
-bun run src/index.ts link create \
+bun src/index.ts --config dev-config.yaml link create \
   --url "https://example.com/force-delete" \
   --slug force-delete-link \
   --content "Force delete"
 
 # Delete without confirmation
-bun run src/index.ts link delete force-delete-link --force
+bun src/index.ts --config dev-config.yaml link delete force-delete-link --force
 ```
 
 **Expected:**

--- a/integration-tests/cli-link/edit.md
+++ b/integration-tests/cli-link/edit.md
@@ -6,7 +6,7 @@ Test editing link fields.
 
 ```bash
 cd cli
-bun run src/index.ts link create \
+bun src/index.ts --config dev-config.yaml link create \
   --url "https://example.com/original" \
   --slug edit-test-link \
   --content "Original content"
@@ -15,7 +15,7 @@ bun run src/index.ts link create \
 ## Edit URL
 
 ```bash
-bun run src/index.ts link edit edit-test-link --url "https://example.com/updated"
+bun src/index.ts --config dev-config.yaml link edit edit-test-link --url "https://example.com/updated"
 ```
 
 **Expected:**
@@ -28,7 +28,7 @@ bun run src/index.ts link edit edit-test-link --url "https://example.com/updated
 ## Verify URL Changed
 
 ```bash
-bun run src/index.ts link show edit-test-link | grep "URL:"
+bun src/index.ts --config dev-config.yaml link show edit-test-link | grep "URL:"
 ```
 
 **Expected:** `URL:       https://example.com/updated`
@@ -36,7 +36,7 @@ bun run src/index.ts link show edit-test-link | grep "URL:"
 ## Edit Content
 
 ```bash
-bun run src/index.ts link edit edit-test-link --content "Updated commentary"
+bun src/index.ts --config dev-config.yaml link edit edit-test-link --content "Updated commentary"
 ```
 
 **Expected:**
@@ -49,7 +49,7 @@ bun run src/index.ts link edit edit-test-link --content "Updated commentary"
 ## Edit Tags
 
 ```bash
-bun run src/index.ts link edit edit-test-link --tags tech,updated
+bun src/index.ts --config dev-config.yaml link edit edit-test-link --tags tech,updated
 ```
 
 **Expected:**
@@ -72,7 +72,7 @@ tags: [file, updated]
 Content updated from file.
 EOF
 
-bun run src/index.ts link edit edit-test-link --file /tmp/updated-link.md
+bun src/index.ts --config dev-config.yaml link edit edit-test-link --file /tmp/updated-link.md
 ```
 
 **Expected:**
@@ -89,6 +89,6 @@ bun run src/index.ts link edit edit-test-link --file /tmp/updated-link.md
 ## Cleanup
 
 ```bash
-bun run src/index.ts link delete edit-test-link --force
+bun src/index.ts --config dev-config.yaml link delete edit-test-link --force
 rm /tmp/updated-link.md
 ```

--- a/integration-tests/cli-link/list.md
+++ b/integration-tests/cli-link/list.md
@@ -8,24 +8,24 @@ Test listing links with various filters.
 cd cli
 
 # Create test links
-bun run src/index.ts link create \
+bun src/index.ts --config dev-config.yaml link create \
   --url "https://example.com/draft" \
   --slug link-draft \
   --content "Draft link"
 
-bun run src/index.ts link create \
+bun src/index.ts --config dev-config.yaml link create \
   --url "https://example.com/published" \
   --slug link-published \
   --content "Published link" \
   --tags tech
 
-bun run src/index.ts link publish link-published
+bun src/index.ts --config dev-config.yaml link publish link-published
 ```
 
 ## List All (Default)
 
 ```bash
-bun run src/index.ts link list
+bun src/index.ts --config dev-config.yaml link list
 ```
 
 **Expected:** Shows both links in table format with slug, title, status, date.
@@ -33,7 +33,7 @@ bun run src/index.ts link list
 ## List Drafts Only
 
 ```bash
-bun run src/index.ts link list --status draft
+bun src/index.ts --config dev-config.yaml link list --status draft
 ```
 
 **Expected:** Shows only `link-draft`.
@@ -41,7 +41,7 @@ bun run src/index.ts link list --status draft
 ## List Published Only
 
 ```bash
-bun run src/index.ts link list --status published
+bun src/index.ts --config dev-config.yaml link list --status published
 ```
 
 **Expected:** Shows only `link-published`.
@@ -49,7 +49,7 @@ bun run src/index.ts link list --status published
 ## List by Tag
 
 ```bash
-bun run src/index.ts link list --tag tech
+bun src/index.ts --config dev-config.yaml link list --tag tech
 ```
 
 **Expected:** Shows only `link-published` (has tech tag).
@@ -57,7 +57,7 @@ bun run src/index.ts link list --tag tech
 ## List with Limit
 
 ```bash
-bun run src/index.ts link list --limit 1
+bun src/index.ts --config dev-config.yaml link list --limit 1
 ```
 
 **Expected:** Shows only 1 link.
@@ -65,7 +65,7 @@ bun run src/index.ts link list --limit 1
 ## List as JSON
 
 ```bash
-bun run src/index.ts link list --json
+bun src/index.ts --config dev-config.yaml link list --json
 ```
 
 **Expected:** JSON array of link objects.
@@ -73,6 +73,6 @@ bun run src/index.ts link list --json
 ## Cleanup
 
 ```bash
-bun run src/index.ts link delete link-draft --force
-bun run src/index.ts link delete link-published --force
+bun src/index.ts --config dev-config.yaml link delete link-draft --force
+bun src/index.ts --config dev-config.yaml link delete link-published --force
 ```

--- a/integration-tests/cli-link/publish.md
+++ b/integration-tests/cli-link/publish.md
@@ -6,7 +6,7 @@ Test publishing and unpublishing links.
 
 ```bash
 cd cli
-bun run src/index.ts link create \
+bun src/index.ts --config dev-config.yaml link create \
   --url "https://example.com/article" \
   --slug publish-test-link \
   --content "Link to publish"
@@ -15,7 +15,7 @@ bun run src/index.ts link create \
 ## Verify Initial State (Draft)
 
 ```bash
-bun run src/index.ts link show publish-test-link | grep "Status:"
+bun src/index.ts --config dev-config.yaml link show publish-test-link | grep "Status:"
 ```
 
 **Expected:** `Status:    draft`
@@ -23,7 +23,7 @@ bun run src/index.ts link show publish-test-link | grep "Status:"
 ## Publish Link
 
 ```bash
-bun run src/index.ts link publish publish-test-link
+bun src/index.ts --config dev-config.yaml link publish publish-test-link
 ```
 
 **Expected:**
@@ -36,7 +36,7 @@ bun run src/index.ts link publish publish-test-link
 ## Verify Published
 
 ```bash
-bun run src/index.ts link show publish-test-link | grep -E "(Status:|Published:)"
+bun src/index.ts --config dev-config.yaml link show publish-test-link | grep -E "(Status:|Published:)"
 ```
 
 **Expected:**
@@ -59,7 +59,7 @@ sleep 1
 ## Unpublish Link
 
 ```bash
-bun run src/index.ts link unpublish publish-test-link
+bun src/index.ts --config dev-config.yaml link unpublish publish-test-link
 ```
 
 **Expected:**
@@ -71,7 +71,7 @@ bun run src/index.ts link unpublish publish-test-link
 ## Verify Unpublished
 
 ```bash
-bun run src/index.ts link show publish-test-link | grep "Status:"
+bun src/index.ts --config dev-config.yaml link show publish-test-link | grep "Status:"
 ```
 
 **Expected:** `Status:    draft`
@@ -79,5 +79,5 @@ bun run src/index.ts link show publish-test-link | grep "Status:"
 ## Cleanup
 
 ```bash
-bun run src/index.ts link delete publish-test-link --force
+bun src/index.ts --config dev-config.yaml link delete publish-test-link --force
 ```

--- a/integration-tests/cli-link/pull.md
+++ b/integration-tests/cli-link/pull.md
@@ -6,7 +6,7 @@ Test downloading links as markdown files.
 
 ```bash
 cd cli
-bun run src/index.ts link create \
+bun src/index.ts --config dev-config.yaml link create \
   --url "https://example.com/pulled-article" \
   --slug pull-test-link \
   --content "Commentary on the article" \
@@ -17,7 +17,7 @@ bun run src/index.ts link create \
 ## Pull to Default Filename
 
 ```bash
-bun run src/index.ts link pull pull-test-link
+bun src/index.ts --config dev-config.yaml link pull pull-test-link
 ```
 
 **Expected:**
@@ -53,7 +53,7 @@ Commentary on the article
 ## Pull to Custom Path
 
 ```bash
-bun run src/index.ts link pull pull-test-link -o /tmp/custom-link.md
+bun src/index.ts --config dev-config.yaml link pull pull-test-link -o /tmp/custom-link.md
 cat /tmp/custom-link.md
 ```
 
@@ -62,7 +62,7 @@ cat /tmp/custom-link.md
 ## Pull as JSON
 
 ```bash
-bun run src/index.ts link pull pull-test-link --json
+bun src/index.ts --config dev-config.yaml link pull pull-test-link --json
 ```
 
 **Expected:** Full JSON object (not saved to file).
@@ -70,6 +70,6 @@ bun run src/index.ts link pull pull-test-link --json
 ## Cleanup
 
 ```bash
-bun run src/index.ts link delete pull-test-link --force
+bun src/index.ts --config dev-config.yaml link delete pull-test-link --force
 rm pull-test-link.md /tmp/custom-link.md
 ```

--- a/integration-tests/cli-link/show.md
+++ b/integration-tests/cli-link/show.md
@@ -6,7 +6,7 @@ Test showing link details.
 
 ```bash
 cd cli
-bun run src/index.ts link create \
+bun src/index.ts --config dev-config.yaml link create \
   --url "https://example.com/article" \
   --slug show-test-link \
   --content "Great article about testing" \
@@ -17,7 +17,7 @@ bun run src/index.ts link create \
 ## Show Link
 
 ```bash
-bun run src/index.ts link show show-test-link
+bun src/index.ts --config dev-config.yaml link show show-test-link
 ```
 
 **Expected:**
@@ -38,7 +38,7 @@ Great article about testing
 ## Show as JSON
 
 ```bash
-bun run src/index.ts link show show-test-link --json
+bun src/index.ts --config dev-config.yaml link show show-test-link --json
 ```
 
 **Expected:** Full JSON object with all fields including `url`, `type: "link"`.
@@ -46,7 +46,7 @@ bun run src/index.ts link show show-test-link --json
 ## Show Non-existent Link
 
 ```bash
-bun run src/index.ts link show nonexistent-link
+bun src/index.ts --config dev-config.yaml link show nonexistent-link
 ```
 
 **Expected:**
@@ -58,5 +58,5 @@ bun run src/index.ts link show nonexistent-link
 ## Cleanup
 
 ```bash
-bun run src/index.ts link delete show-test-link --force
+bun src/index.ts --config dev-config.yaml link delete show-test-link --force
 ```

--- a/integration-tests/cli-note/README.md
+++ b/integration-tests/cli-note/README.md
@@ -5,13 +5,18 @@ Manual integration tests for the `ec note` CLI commands.
 ## Prerequisites
 
 1. Dev environment running: `make dev`
-2. CLI configured with API key (see `cli-auth` skill)
+2. CLI dev config set up:
+   ```bash
+   cp cli/dev-config.yaml.example cli/dev-config.yaml
+   # Then login to get API key:
+   cd cli && bun src/index.ts --config dev-config.yaml login --api-url http://localhost:5000/api
+   ```
 
 ### Verify setup
 
 ```bash
 make dev-status
-cd cli && bun run src/index.ts config show
+cd cli && bun src/index.ts --config dev-config.yaml config show
 ```
 
 ## Tests

--- a/integration-tests/cli-note/create-basic.md
+++ b/integration-tests/cli-note/create-basic.md
@@ -6,7 +6,7 @@ Create a simple note with required fields only.
 
 ```bash
 cd cli
-bun run src/index.ts note create \
+bun src/index.ts --config dev-config.yaml note create \
   --slug test-note \
   --content "Just shipped a new feature! 🚀"
 ```
@@ -21,7 +21,7 @@ bun run src/index.ts note create \
 ## Verify
 
 ```bash
-bun run src/index.ts note show test-note
+bun src/index.ts --config dev-config.yaml note show test-note
 ```
 
 **Expected:**
@@ -39,5 +39,5 @@ Just shipped a new feature! 🚀
 ## Cleanup
 
 ```bash
-bun run src/index.ts note delete test-note --force
+bun src/index.ts --config dev-config.yaml note delete test-note --force
 ```

--- a/integration-tests/cli-note/create-errors.md
+++ b/integration-tests/cli-note/create-errors.md
@@ -6,7 +6,7 @@ Test error handling for invalid inputs.
 
 ```bash
 cd cli
-bun run src/index.ts note create --content "Test content"
+bun src/index.ts --config dev-config.yaml note create --content "Test content"
 ```
 
 **Expected:**
@@ -19,7 +19,7 @@ bun run src/index.ts note create --content "Test content"
 ## Missing Content
 
 ```bash
-bun run src/index.ts note create --slug test
+bun src/index.ts --config dev-config.yaml note create --slug test
 ```
 
 **Expected:**
@@ -32,7 +32,7 @@ bun run src/index.ts note create --slug test
 ## File Not Found
 
 ```bash
-bun run src/index.ts note create --file /nonexistent/file.md
+bun src/index.ts --config dev-config.yaml note create --file /nonexistent/file.md
 ```
 
 **Expected:**
@@ -50,7 +50,7 @@ slug: empty-test
 ---
 EOF
 
-bun run src/index.ts note create --file /tmp/empty-note.md
+bun src/index.ts --config dev-config.yaml note create --file /tmp/empty-note.md
 ```
 
 **Expected:**

--- a/integration-tests/cli-note/create-from-file.md
+++ b/integration-tests/cli-note/create-from-file.md
@@ -26,7 +26,7 @@ EOF
 
 ```bash
 cd cli
-bun run src/index.ts note create --file /tmp/test-note.md
+bun src/index.ts --config dev-config.yaml note create --file /tmp/test-note.md
 ```
 
 ## Expected Output
@@ -40,7 +40,7 @@ bun run src/index.ts note create --file /tmp/test-note.md
 ## Verify
 
 ```bash
-bun run src/index.ts note show file-note
+bun src/index.ts --config dev-config.yaml note show file-note
 ```
 
 **Expected:** Shows the full content from the file.
@@ -48,7 +48,7 @@ bun run src/index.ts note show file-note
 ## Pull and Verify Roundtrip
 
 ```bash
-bun run src/index.ts note pull file-note -o /tmp/pulled-note.md
+bun src/index.ts --config dev-config.yaml note pull file-note -o /tmp/pulled-note.md
 cat /tmp/pulled-note.md
 ```
 
@@ -57,6 +57,6 @@ cat /tmp/pulled-note.md
 ## Cleanup
 
 ```bash
-bun run src/index.ts note delete file-note --force
+bun src/index.ts --config dev-config.yaml note delete file-note --force
 rm /tmp/test-note.md /tmp/pulled-note.md
 ```

--- a/integration-tests/cli-note/delete.md
+++ b/integration-tests/cli-note/delete.md
@@ -6,7 +6,7 @@ Test deleting notes with confirmation.
 
 ```bash
 cd cli
-bun run src/index.ts note create \
+bun src/index.ts --config dev-config.yaml note create \
   --slug delete-test-note \
   --content "Note to delete"
 ```
@@ -14,7 +14,7 @@ bun run src/index.ts note create \
 ## Delete with Confirmation (Cancel)
 
 ```bash
-echo "n" | bun run src/index.ts note delete delete-test-note
+echo "n" | bun src/index.ts --config dev-config.yaml note delete delete-test-note
 ```
 
 **Expected:**
@@ -29,7 +29,7 @@ Are you sure? (y/N): Cancelled.
 ## Verify Still Exists
 
 ```bash
-bun run src/index.ts note show delete-test-note
+bun src/index.ts --config dev-config.yaml note show delete-test-note
 ```
 
 **Expected:** Shows the note details.
@@ -37,7 +37,7 @@ bun run src/index.ts note show delete-test-note
 ## Delete with Confirmation (Confirm)
 
 ```bash
-echo "y" | bun run src/index.ts note delete delete-test-note
+echo "y" | bun src/index.ts --config dev-config.yaml note delete delete-test-note
 ```
 
 **Expected:**
@@ -52,7 +52,7 @@ Are you sure? (y/N): ✅ Deleted: delete-test-note
 ## Verify Deleted
 
 ```bash
-bun run src/index.ts note show delete-test-note
+bun src/index.ts --config dev-config.yaml note show delete-test-note
 ```
 
 **Expected:**
@@ -65,12 +65,12 @@ bun run src/index.ts note show delete-test-note
 
 ```bash
 # Create another note
-bun run src/index.ts note create \
+bun src/index.ts --config dev-config.yaml note create \
   --slug force-delete-note \
   --content "Force delete"
 
 # Delete without confirmation
-bun run src/index.ts note delete force-delete-note --force
+bun src/index.ts --config dev-config.yaml note delete force-delete-note --force
 ```
 
 **Expected:**

--- a/integration-tests/cli-note/edit.md
+++ b/integration-tests/cli-note/edit.md
@@ -6,7 +6,7 @@ Test editing note content.
 
 ```bash
 cd cli
-bun run src/index.ts note create \
+bun src/index.ts --config dev-config.yaml note create \
   --slug edit-test-note \
   --content "Original content"
 ```
@@ -14,7 +14,7 @@ bun run src/index.ts note create \
 ## Edit Content
 
 ```bash
-bun run src/index.ts note edit edit-test-note --content "Updated content here"
+bun src/index.ts --config dev-config.yaml note edit edit-test-note --content "Updated content here"
 ```
 
 **Expected:**
@@ -27,7 +27,7 @@ bun run src/index.ts note edit edit-test-note --content "Updated content here"
 ## Verify Content Changed
 
 ```bash
-bun run src/index.ts note show edit-test-note
+bun src/index.ts --config dev-config.yaml note show edit-test-note
 ```
 
 **Expected:** Shows "Updated content here" (not original).
@@ -45,7 +45,7 @@ Content updated from file.
 Multiple paragraphs work too.
 EOF
 
-bun run src/index.ts note edit edit-test-note --file /tmp/updated-note.md
+bun src/index.ts --config dev-config.yaml note edit edit-test-note --file /tmp/updated-note.md
 ```
 
 **Expected:**
@@ -59,7 +59,7 @@ bun run src/index.ts note edit edit-test-note --file /tmp/updated-note.md
 ## Verify File Content
 
 ```bash
-bun run src/index.ts note show edit-test-note
+bun src/index.ts --config dev-config.yaml note show edit-test-note
 ```
 
 **Expected:** Shows content from file (slug in frontmatter is ignored).
@@ -67,6 +67,6 @@ bun run src/index.ts note show edit-test-note
 ## Cleanup
 
 ```bash
-bun run src/index.ts note delete edit-test-note --force
+bun src/index.ts --config dev-config.yaml note delete edit-test-note --force
 rm /tmp/updated-note.md
 ```

--- a/integration-tests/cli-note/list.md
+++ b/integration-tests/cli-note/list.md
@@ -8,15 +8,15 @@ Test listing notes with various filters.
 cd cli
 
 # Create test notes
-bun run src/index.ts note create --slug note-draft --content "Draft note"
-bun run src/index.ts note create --slug note-published --content "Published note"
-bun run src/index.ts note publish note-published
+bun src/index.ts --config dev-config.yaml note create --slug note-draft --content "Draft note"
+bun src/index.ts --config dev-config.yaml note create --slug note-published --content "Published note"
+bun src/index.ts --config dev-config.yaml note publish note-published
 ```
 
 ## List All (Default)
 
 ```bash
-bun run src/index.ts note list
+bun src/index.ts --config dev-config.yaml note list
 ```
 
 **Expected:** Shows both notes in table format with slug, excerpt, status, date.
@@ -24,7 +24,7 @@ bun run src/index.ts note list
 ## List Drafts Only
 
 ```bash
-bun run src/index.ts note list --status draft
+bun src/index.ts --config dev-config.yaml note list --status draft
 ```
 
 **Expected:** Shows only `note-draft`.
@@ -32,7 +32,7 @@ bun run src/index.ts note list --status draft
 ## List Published Only
 
 ```bash
-bun run src/index.ts note list --status published
+bun src/index.ts --config dev-config.yaml note list --status published
 ```
 
 **Expected:** Shows only `note-published`.
@@ -40,7 +40,7 @@ bun run src/index.ts note list --status published
 ## List with Limit
 
 ```bash
-bun run src/index.ts note list --limit 1
+bun src/index.ts --config dev-config.yaml note list --limit 1
 ```
 
 **Expected:** Shows only 1 note.
@@ -48,7 +48,7 @@ bun run src/index.ts note list --limit 1
 ## List as JSON
 
 ```bash
-bun run src/index.ts note list --json
+bun src/index.ts --config dev-config.yaml note list --json
 ```
 
 **Expected:** JSON array of note objects.
@@ -56,6 +56,6 @@ bun run src/index.ts note list --json
 ## Cleanup
 
 ```bash
-bun run src/index.ts note delete note-draft --force
-bun run src/index.ts note delete note-published --force
+bun src/index.ts --config dev-config.yaml note delete note-draft --force
+bun src/index.ts --config dev-config.yaml note delete note-published --force
 ```

--- a/integration-tests/cli-note/publish.md
+++ b/integration-tests/cli-note/publish.md
@@ -6,7 +6,7 @@ Test publishing and unpublishing notes.
 
 ```bash
 cd cli
-bun run src/index.ts note create \
+bun src/index.ts --config dev-config.yaml note create \
   --slug publish-test-note \
   --content "Note to publish"
 ```
@@ -14,7 +14,7 @@ bun run src/index.ts note create \
 ## Verify Initial State (Draft)
 
 ```bash
-bun run src/index.ts note show publish-test-note | grep "Status:"
+bun src/index.ts --config dev-config.yaml note show publish-test-note | grep "Status:"
 ```
 
 **Expected:** `Status:    draft`
@@ -22,7 +22,7 @@ bun run src/index.ts note show publish-test-note | grep "Status:"
 ## Publish Note
 
 ```bash
-bun run src/index.ts note publish publish-test-note
+bun src/index.ts --config dev-config.yaml note publish publish-test-note
 ```
 
 **Expected:**
@@ -34,7 +34,7 @@ bun run src/index.ts note publish publish-test-note
 ## Verify Published
 
 ```bash
-bun run src/index.ts note show publish-test-note | grep -E "(Status:|Published:)"
+bun src/index.ts --config dev-config.yaml note show publish-test-note | grep -E "(Status:|Published:)"
 ```
 
 **Expected:**
@@ -57,7 +57,7 @@ sleep 1
 ## Unpublish Note
 
 ```bash
-bun run src/index.ts note unpublish publish-test-note
+bun src/index.ts --config dev-config.yaml note unpublish publish-test-note
 ```
 
 **Expected:**
@@ -69,7 +69,7 @@ bun run src/index.ts note unpublish publish-test-note
 ## Verify Unpublished
 
 ```bash
-bun run src/index.ts note show publish-test-note | grep "Status:"
+bun src/index.ts --config dev-config.yaml note show publish-test-note | grep "Status:"
 ```
 
 **Expected:** `Status:    draft`
@@ -77,5 +77,5 @@ bun run src/index.ts note show publish-test-note | grep "Status:"
 ## Cleanup
 
 ```bash
-bun run src/index.ts note delete publish-test-note --force
+bun src/index.ts --config dev-config.yaml note delete publish-test-note --force
 ```

--- a/integration-tests/cli-note/pull.md
+++ b/integration-tests/cli-note/pull.md
@@ -6,7 +6,7 @@ Test downloading notes as markdown files.
 
 ```bash
 cd cli
-bun run src/index.ts note create \
+bun src/index.ts --config dev-config.yaml note create \
   --slug pull-test-note \
   --content "This is a note to pull."
 ```
@@ -14,7 +14,7 @@ bun run src/index.ts note create \
 ## Pull to Default Filename
 
 ```bash
-bun run src/index.ts note pull pull-test-note
+bun src/index.ts --config dev-config.yaml note pull pull-test-note
 ```
 
 **Expected:**
@@ -47,7 +47,7 @@ Note: Notes have minimal frontmatter - no title, tags, or excerpt.
 ## Pull to Custom Path
 
 ```bash
-bun run src/index.ts note pull pull-test-note -o /tmp/custom-note.md
+bun src/index.ts --config dev-config.yaml note pull pull-test-note -o /tmp/custom-note.md
 cat /tmp/custom-note.md
 ```
 
@@ -56,7 +56,7 @@ cat /tmp/custom-note.md
 ## Pull as JSON
 
 ```bash
-bun run src/index.ts note pull pull-test-note --json
+bun src/index.ts --config dev-config.yaml note pull pull-test-note --json
 ```
 
 **Expected:** Full JSON object (not saved to file).
@@ -64,6 +64,6 @@ bun run src/index.ts note pull pull-test-note --json
 ## Cleanup
 
 ```bash
-bun run src/index.ts note delete pull-test-note --force
+bun src/index.ts --config dev-config.yaml note delete pull-test-note --force
 rm pull-test-note.md /tmp/custom-note.md
 ```

--- a/integration-tests/cli-note/show.md
+++ b/integration-tests/cli-note/show.md
@@ -6,7 +6,7 @@ Test showing note details.
 
 ```bash
 cd cli
-bun run src/index.ts note create \
+bun src/index.ts --config dev-config.yaml note create \
   --slug show-test-note \
   --content "This is a test note with some content."
 ```
@@ -14,7 +14,7 @@ bun run src/index.ts note create \
 ## Show Note
 
 ```bash
-bun run src/index.ts note show show-test-note
+bun src/index.ts --config dev-config.yaml note show show-test-note
 ```
 
 **Expected:**
@@ -32,7 +32,7 @@ This is a test note with some content.
 ## Show as JSON
 
 ```bash
-bun run src/index.ts note show show-test-note --json
+bun src/index.ts --config dev-config.yaml note show show-test-note --json
 ```
 
 **Expected:** Full JSON object with `type: "note"`, no title field.
@@ -40,7 +40,7 @@ bun run src/index.ts note show show-test-note --json
 ## Show Non-existent Note
 
 ```bash
-bun run src/index.ts note show nonexistent-note
+bun src/index.ts --config dev-config.yaml note show nonexistent-note
 ```
 
 **Expected:**
@@ -52,5 +52,5 @@ bun run src/index.ts note show nonexistent-note
 ## Cleanup
 
 ```bash
-bun run src/index.ts note delete show-test-note --force
+bun src/index.ts --config dev-config.yaml note delete show-test-note --force
 ```

--- a/integration-tests/cli-post/README.md
+++ b/integration-tests/cli-post/README.md
@@ -5,13 +5,18 @@ Manual integration tests for the `ec post` CLI commands.
 ## Prerequisites
 
 1. Dev environment running: `make dev`
-2. CLI configured with API key (see `cli-auth` skill)
+2. CLI dev config set up:
+   ```bash
+   cp cli/dev-config.yaml.example cli/dev-config.yaml
+   # Then login to get API key:
+   cd cli && bun src/index.ts --config dev-config.yaml login --api-url http://localhost:5000/api
+   ```
 
 ### Verify setup
 
 ```bash
 make dev-status
-cd cli && bun run src/index.ts config show
+cd cli && bun src/index.ts --config dev-config.yaml config show
 ```
 
 ## Tests

--- a/integration-tests/cli-post/create-basic.md
+++ b/integration-tests/cli-post/create-basic.md
@@ -6,7 +6,7 @@ Create a simple article with required fields only.
 
 ```bash
 cd cli
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "Integration Test Post" \
   --slug integration-test-post \
   --content $'# Hello World\n\nThis is a test post created via CLI.'
@@ -26,7 +26,7 @@ bun run src/index.ts post create \
 ## Verify
 
 ```bash
-bun run src/index.ts post show integration-test-post
+bun src/index.ts --config dev-config.yaml post show integration-test-post
 ```
 
 Should display the post with correct title, slug, type, and content.
@@ -34,5 +34,5 @@ Should display the post with correct title, slug, type, and content.
 ## Cleanup
 
 ```bash
-bun run src/index.ts post delete integration-test-post --force
+bun src/index.ts --config dev-config.yaml post delete integration-test-post --force
 ```

--- a/integration-tests/cli-post/create-errors.md
+++ b/integration-tests/cli-post/create-errors.md
@@ -6,7 +6,7 @@ Test validation and error handling for post creation.
 
 ```bash
 cd cli
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "No Slug Post" \
   --content "This should fail"
 ```
@@ -21,7 +21,7 @@ Run 'ec post create --help' for usage.
 ## Missing Content
 
 ```bash
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "No Content Post" \
   --slug no-content-post
 ```
@@ -36,7 +36,7 @@ Run 'ec post create --help' for usage.
 ## Article Without Title
 
 ```bash
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --slug no-title-article \
   --content "Article needs a title"
 ```
@@ -50,7 +50,7 @@ bun run src/index.ts post create \
 ## Invalid Slug Format
 
 ```bash
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "Bad Slug" \
   --slug "Invalid Slug With Spaces" \
   --content "This should fail"
@@ -62,13 +62,13 @@ bun run src/index.ts post create \
 
 ```bash
 # Create first post
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "First" \
   --slug duplicate-test \
   --content "First post"
 
 # Try to create with same slug
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "Second" \
   --slug duplicate-test \
   --content "Should fail"
@@ -79,5 +79,5 @@ bun run src/index.ts post create \
 **Cleanup:**
 
 ```bash
-bun run src/index.ts post delete duplicate-test --force
+bun src/index.ts --config dev-config.yaml post delete duplicate-test --force
 ```

--- a/integration-tests/cli-post/create-from-file.md
+++ b/integration-tests/cli-post/create-from-file.md
@@ -32,7 +32,7 @@ EOF
 ## Create from File
 
 ```bash
-bun run src/index.ts post create --file /tmp/test-post.md
+bun src/index.ts --config dev-config.yaml post create --file /tmp/test-post.md
 ```
 
 **Expected:**
@@ -49,7 +49,7 @@ bun run src/index.ts post create --file /tmp/test-post.md
 ## Verify Post Created
 
 ```bash
-bun run src/index.ts post show file-created-post
+bun src/index.ts --config dev-config.yaml post show file-created-post
 ```
 
 **Expected:** Shows title "File Created Post", tags "Test, File Based", and content starting with "# Hello from File".
@@ -57,7 +57,7 @@ bun run src/index.ts post show file-created-post
 ## Publish and Verify on Home Page
 
 ```bash
-bun run src/index.ts post publish file-created-post
+bun src/index.ts --config dev-config.yaml post publish file-created-post
 
 ~/.local/share/pi-skills/browser-tools/browser-nav.js http://localhost:5000
 sleep 1
@@ -83,7 +83,7 @@ sleep 1
 ## Pull Back and Verify Roundtrip
 
 ```bash
-bun run src/index.ts post pull file-created-post --output /tmp/pulled.md
+bun src/index.ts --config dev-config.yaml post pull file-created-post --output /tmp/pulled.md
 cat /tmp/pulled.md
 ```
 
@@ -109,7 +109,7 @@ excerpt: This post was updated from a file.
 The content has been changed via file-based editing.
 EOF
 
-bun run src/index.ts post edit file-created-post --file /tmp/updated-post.md
+bun src/index.ts --config dev-config.yaml post edit file-created-post --file /tmp/updated-post.md
 ```
 
 **Expected:**
@@ -126,7 +126,7 @@ bun run src/index.ts post edit file-created-post --file /tmp/updated-post.md
 ## Verify Update
 
 ```bash
-bun run src/index.ts post show file-created-post
+bun src/index.ts --config dev-config.yaml post show file-created-post
 ```
 
 **Expected:** Title is "Updated via File", tags are "Updated, Roundtrip".
@@ -134,7 +134,7 @@ bun run src/index.ts post show file-created-post
 ## CLI Override of Frontmatter
 
 ```bash
-bun run src/index.ts post edit file-created-post --file /tmp/updated-post.md --tags cli,override
+bun src/index.ts --config dev-config.yaml post edit file-created-post --file /tmp/updated-post.md --tags cli,override
 ```
 
 **Expected:** Tags are "Cli, Override" (CLI flag overrides frontmatter).
@@ -142,6 +142,6 @@ bun run src/index.ts post edit file-created-post --file /tmp/updated-post.md --t
 ## Cleanup
 
 ```bash
-bun run src/index.ts post delete file-created-post --force
+bun src/index.ts --config dev-config.yaml post delete file-created-post --force
 rm /tmp/test-post.md /tmp/updated-post.md /tmp/pulled.md
 ```

--- a/integration-tests/cli-post/create-with-images.md
+++ b/integration-tests/cli-post/create-with-images.md
@@ -14,7 +14,7 @@ ls -la cli/examples/sample-image.png
 
 ```bash
 cd cli
-bun run src/index.ts post create --file examples/with-images.md
+bun src/index.ts --config dev-config.yaml post create --file examples/with-images.md
 ```
 
 **Expected:**
@@ -40,7 +40,7 @@ curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/media/posts/image-d
 ## Verify URL Was Rewritten in Content
 
 ```bash
-bun run src/index.ts post pull image-demo-post --output /tmp/pulled.md
+bun src/index.ts --config dev-config.yaml post pull image-demo-post --output /tmp/pulled.md
 grep "sample-image" /tmp/pulled.md
 ```
 
@@ -49,7 +49,7 @@ grep "sample-image" /tmp/pulled.md
 ## Publish and View Banner in Browser
 
 ```bash
-bun run src/index.ts post publish image-demo-post
+bun src/index.ts --config dev-config.yaml post publish image-demo-post
 
 ~/.local/share/pi-skills/browser-tools/browser-nav.js http://localhost:5000/posts/image-demo-post
 sleep 1
@@ -65,6 +65,6 @@ sleep 1
 ## Cleanup
 
 ```bash
-bun run src/index.ts post delete image-demo-post --force
+bun src/index.ts --config dev-config.yaml post delete image-demo-post --force
 rm /tmp/pulled.md
 ```

--- a/integration-tests/cli-post/create-with-options.md
+++ b/integration-tests/cli-post/create-with-options.md
@@ -6,7 +6,7 @@ Create an article with tags, excerpt, and JSON output.
 
 ```bash
 cd cli
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "Tagged Test Post" \
   --slug tagged-test-post \
   --content "Content with tags" \
@@ -27,7 +27,7 @@ bun run src/index.ts post create \
 ## Verify with JSON
 
 ```bash
-bun run src/index.ts post show tagged-test-post --json
+bun src/index.ts --config dev-config.yaml post show tagged-test-post --json
 ```
 
 Should include `"tags": ["tech", "testing"]` and `"excerpt": "A short summary"`.
@@ -35,5 +35,5 @@ Should include `"tags": ["tech", "testing"]` and `"excerpt": "A short summary"`.
 ## Cleanup
 
 ```bash
-bun run src/index.ts post delete tagged-test-post --force
+bun src/index.ts --config dev-config.yaml post delete tagged-test-post --force
 ```

--- a/integration-tests/cli-post/delete.md
+++ b/integration-tests/cli-post/delete.md
@@ -6,7 +6,7 @@ Test deleting posts with confirmation.
 
 ```bash
 cd cli
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "Delete Test" \
   --slug delete-test \
   --content "To be deleted"
@@ -15,7 +15,7 @@ bun run src/index.ts post create \
 ## Delete with Confirmation
 
 ```bash
-bun run src/index.ts post delete delete-test
+bun src/index.ts --config dev-config.yaml post delete delete-test
 ```
 
 **Expected:** Prompts `Delete 'Delete Test' (delete-test)? [y/N]`
@@ -27,13 +27,13 @@ bun run src/index.ts post delete delete-test
 
 ```bash
 # Recreate first
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "Force Delete" \
   --slug force-delete \
   --content "Content"
 
 # Delete without prompt
-bun run src/index.ts post delete force-delete --force
+bun src/index.ts --config dev-config.yaml post delete force-delete --force
 ```
 
 **Expected:**
@@ -45,7 +45,7 @@ bun run src/index.ts post delete force-delete --force
 ## Delete Non-Existent
 
 ```bash
-bun run src/index.ts post delete does-not-exist --force
+bun src/index.ts --config dev-config.yaml post delete does-not-exist --force
 ```
 
 **Expected:**
@@ -57,8 +57,8 @@ bun run src/index.ts post delete does-not-exist --force
 ## Delete with JSON Output
 
 ```bash
-bun run src/index.ts post create --title "JSON Delete" --slug json-delete --content "X"
-bun run src/index.ts post delete json-delete --force --json
+bun src/index.ts --config dev-config.yaml post create --title "JSON Delete" --slug json-delete --content "X"
+bun src/index.ts --config dev-config.yaml post delete json-delete --force --json
 ```
 
 **Expected:**

--- a/integration-tests/cli-post/edit.md
+++ b/integration-tests/cli-post/edit.md
@@ -6,7 +6,7 @@ Test editing post fields.
 
 ```bash
 cd cli
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "Edit Test" \
   --slug edit-test \
   --content "Original content" \
@@ -16,7 +16,7 @@ bun run src/index.ts post create \
 ## Edit Title
 
 ```bash
-bun run src/index.ts post edit edit-test --title "Updated Title"
+bun src/index.ts --config dev-config.yaml post edit edit-test --title "Updated Title"
 ```
 
 **Expected:**
@@ -29,13 +29,13 @@ bun run src/index.ts post edit edit-test --title "Updated Title"
 **Verify:**
 
 ```bash
-bun run src/index.ts post show edit-test
+bun src/index.ts --config dev-config.yaml post show edit-test
 ```
 
 ## Edit Content
 
 ```bash
-bun run src/index.ts post edit edit-test --content "New content here"
+bun src/index.ts --config dev-config.yaml post edit edit-test --content "New content here"
 ```
 
 **Expected:** Success message, content updated.
@@ -43,7 +43,7 @@ bun run src/index.ts post edit edit-test --content "New content here"
 ## Edit Tags
 
 ```bash
-bun run src/index.ts post edit edit-test --tags new,tags
+bun src/index.ts --config dev-config.yaml post edit edit-test --tags new,tags
 ```
 
 **Expected:** Tags replaced with `new, tags`.
@@ -51,7 +51,7 @@ bun run src/index.ts post edit edit-test --tags new,tags
 ## Edit Multiple Fields
 
 ```bash
-bun run src/index.ts post edit edit-test \
+bun src/index.ts --config dev-config.yaml post edit edit-test \
   --title "Final Title" \
   --excerpt "New excerpt"
 ```
@@ -61,7 +61,7 @@ bun run src/index.ts post edit edit-test \
 ## Edit Non-Existent
 
 ```bash
-bun run src/index.ts post edit does-not-exist --title "Fail"
+bun src/index.ts --config dev-config.yaml post edit does-not-exist --title "Fail"
 ```
 
 **Expected:**
@@ -73,5 +73,5 @@ bun run src/index.ts post edit does-not-exist --title "Fail"
 ## Cleanup
 
 ```bash
-bun run src/index.ts post delete edit-test --force
+bun src/index.ts --config dev-config.yaml post delete edit-test --force
 ```

--- a/integration-tests/cli-post/list.md
+++ b/integration-tests/cli-post/list.md
@@ -8,15 +8,15 @@ Test listing posts with various filters.
 cd cli
 
 # Create test posts
-bun run src/index.ts post create --title "Draft Post" --slug list-draft --content "Draft"
-bun run src/index.ts post create --title "Published Post" --slug list-published --content "Published"
-bun run src/index.ts post publish list-published
+bun src/index.ts --config dev-config.yaml post create --title "Draft Post" --slug list-draft --content "Draft"
+bun src/index.ts --config dev-config.yaml post create --title "Published Post" --slug list-published --content "Published"
+bun src/index.ts --config dev-config.yaml post publish list-published
 ```
 
 ## List All (Default)
 
 ```bash
-bun run src/index.ts post list
+bun src/index.ts --config dev-config.yaml post list
 ```
 
 **Expected:** Shows both posts in table format with slug, title, status, date.
@@ -24,7 +24,7 @@ bun run src/index.ts post list
 ## List Drafts Only
 
 ```bash
-bun run src/index.ts post list --status draft
+bun src/index.ts --config dev-config.yaml post list --status draft
 ```
 
 **Expected:** Shows only `list-draft`.
@@ -32,7 +32,7 @@ bun run src/index.ts post list --status draft
 ## List Published Only
 
 ```bash
-bun run src/index.ts post list --status published
+bun src/index.ts --config dev-config.yaml post list --status published
 ```
 
 **Expected:** Shows only `list-published`.
@@ -40,7 +40,7 @@ bun run src/index.ts post list --status published
 ## List with Limit
 
 ```bash
-bun run src/index.ts post list --limit 1
+bun src/index.ts --config dev-config.yaml post list --limit 1
 ```
 
 **Expected:** Shows only 1 post.
@@ -48,7 +48,7 @@ bun run src/index.ts post list --limit 1
 ## List as JSON
 
 ```bash
-bun run src/index.ts post list --json
+bun src/index.ts --config dev-config.yaml post list --json
 ```
 
 **Expected:** JSON array of post objects.
@@ -56,6 +56,6 @@ bun run src/index.ts post list --json
 ## Cleanup
 
 ```bash
-bun run src/index.ts post delete list-draft --force
-bun run src/index.ts post delete list-published --force
+bun src/index.ts --config dev-config.yaml post delete list-draft --force
+bun src/index.ts --config dev-config.yaml post delete list-published --force
 ```

--- a/integration-tests/cli-post/publish.md
+++ b/integration-tests/cli-post/publish.md
@@ -6,7 +6,7 @@ Test publishing and unpublishing posts, verifying visibility on the website.
 
 ```bash
 cd cli
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "Publish Test" \
   --slug publish-test \
   --content $'# Hello\n\nThis is a published post.'
@@ -29,7 +29,7 @@ sleep 1
 ## Publish
 
 ```bash
-bun run src/index.ts post publish publish-test
+bun src/index.ts --config dev-config.yaml post publish publish-test
 ```
 
 **Expected:**
@@ -62,7 +62,7 @@ sleep 1
 ## Unpublish
 
 ```bash
-bun run src/index.ts post unpublish publish-test
+bun src/index.ts --config dev-config.yaml post unpublish publish-test
 ```
 
 **Expected:**
@@ -86,13 +86,13 @@ sleep 1
 ## Re-publish and Delete
 
 ```bash
-bun run src/index.ts post publish publish-test
+bun src/index.ts --config dev-config.yaml post publish publish-test
 ```
 
 Verify it's back on home page, then delete:
 
 ```bash
-bun run src/index.ts post delete publish-test --force
+bun src/index.ts --config dev-config.yaml post delete publish-test --force
 ```
 
 ## Verify Deleted Not on Home Page

--- a/integration-tests/cli-post/show.md
+++ b/integration-tests/cli-post/show.md
@@ -6,7 +6,7 @@ Test displaying post details.
 
 ```bash
 cd cli
-bun run src/index.ts post create \
+bun src/index.ts --config dev-config.yaml post create \
   --title "Show Test" \
   --slug show-test \
   --content $'# Content\n\nWith markdown.' \
@@ -19,7 +19,7 @@ bun run src/index.ts post create \
 ## Show Post
 
 ```bash
-bun run src/index.ts post show show-test
+bun src/index.ts --config dev-config.yaml post show show-test
 ```
 
 **Expected:**
@@ -43,7 +43,7 @@ With markdown.
 ## Show as JSON
 
 ```bash
-bun run src/index.ts post show show-test --json
+bun src/index.ts --config dev-config.yaml post show show-test --json
 ```
 
 **Expected:** Full post object as JSON.
@@ -51,7 +51,7 @@ bun run src/index.ts post show show-test --json
 ## Show Non-Existent
 
 ```bash
-bun run src/index.ts post show does-not-exist
+bun src/index.ts --config dev-config.yaml post show does-not-exist
 ```
 
 **Expected:**
@@ -63,5 +63,5 @@ bun run src/index.ts post show does-not-exist
 ## Cleanup
 
 ```bash
-bun run src/index.ts post delete show-test --force
+bun src/index.ts --config dev-config.yaml post delete show-test --force
 ```

--- a/integration-tests/cli-source/README.md
+++ b/integration-tests/cli-source/README.md
@@ -5,13 +5,18 @@ Manual integration tests for the `ec source` CLI commands.
 ## Prerequisites
 
 1. Dev environment running: `make dev`
-2. CLI configured with API key (see `cli-auth` skill)
+2. CLI dev config set up:
+   ```bash
+   cp cli/dev-config.yaml.example cli/dev-config.yaml
+   # Then login to get API key:
+   cd cli && bun src/index.ts --config dev-config.yaml login --api-url http://localhost:5000/api
+   ```
 
 ### Verify setup
 
 ```bash
 make dev-status
-cd cli && bun run src/index.ts config show
+cd cli && bun src/index.ts --config dev-config.yaml config show
 ```
 
 ## Tests

--- a/integration-tests/cli-source/create.md
+++ b/integration-tests/cli-source/create.md
@@ -6,7 +6,7 @@ Test creating sources with various options.
 
 ```bash
 cd cli
-bun run src/index.ts source create --name "Test Source" --url "https://example.com"
+bun src/index.ts --config dev-config.yaml source create --name "Test Source" --url "https://example.com"
 ```
 
 **Expected:** Success message with source ID.
@@ -14,7 +14,7 @@ bun run src/index.ts source create --name "Test Source" --url "https://example.c
 ## Create with Feed URL
 
 ```bash
-bun run src/index.ts source create --name "Hacker News" --url "https://news.ycombinator.com" --feed-url "https://news.ycombinator.com/rss"
+bun src/index.ts --config dev-config.yaml source create --name "Hacker News" --url "https://news.ycombinator.com" --feed-url "https://news.ycombinator.com/rss"
 ```
 
 **Expected:** Success message with source ID.
@@ -22,7 +22,7 @@ bun run src/index.ts source create --name "Hacker News" --url "https://news.ycom
 ## Create with JSON Output
 
 ```bash
-bun run src/index.ts source create --name "JSON Test" --url "https://json.example.com" --json
+bun src/index.ts --config dev-config.yaml source create --name "JSON Test" --url "https://json.example.com" --json
 ```
 
 **Expected:** JSON object with id, name, url, feed_url fields.
@@ -30,7 +30,7 @@ bun run src/index.ts source create --name "JSON Test" --url "https://json.exampl
 ## Error: Missing Name
 
 ```bash
-bun run src/index.ts source create --url "https://example.com"
+bun src/index.ts --config dev-config.yaml source create --url "https://example.com"
 ```
 
 **Expected:** Error message about missing --name.
@@ -38,7 +38,7 @@ bun run src/index.ts source create --url "https://example.com"
 ## Error: Missing URL
 
 ```bash
-bun run src/index.ts source create --name "Test"
+bun src/index.ts --config dev-config.yaml source create --name "Test"
 ```
 
 **Expected:** Error message about missing --url.
@@ -47,8 +47,8 @@ bun run src/index.ts source create --name "Test"
 
 ```bash
 # List sources to get IDs
-bun run src/index.ts source list
+bun src/index.ts --config dev-config.yaml source list
 
 # Delete test sources (replace IDs as needed)
-bun run src/index.ts source delete <id> --force
+bun src/index.ts --config dev-config.yaml source delete <id> --force
 ```

--- a/integration-tests/cli-source/delete.md
+++ b/integration-tests/cli-source/delete.md
@@ -8,8 +8,8 @@ Test deleting sources with confirmation.
 cd cli
 
 # Create test sources
-bun run src/index.ts source create --name "Delete Test 1" --url "https://delete1.example.com" --json
-bun run src/index.ts source create --name "Delete Test 2" --url "https://delete2.example.com" --json
+bun src/index.ts --config dev-config.yaml source create --name "Delete Test 1" --url "https://delete1.example.com" --json
+bun src/index.ts --config dev-config.yaml source create --name "Delete Test 2" --url "https://delete2.example.com" --json
 ```
 
 Note the IDs from the output.
@@ -17,7 +17,7 @@ Note the IDs from the output.
 ## Delete with Confirmation
 
 ```bash
-bun run src/index.ts source delete <id1>
+bun src/index.ts --config dev-config.yaml source delete <id1>
 ```
 
 **Expected:** Prompt: "Delete source 'Delete Test 1'? This may affect linked posts. [y/N]"
@@ -29,7 +29,7 @@ Type `y` and press Enter.
 ## Delete with Force Flag
 
 ```bash
-bun run src/index.ts source delete <id2> --force
+bun src/index.ts --config dev-config.yaml source delete <id2> --force
 ```
 
 **Expected:** No prompt, immediate success message.
@@ -38,8 +38,8 @@ bun run src/index.ts source delete <id2> --force
 
 ```bash
 # Create another source
-bun run src/index.ts source create --name "Cancel Test" --url "https://cancel.example.com" --json
-bun run src/index.ts source delete <id>
+bun src/index.ts --config dev-config.yaml source create --name "Cancel Test" --url "https://cancel.example.com" --json
+bun src/index.ts --config dev-config.yaml source delete <id>
 ```
 
 **Expected:** Prompt appears.
@@ -49,7 +49,7 @@ Type `n` and press Enter.
 **Expected:** "Cancelled." message.
 
 ```bash
-bun run src/index.ts source show <id>
+bun src/index.ts --config dev-config.yaml source show <id>
 ```
 
 **Expected:** Source still exists.
@@ -57,7 +57,7 @@ bun run src/index.ts source show <id>
 ## Error: Non-existent ID
 
 ```bash
-bun run src/index.ts source delete 99999 --force
+bun src/index.ts --config dev-config.yaml source delete 99999 --force
 ```
 
 **Expected:** Error message "Source not found".
@@ -66,5 +66,5 @@ bun run src/index.ts source delete 99999 --force
 
 ```bash
 # Delete any remaining test sources
-bun run src/index.ts source list --json | jq -r '.[].id' | xargs -I {} bun run src/index.ts source delete {} --force
+bun src/index.ts --config dev-config.yaml source list --json | jq -r '.[].id' | xargs -I {} bun src/index.ts --config dev-config.yaml source delete {} --force
 ```

--- a/integration-tests/cli-source/edit.md
+++ b/integration-tests/cli-source/edit.md
@@ -8,7 +8,7 @@ Test editing source fields.
 cd cli
 
 # Create a test source
-bun run src/index.ts source create --name "Edit Test" --url "https://edit.example.com" --json
+bun src/index.ts --config dev-config.yaml source create --name "Edit Test" --url "https://edit.example.com" --json
 ```
 
 Note the ID from the output.
@@ -16,13 +16,13 @@ Note the ID from the output.
 ## Edit Name
 
 ```bash
-bun run src/index.ts source edit <id> --name "Updated Name"
+bun src/index.ts --config dev-config.yaml source edit <id> --name "Updated Name"
 ```
 
 **Expected:** Success message.
 
 ```bash
-bun run src/index.ts source show <id>
+bun src/index.ts --config dev-config.yaml source show <id>
 ```
 
 **Expected:** Name shows "Updated Name".
@@ -30,7 +30,7 @@ bun run src/index.ts source show <id>
 ## Edit URL
 
 ```bash
-bun run src/index.ts source edit <id> --url "https://updated.example.com"
+bun src/index.ts --config dev-config.yaml source edit <id> --url "https://updated.example.com"
 ```
 
 **Expected:** Success message.
@@ -38,13 +38,13 @@ bun run src/index.ts source edit <id> --url "https://updated.example.com"
 ## Add Feed URL
 
 ```bash
-bun run src/index.ts source edit <id> --feed-url "https://updated.example.com/feed"
+bun src/index.ts --config dev-config.yaml source edit <id> --feed-url "https://updated.example.com/feed"
 ```
 
 **Expected:** Success message.
 
 ```bash
-bun run src/index.ts source show <id>
+bun src/index.ts --config dev-config.yaml source show <id>
 ```
 
 **Expected:** Feed URL shows the new value.
@@ -52,13 +52,13 @@ bun run src/index.ts source show <id>
 ## Remove Feed URL
 
 ```bash
-bun run src/index.ts source edit <id> --no-feed-url
+bun src/index.ts --config dev-config.yaml source edit <id> --no-feed-url
 ```
 
 **Expected:** Success message.
 
 ```bash
-bun run src/index.ts source show <id>
+bun src/index.ts --config dev-config.yaml source show <id>
 ```
 
 **Expected:** Feed URL shows "-".
@@ -66,7 +66,7 @@ bun run src/index.ts source show <id>
 ## Edit with JSON Output
 
 ```bash
-bun run src/index.ts source edit <id> --name "JSON Edit" --json
+bun src/index.ts --config dev-config.yaml source edit <id> --name "JSON Edit" --json
 ```
 
 **Expected:** JSON object with updated source.
@@ -74,7 +74,7 @@ bun run src/index.ts source edit <id> --name "JSON Edit" --json
 ## Error: No Updates Provided
 
 ```bash
-bun run src/index.ts source edit <id>
+bun src/index.ts --config dev-config.yaml source edit <id>
 ```
 
 **Expected:** Error message about no update options provided.
@@ -82,7 +82,7 @@ bun run src/index.ts source edit <id>
 ## Error: Non-existent ID
 
 ```bash
-bun run src/index.ts source edit 99999 --name "Test"
+bun src/index.ts --config dev-config.yaml source edit 99999 --name "Test"
 ```
 
 **Expected:** Error message "Source not found".
@@ -90,5 +90,5 @@ bun run src/index.ts source edit 99999 --name "Test"
 ## Cleanup
 
 ```bash
-bun run src/index.ts source delete <id> --force
+bun src/index.ts --config dev-config.yaml source delete <id> --force
 ```

--- a/integration-tests/cli-source/list.md
+++ b/integration-tests/cli-source/list.md
@@ -8,14 +8,14 @@ Test listing sources.
 cd cli
 
 # Create test sources
-bun run src/index.ts source create --name "Source One" --url "https://one.example.com"
-bun run src/index.ts source create --name "Source Two" --url "https://two.example.com" --feed-url "https://two.example.com/feed"
+bun src/index.ts --config dev-config.yaml source create --name "Source One" --url "https://one.example.com"
+bun src/index.ts --config dev-config.yaml source create --name "Source Two" --url "https://two.example.com" --feed-url "https://two.example.com/feed"
 ```
 
 ## List All Sources
 
 ```bash
-bun run src/index.ts source list
+bun src/index.ts --config dev-config.yaml source list
 ```
 
 **Expected:** Table with ID, NAME, URL columns showing both sources.
@@ -23,7 +23,7 @@ bun run src/index.ts source list
 ## List as JSON
 
 ```bash
-bun run src/index.ts source list --json
+bun src/index.ts --config dev-config.yaml source list --json
 ```
 
 **Expected:** JSON array of source objects with id, name, url, feed_url fields.
@@ -32,7 +32,7 @@ bun run src/index.ts source list --json
 
 ```bash
 # After cleanup, verify empty list
-bun run src/index.ts source list
+bun src/index.ts --config dev-config.yaml source list
 ```
 
 **Expected:** "No sources found." message.
@@ -40,5 +40,5 @@ bun run src/index.ts source list
 ## Cleanup
 
 ```bash
-bun run src/index.ts source list --json | jq -r '.[].id' | xargs -I {} bun run src/index.ts source delete {} --force
+bun src/index.ts --config dev-config.yaml source list --json | jq -r '.[].id' | xargs -I {} bun src/index.ts --config dev-config.yaml source delete {} --force
 ```

--- a/integration-tests/cli-source/show.md
+++ b/integration-tests/cli-source/show.md
@@ -8,7 +8,7 @@ Test showing source details.
 cd cli
 
 # Create a test source and capture ID
-bun run src/index.ts source create --name "Show Test" --url "https://show.example.com" --feed-url "https://show.example.com/rss" --json
+bun src/index.ts --config dev-config.yaml source create --name "Show Test" --url "https://show.example.com" --feed-url "https://show.example.com/rss" --json
 ```
 
 Note the ID from the output.
@@ -16,7 +16,7 @@ Note the ID from the output.
 ## Show Source Details
 
 ```bash
-bun run src/index.ts source show <id>
+bun src/index.ts --config dev-config.yaml source show <id>
 ```
 
 **Expected:** Formatted output with:
@@ -29,7 +29,7 @@ bun run src/index.ts source show <id>
 ## Show as JSON
 
 ```bash
-bun run src/index.ts source show <id> --json
+bun src/index.ts --config dev-config.yaml source show <id> --json
 ```
 
 **Expected:** JSON object with all source fields.
@@ -37,7 +37,7 @@ bun run src/index.ts source show <id> --json
 ## Error: Non-existent ID
 
 ```bash
-bun run src/index.ts source show 99999
+bun src/index.ts --config dev-config.yaml source show 99999
 ```
 
 **Expected:** Error message "Source not found".
@@ -45,7 +45,7 @@ bun run src/index.ts source show 99999
 ## Error: Missing ID
 
 ```bash
-bun run src/index.ts source show
+bun src/index.ts --config dev-config.yaml source show
 ```
 
 **Expected:** Error message about missing source ID.
@@ -53,5 +53,5 @@ bun run src/index.ts source show
 ## Cleanup
 
 ```bash
-bun run src/index.ts source delete <id> --force
+bun src/index.ts --config dev-config.yaml source delete <id> --force
 ```

--- a/integration-tests/cli-tag/README.md
+++ b/integration-tests/cli-tag/README.md
@@ -5,13 +5,18 @@ Manual integration tests for the `ec tag` CLI commands.
 ## Prerequisites
 
 1. Dev environment running: `make dev`
-2. CLI configured with API key (see `cli-auth` skill)
+2. CLI dev config set up:
+   ```bash
+   cp cli/dev-config.yaml.example cli/dev-config.yaml
+   # Then login to get API key:
+   cd cli && bun src/index.ts --config dev-config.yaml login --api-url http://localhost:5000/api
+   ```
 
 ### Verify setup
 
 ```bash
 make dev-status
-cd cli && bun run src/index.ts config show
+cd cli && bun src/index.ts --config dev-config.yaml config show
 ```
 
 ## Tests

--- a/integration-tests/cli-tag/list.md
+++ b/integration-tests/cli-tag/list.md
@@ -8,15 +8,15 @@ Test listing tags with post counts.
 cd cli
 
 # Create posts with tags to have meaningful counts
-bun run src/index.ts post create --title "Tag Test 1" --slug tag-test-1 --content "Content" --tags tech,testing
-bun run src/index.ts post create --title "Tag Test 2" --slug tag-test-2 --content "Content" --tags tech,demo
-bun run src/index.ts post create --title "Tag Test 3" --slug tag-test-3 --content "Content" --tags demo
+bun src/index.ts --config dev-config.yaml post create --title "Tag Test 1" --slug tag-test-1 --content "Content" --tags tech,testing
+bun src/index.ts --config dev-config.yaml post create --title "Tag Test 2" --slug tag-test-2 --content "Content" --tags tech,demo
+bun src/index.ts --config dev-config.yaml post create --title "Tag Test 3" --slug tag-test-3 --content "Content" --tags demo
 ```
 
 ## List All Tags
 
 ```bash
-bun run src/index.ts tag list
+bun src/index.ts --config dev-config.yaml tag list
 ```
 
 **Expected:** Table with TAG and COUNT columns:
@@ -29,7 +29,7 @@ bun run src/index.ts tag list
 ## List as JSON
 
 ```bash
-bun run src/index.ts tag list --json
+bun src/index.ts --config dev-config.yaml tag list --json
 ```
 
 **Expected:** JSON array of tag objects with id, name, slug, count fields.
@@ -39,7 +39,7 @@ bun run src/index.ts tag list --json
 If no posts exist with tags:
 
 ```bash
-bun run src/index.ts tag list
+bun src/index.ts --config dev-config.yaml tag list
 ```
 
 **Expected:** Either "No tags found." or empty table.
@@ -47,7 +47,7 @@ bun run src/index.ts tag list
 ## Cleanup
 
 ```bash
-bun run src/index.ts post delete tag-test-1 --force
-bun run src/index.ts post delete tag-test-2 --force
-bun run src/index.ts post delete tag-test-3 --force
+bun src/index.ts --config dev-config.yaml post delete tag-test-1 --force
+bun src/index.ts --config dev-config.yaml post delete tag-test-2 --force
+bun src/index.ts --config dev-config.yaml post delete tag-test-3 --force
 ```


### PR DESCRIPTION
## Summary

Add support for specifying an alternate config file path for development and testing purposes.

## Problem

The CLI config file path was hardcoded to `~/.config/ec/config.yaml`. For development and testing against different environments, it's useful to specify an alternate config file.

## Solution

Add support for config path override via:
1. `--config PATH` flag (highest priority)
2. `EC_CONFIG` environment variable
3. Default: `~/.config/ec/config.yaml` (unchanged behavior)

## Changes

### Code
- Add `configPath` to `GlobalOptions` in `types.ts`
- Parse `--config` flag in `parseArgs()`
- Update `loadConfig()`, `saveConfig()`, `getConfigPath()` to accept optional path
- Update all 34 command files to pass `configPath` through
- Update help text to document the new flag
- Add tests for new functionality (6 new tests)

### Documentation
- Create `cli/dev-config.yaml.example` template
- Add `cli/dev-config.yaml` to `.gitignore`
- Add "CLI Development" section to AGENTS.md
- Update all 41 integration test files to use `--config dev-config.yaml`
- Update integration test READMEs with dev config setup instructions

## Example Usage

```bash
# Use alternate config for dev
ec --config ./dev-config.yaml post list

# Via environment variable
EC_CONFIG=./dev-config.yaml ec post list

# Default behavior unchanged
ec post list  # uses ~/.config/ec/config.yaml
```

## Testing

- [x] All 113 CLI tests pass (6 new)
- [x] All 178 web tests pass
- [x] Linting passes

Closes #1408