### PR TITLE
feat(federation): add logtape config to capture Fedify logs

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,12 @@ import { mediaRoute } from "./routes/media";
 import { federation } from "./federation/setup";
 import { logger } from "./utils/logger";
 import { rewriteUrlForProxy } from "./utils/proxy";
+import { configureLogtape } from "./utils/logtape-config";
+
+// Configure logtape to capture Fedify's internal logs
+configureLogtape().catch((err) => {
+  logger.error("logtape", "Failed to configure logtape", { error: String(err) });
+});
 
 // Detect runtime for static file serving
 const isBun = typeof globalThis.Bun !== "undefined";

--- a/src/utils/logtape-config.ts
+++ b/src/utils/logtape-config.ts
@@ -1,0 +1,27 @@
+import { configure, getConsoleSink } from "@logtape/logtape";
+
+/**
+ * Configure logtape to capture Fedify's internal logs.
+ * Call this early in app startup.
+ */
+export async function configureLogtape(): Promise<void> {
+  await configure({
+    sinks: {
+      console: getConsoleSink(),
+    },
+    loggers: [
+      {
+        // Capture all Fedify logs
+        category: ["fedify"],
+        lowestLevel: "debug",
+        sinks: ["console"],
+      },
+      {
+        // Also capture logtape meta logs if needed
+        category: ["logtape", "meta"],
+        lowestLevel: "warning",
+        sinks: ["console"],
+      },
+    ],
+  });
+}


### PR DESCRIPTION
## Summary

Configure `@logtape/logtape` to output Fedify's internal debug logs. This enables visibility into signature verification, activity processing, and other internal operations when debugging federation issues.

## Changes

- Add `src/utils/logtape-config.ts` - configures logtape with console sink
- Call `configureLogtape()` at app startup in `src/index.tsx`

## Why

Follow requests from Mastodon appear to be processed (shows 'Unfollow' momentarily) but then revert. Without Fedify's internal logs, we can't see what's happening during signature verification or activity processing.

## Testing

- All existing tests pass (305 tests)
- Manual testing: deploy and verify Fedify logs appear when processing inbox requests

Closes #1425