### PR TITLE
fix(federation): add contextLocalStorage to logtape config

### DIFF
--- a/src/utils/logtape-config.ts
+++ b/src/utils/logtape-config.ts
@@ -1,4 +1,5 @@
 import { configure, getConsoleSink } from "@logtape/logtape";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 /**
  * Configure logtape to capture Fedify's internal logs.
@@ -6,6 +7,7 @@ import { configure, getConsoleSink } from "@logtape/logtape";
  */
 export async function configureLogtape(): Promise<void> {
   await configure({
+    contextLocalStorage: new AsyncLocalStorage(),
     sinks: {
       console: getConsoleSink(),
     },


### PR DESCRIPTION
Fix logtape warning: 'Context-local storage is not configured'

This enables proper async context tracking in Fedify by passing an AsyncLocalStorage instance to logtape's configure().