### PR TITLE
fix(federation): rewrite request URL for correct protocol behind proxy

### DIFF
--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -91,7 +91,8 @@ export function createFedifyFederation() {
         preferredUsername: identifier,
         name: "Erik Craddock",
         summary: "Personal blog - articles, links, and notes",
-        url: new URL("/", ctx.url),
+        // Use canonicalOrigin to ensure correct protocol behind reverse proxy
+        url: new URL("/", ctx.canonicalOrigin),
         inbox: ctx.getInboxUri(identifier),
         outbox: ctx.getOutboxUri(identifier),
         followers: ctx.getFollowersUri(identifier),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { federation as fedifyMiddleware } from "@fedify/hono";
+import type { Context, Next } from "hono";
 import { pages } from "./routes/pages";
 import { feed } from "./routes/feed";
 import { auth } from "./routes/auth";
@@ -8,18 +8,64 @@ import { api } from "./routes/api";
 import { mediaRoute } from "./routes/media";
 import { federation } from "./federation/setup";
 import { logger } from "./utils/logger";
+import { rewriteUrlForProxy } from "./utils/proxy";
 
 // Detect runtime for static file serving
 const isBun = typeof globalThis.Bun !== "undefined";
 
 const app = new Hono();
 
+/**
+ * Custom Fedify middleware that handles X-Forwarded-Proto header.
+ *
+ * When running behind a reverse proxy (like Caddy), the request URL
+ * comes in as http:// even though the original request was https://.
+ * This middleware rewrites the request URL to use the correct protocol
+ * before passing it to Fedify.
+ */
+function createProxyAwareFedifyMiddleware() {
+  return async (c: Context, next: Next) => {
+    const forwardedProto = c.req.header("x-forwarded-proto");
+    const forwardedHost = c.req.header("x-forwarded-host") || c.req.header("host");
+
+    let request = c.req.raw;
+
+    // Rewrite URL if behind a proxy with HTTPS
+    const rewrittenUrl = rewriteUrlForProxy(request.url, forwardedProto, forwardedHost);
+    if (rewrittenUrl !== request.url) {
+      request = new Request(rewrittenUrl, {
+        method: request.method,
+        headers: request.headers,
+        body: request.body,
+        // @ts-expect-error - duplex is needed for streaming bodies
+        duplex: "half",
+      });
+    }
+
+    // Call Fedify's fetch directly with the (possibly modified) request
+    const response = await federation.fetch(request, {
+      contextData: undefined,
+      onNotFound: async () => {
+        await next();
+        return c.res;
+      },
+      onNotAcceptable: async () => {
+        await next();
+        if (c.res.status !== 404) return c.res;
+        return new Response("Not acceptable", {
+          status: 406,
+          headers: { "Content-Type": "text/plain", Vary: "Accept" },
+        });
+      },
+    });
+
+    return response;
+  };
+}
+
 // Fedify middleware - handles ActivityPub requests
 // Must be before other routes so it can intercept AP requests via content negotiation
-app.use(
-  "*",
-  fedifyMiddleware(federation, () => undefined)
-);
+app.use("*", createProxyAwareFedifyMiddleware());
 
 // Request logging middleware
 app.use("*", async (c, next) => {

--- a/src/utils/__tests__/proxy.test.ts
+++ b/src/utils/__tests__/proxy.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "bun:test";
+import { rewriteUrlForProxy, isHttps } from "../proxy";
+
+describe("proxy utilities", () => {
+  describe("rewriteUrlForProxy", () => {
+    it("rewrites http to https when forwarded proto is https", () => {
+      const result = rewriteUrlForProxy(
+        "http://localhost:5000/users/erik",
+        "https",
+        "erikcraddock.me"
+      );
+      expect(result).toBe("https://erikcraddock.me/users/erik");
+    });
+
+    it("preserves path and query string", () => {
+      const result = rewriteUrlForProxy(
+        "http://localhost:5000/users/erik/outbox?cursor=0",
+        "https",
+        "erikcraddock.me"
+      );
+      expect(result).toBe("https://erikcraddock.me/users/erik/outbox?cursor=0");
+    });
+
+    it("returns original URL when forwardedProto is not https", () => {
+      const original = "http://localhost:5000/users/erik";
+      expect(rewriteUrlForProxy(original, "http", "localhost")).toBe(original);
+      expect(rewriteUrlForProxy(original, undefined, "localhost")).toBe(original);
+    });
+
+    it("returns original URL when forwardedHost is missing", () => {
+      const original = "http://localhost:5000/users/erik";
+      expect(rewriteUrlForProxy(original, "https", undefined)).toBe(original);
+      expect(rewriteUrlForProxy(original, "https", "")).toBe(original);
+    });
+
+    it("returns original URL when already https", () => {
+      const original = "https://erikcraddock.me/users/erik";
+      expect(rewriteUrlForProxy(original, "https", "erikcraddock.me")).toBe(original);
+    });
+
+    it("handles URLs with non-default ports in forwarded host", () => {
+      const result = rewriteUrlForProxy(
+        "http://localhost:5000/users/erik",
+        "https",
+        "erikcraddock.me:8443"
+      );
+      expect(result).toBe("https://erikcraddock.me:8443/users/erik");
+    });
+
+    it("strips default port 443 for https", () => {
+      // URL class automatically removes default ports
+      const result = rewriteUrlForProxy(
+        "http://localhost:5000/users/erik",
+        "https",
+        "erikcraddock.me:443"
+      );
+      expect(result).toBe("https://erikcraddock.me/users/erik");
+    });
+  });
+
+  describe("isHttps", () => {
+    it("returns true for https URLs", () => {
+      expect(isHttps("https://erikcraddock.me")).toBe(true);
+      expect(isHttps("https://erikcraddock.me/users/erik")).toBe(true);
+    });
+
+    it("returns false for http URLs", () => {
+      expect(isHttps("http://localhost:5000")).toBe(false);
+      expect(isHttps("http://erikcraddock.me")).toBe(false);
+    });
+  });
+});

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,0 +1,44 @@
+/**
+ * Utilities for handling reverse proxy headers.
+ *
+ * When running behind a reverse proxy (like Caddy), requests come in with
+ * http:// URLs even though the original request was https://. These utilities
+ * help rewrite URLs to use the correct protocol.
+ */
+
+/**
+ * Rewrite a URL to use the protocol and host from proxy headers.
+ *
+ * @param originalUrl The original request URL (may have wrong protocol)
+ * @param forwardedProto The X-Forwarded-Proto header value (e.g., "https")
+ * @param forwardedHost The X-Forwarded-Host or Host header value
+ * @returns A new URL with the correct protocol, or the original if no rewrite needed
+ */
+export function rewriteUrlForProxy(
+  originalUrl: string,
+  forwardedProto: string | undefined,
+  forwardedHost: string | undefined
+): string {
+  // Only rewrite if we have proxy headers indicating HTTPS
+  if (forwardedProto !== "https" || !forwardedHost) {
+    return originalUrl;
+  }
+
+  const url = new URL(originalUrl);
+
+  // If already https, no need to rewrite
+  if (url.protocol === "https:") {
+    return originalUrl;
+  }
+
+  // Construct new URL with https and forwarded host
+  const newUrl = new URL(url.pathname + url.search, `https://${forwardedHost}`);
+  return newUrl.toString();
+}
+
+/**
+ * Check if a URL uses the HTTPS protocol.
+ */
+export function isHttps(url: string): boolean {
+  return url.startsWith("https://");
+}


### PR DESCRIPTION
## Problem

The outbox pagination URLs were using `http://` instead of `https://`:

```json
{
  "totalItems": 4,
  "first": "http://erikcraddock.me/users/erik/outbox?cursor=0"
}
```

This caused Mastodon to fail when fetching posts, resulting in "No posts here!" on the profile.

## Root Cause

Fedify constructs URLs from the incoming request. Behind a reverse proxy (Caddy), requests arrive with `http://` even when the original was `https://`. The `origin` option in PR #55 fixed actor URLs but not the request-derived URLs used for collection pagination.

## Solution

1. **Proxy-aware Fedify middleware** - Rewrites request URLs based on `X-Forwarded-Proto` and `X-Forwarded-Host` headers before passing to Fedify
2. **Fix actor `url` field** - Use `ctx.canonicalOrigin` instead of `ctx.url`
3. **Add `rewriteUrlForProxy` utility** - Extracted testable function with 9 tests

## Changes

- `src/index.tsx` - Custom proxy-aware Fedify middleware
- `src/federation/setup.ts` - Actor URL uses canonicalOrigin  
- `src/utils/proxy.ts` - URL rewriting utility
- `src/utils/__tests__/proxy.test.ts` - Tests for proxy utilities

## Testing

- 9 new tests for URL rewriting logic
- All 305 tests pass

## Verification

After deploy:
```bash
curl -s -H 'Accept: application/activity+json' https://erikcraddock.me/users/erik/outbox | jq '{first}'
# Should return: "first": "https://erikcraddock.me/users/erik/outbox?cursor=0"

curl -s -H 'Accept: application/activity+json' https://erikcraddock.me/users/erik | jq '{url}'
# Should return: "url": "https://erikcraddock.me/"
```

Fixes #1423