### PR TITLE
fix: add sharedInbox and assertionMethods to actor config

### DIFF
--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -1,7 +1,7 @@
 import {
   createFederation,
   Person,
-  CryptographicKey,
+  Endpoints,
   Follow,
   Undo,
   isActor,
@@ -81,13 +81,12 @@ export function createFedifyFederation() {
         return null; // Only support the single user
       }
 
-      // Get or create key pair for this actor
-      const keyPair = await getOrCreateKeyPair();
-
-      const actorUri = ctx.getActorUri(identifier);
+      // Get key pairs using Fedify's method - returns keys in proper format
+      // for both HTTP Signatures (publicKey) and Object Integrity Proofs (assertionMethods)
+      const keys = await ctx.getActorKeyPairs(identifier);
 
       return new Person({
-        id: actorUri,
+        id: ctx.getActorUri(identifier),
         preferredUsername: identifier,
         name: "Erik Craddock",
         summary: "Personal blog - articles, links, and notes",
@@ -96,11 +95,12 @@ export function createFedifyFederation() {
         inbox: ctx.getInboxUri(identifier),
         outbox: ctx.getOutboxUri(identifier),
         followers: ctx.getFollowersUri(identifier),
-        publicKey: new CryptographicKey({
-          id: new URL(`${actorUri}#main-key`),
-          owner: actorUri,
-          publicKey: keyPair.publicKey,
-        }),
+        // Shared inbox for efficient batch delivery to multiple followers on same instance
+        endpoints: new Endpoints({ sharedInbox: ctx.getInboxUri() }),
+        // First key's CryptographicKey for HTTP Signatures (legacy, widely supported)
+        publicKey: keys[0].cryptographicKey,
+        // All keys as Multikey for Object Integrity Proofs (modern standard)
+        assertionMethods: keys.map((key) => key.multikey),
       });
     })
     // Set up key pairs dispatcher - provides keys for HTTP signatures


### PR DESCRIPTION
## Summary

Fix missing actor properties that were causing Fedify warnings and potentially breaking federation with Mastodon.

## Changes

- Use `ctx.getActorKeyPairs()` instead of manual `CryptographicKey` construction
- Add `endpoints.sharedInbox` for efficient batch delivery to followers on same instance
- Add `assertionMethods` for Object Integrity Proofs verification (FEP-8b32)
- Remove unused `CryptographicKey` import, add `Endpoints` import

## Problem

Fedify logs showed warnings:
```
WRN fedify·federation·actor ... actor does not have endpoints.sharedInbox property
WRN fedify·federation·actor ... actor does not have assertionMethod property
```

The missing `assertionMethod` may have caused Mastodon to fail signature verification when sending Follow activities.

## Testing

- All existing tests pass
- No database changes required
- Manual verification needed after deploy: Follow from Mastodon should work

## References

- Fedify Actor Dispatcher docs: https://fedify.dev/manual/actor
- Using latest stable: @fedify/fedify@1.10.2

Fixes #1427