### PR TITLE
feat: add ActivityPub production integration tests

### DIFF
--- a/integration-tests/activitypub-production/README.md
+++ b/integration-tests/activitypub-production/README.md
@@ -1,0 +1,39 @@
+# ActivityPub Production Tests
+
+Manual integration tests to verify ActivityPub endpoints on production return correct URLs and data.
+
+## Why These Tests Exist
+
+Federation issues (especially http vs https URLs) can break Mastodon compatibility silently. These tests catch problems before users report them.
+
+## When to Run
+
+- After deploying changes to ActivityPub/federation code
+- After changing proxy or URL configuration
+- When debugging federation issues
+- Periodically as a health check
+
+## Production Details
+
+- **URL**: https://erikcraddock.me
+- **Actor**: @erik@erikcraddock.me
+
+## Test Files
+
+| File                         | Endpoint                | What it tests                    |
+| ---------------------------- | ----------------------- | -------------------------------- |
+| [actor.md](actor.md)         | `/users/erik`           | Actor profile, keys, URLs        |
+| [outbox.md](outbox.md)       | `/users/erik/outbox`    | Outbox collection and pagination |
+| [followers.md](followers.md) | `/users/erik/followers` | Followers collection             |
+
+## Key Verifications
+
+All tests verify that URLs use `https://` (not `http://`). This is critical for federation - Mastodon and other servers will reject or ignore activities with http URLs.
+
+## Running Tests
+
+Execute each test file's commands and verify the expected output. The agent should:
+
+1. Run the curl command
+2. Check each verification point
+3. Report any failures with the actual value received

--- a/integration-tests/activitypub-production/actor.md
+++ b/integration-tests/activitypub-production/actor.md
@@ -1,0 +1,116 @@
+# Test: Actor Endpoint
+
+Verify the Actor endpoint returns correct ActivityPub data with https URLs.
+
+## Endpoint
+
+```
+GET https://erikcraddock.me/users/erik
+Accept: application/activity+json
+```
+
+## Command
+
+```bash
+curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik | jq .
+```
+
+## Expected Response Structure
+
+```json
+{
+  "@context": [...],
+  "type": "Person",
+  "id": "https://erikcraddock.me/users/erik",
+  "inbox": "https://erikcraddock.me/users/erik/inbox",
+  "outbox": "https://erikcraddock.me/users/erik/outbox",
+  "followers": "https://erikcraddock.me/users/erik/followers",
+  "following": "https://erikcraddock.me/users/erik/following",
+  "url": "https://erikcraddock.me/",
+  "preferredUsername": "erik",
+  "name": "...",
+  "publicKey": {
+    "id": "https://erikcraddock.me/users/erik#main-key",
+    "owner": "https://erikcraddock.me/users/erik",
+    "publicKeyPem": "-----BEGIN PUBLIC KEY-----..."
+  }
+}
+```
+
+## Verifications
+
+Run these checks against the response:
+
+### 1. All core URLs use https
+
+```bash
+curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik | jq -r '
+  .id, .inbox, .outbox, .followers, .following, .url
+' | grep -v "^https://" && echo "FAIL: Found non-https URL" || echo "PASS: All core URLs use https"
+```
+
+### 2. Public key URLs use https
+
+```bash
+curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik | jq -r '
+  .publicKey.id, .publicKey.owner
+' | grep -v "^https://" && echo "FAIL: Found non-https key URL" || echo "PASS: Public key URLs use https"
+```
+
+### 3. Type is Person
+
+```bash
+curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik | jq -r '.type' | grep -q "Person" && echo "PASS: Type is Person" || echo "FAIL: Type is not Person"
+```
+
+### 4. preferredUsername is erik
+
+```bash
+curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik | jq -r '.preferredUsername' | grep -q "erik" && echo "PASS: preferredUsername is erik" || echo "FAIL: preferredUsername mismatch"
+```
+
+### 5. Public key is present and valid format
+
+```bash
+curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik | jq -r '.publicKey.publicKeyPem' | grep -q "BEGIN PUBLIC KEY" && echo "PASS: Public key present" || echo "FAIL: Public key missing or invalid"
+```
+
+## Quick All-in-One Check
+
+```bash
+ACTOR=$(curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik)
+
+echo "=== Actor Endpoint Tests ==="
+echo
+
+# Check all URLs are https
+URLS=$(echo "$ACTOR" | jq -r '[.id, .inbox, .outbox, .followers, .following, .url, .publicKey.id, .publicKey.owner] | .[]')
+if echo "$URLS" | grep -qv "^https://"; then
+  echo "❌ FAIL: Found non-https URL"
+  echo "$URLS" | grep -v "^https://"
+else
+  echo "✅ All URLs use https"
+fi
+
+# Check type
+TYPE=$(echo "$ACTOR" | jq -r '.type')
+[ "$TYPE" = "Person" ] && echo "✅ Type is Person" || echo "❌ Type is: $TYPE"
+
+# Check username
+USERNAME=$(echo "$ACTOR" | jq -r '.preferredUsername')
+[ "$USERNAME" = "erik" ] && echo "✅ preferredUsername is erik" || echo "❌ preferredUsername is: $USERNAME"
+
+# Check public key
+echo "$ACTOR" | jq -r '.publicKey.publicKeyPem' | grep -q "BEGIN PUBLIC KEY" && echo "✅ Public key present" || echo "❌ Public key missing"
+
+echo
+echo "=== Done ==="
+```
+
+## Failure Scenarios
+
+If any test fails:
+
+1. **Non-https URLs**: Check proxy configuration, `X-Forwarded-Proto` header handling
+2. **Missing public key**: Check actor key generation on startup
+3. **Wrong type/username**: Check federation configuration

--- a/integration-tests/activitypub-production/followers.md
+++ b/integration-tests/activitypub-production/followers.md
@@ -1,0 +1,140 @@
+# Test: Followers Endpoint
+
+Verify the Followers collection returns correct ActivityPub data with https URLs.
+
+## Endpoint
+
+```
+GET https://erikcraddock.me/users/erik/followers
+Accept: application/activity+json
+```
+
+## Command
+
+```bash
+curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik/followers | jq .
+```
+
+## Expected Response Structure
+
+For a collection (may be paginated if many followers):
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "OrderedCollection",
+  "id": "https://erikcraddock.me/users/erik/followers",
+  "totalItems": <number>,
+  "first": "https://erikcraddock.me/users/erik/followers?cursor=..."
+}
+```
+
+Or for a small collection (items inline):
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "OrderedCollection",
+  "id": "https://erikcraddock.me/users/erik/followers",
+  "totalItems": <number>,
+  "orderedItems": [
+    "https://mastodon.social/users/someone",
+    ...
+  ]
+}
+```
+
+## Verifications
+
+```bash
+FOLLOWERS=$(curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik/followers)
+
+echo "=== Followers Collection Tests ==="
+echo
+
+# Check id is https
+ID=$(echo "$FOLLOWERS" | jq -r '.id')
+[[ "$ID" == https://* ]] && echo "✅ id uses https" || echo "❌ id is: $ID"
+
+# Check type
+TYPE=$(echo "$FOLLOWERS" | jq -r '.type')
+[ "$TYPE" = "OrderedCollection" ] && echo "✅ Type is OrderedCollection" || echo "❌ Type is: $TYPE"
+
+# Check totalItems exists
+TOTAL=$(echo "$FOLLOWERS" | jq -r '.totalItems')
+echo "ℹ️  totalItems: $TOTAL"
+
+# Check first is https (if present - for paginated collections)
+FIRST=$(echo "$FOLLOWERS" | jq -r '.first // empty')
+if [ -n "$FIRST" ]; then
+  [[ "$FIRST" == https://* ]] && echo "✅ first uses https" || echo "❌ first is: $FIRST"
+else
+  echo "ℹ️  first not present (collection may not be paginated)"
+fi
+
+# Check orderedItems URLs are https (if present - for inline items)
+ITEMS=$(echo "$FOLLOWERS" | jq -r '.orderedItems // [] | .[]' 2>/dev/null)
+if [ -n "$ITEMS" ]; then
+  echo "Checking orderedItems URLs..."
+  echo "$ITEMS" | while read url; do
+    [[ "$url" == https://* ]] && echo "  ✅ $url" || echo "  ❌ $url"
+  done
+else
+  echo "ℹ️  orderedItems not present or empty"
+fi
+
+echo
+echo "=== Done ==="
+```
+
+## Quick All-in-One Check
+
+```bash
+echo "=== Followers Endpoint Tests ==="
+echo
+
+FOLLOWERS=$(curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik/followers)
+
+# Check all collection-level URLs
+echo "--- Collection URLs ---"
+echo "$FOLLOWERS" | jq -r '[.id, .first // empty] | .[] | select(. != "")' | while read url; do
+  [[ "$url" == https://* ]] && echo "✅ $url" || echo "❌ $url"
+done
+
+# Stats
+TYPE=$(echo "$FOLLOWERS" | jq -r '.type')
+TOTAL=$(echo "$FOLLOWERS" | jq -r '.totalItems')
+echo
+echo "Type: $TYPE"
+echo "Total followers: $TOTAL"
+
+echo
+echo "=== Done ==="
+```
+
+## Paginated Followers (if applicable)
+
+If the collection is paginated, also test the first page:
+
+```bash
+# Get the first page URL from the collection
+FIRST_URL=$(curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik/followers | jq -r '.first // empty')
+
+if [ -n "$FIRST_URL" ]; then
+  echo "Testing first page: $FIRST_URL"
+  PAGE=$(curl -s -H "Accept: application/activity+json" "$FIRST_URL")
+
+  # Check page URLs
+  echo "$PAGE" | jq -r '[.id, .partOf, .next // empty, .prev // empty] | .[] | select(. != "")' | while read url; do
+    [[ "$url" == https://* ]] && echo "✅ $url" || echo "❌ $url"
+  done
+fi
+```
+
+## Failure Scenarios
+
+If any test fails:
+
+1. **Non-https URLs**: Check proxy configuration, URL rewriting in federation code
+2. **Wrong type**: Should be OrderedCollection
+3. **Missing totalItems**: Check federation followers tracking

--- a/integration-tests/activitypub-production/outbox.md
+++ b/integration-tests/activitypub-production/outbox.md
@@ -1,0 +1,164 @@
+# Test: Outbox Endpoint
+
+Verify the Outbox collection and paginated pages return correct ActivityPub data with https URLs.
+
+## Endpoints
+
+- Collection: `GET https://erikcraddock.me/users/erik/outbox`
+- First page: `GET https://erikcraddock.me/users/erik/outbox?cursor=0`
+
+## Part 1: Outbox Collection
+
+### Command
+
+```bash
+curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik/outbox | jq .
+```
+
+### Expected Response Structure
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "OrderedCollection",
+  "id": "https://erikcraddock.me/users/erik/outbox",
+  "totalItems": <number>,
+  "first": "https://erikcraddock.me/users/erik/outbox?cursor=0"
+}
+```
+
+### Verifications
+
+```bash
+OUTBOX=$(curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik/outbox)
+
+echo "=== Outbox Collection Tests ==="
+echo
+
+# Check id is https
+ID=$(echo "$OUTBOX" | jq -r '.id')
+[[ "$ID" == https://* ]] && echo "✅ id uses https" || echo "❌ id is: $ID"
+
+# Check first is https
+FIRST=$(echo "$OUTBOX" | jq -r '.first')
+[[ "$FIRST" == https://* ]] && echo "✅ first uses https" || echo "❌ first is: $FIRST"
+
+# Check type
+TYPE=$(echo "$OUTBOX" | jq -r '.type')
+[ "$TYPE" = "OrderedCollection" ] && echo "✅ Type is OrderedCollection" || echo "❌ Type is: $TYPE"
+
+# Check totalItems exists and is > 0
+TOTAL=$(echo "$OUTBOX" | jq -r '.totalItems')
+[ "$TOTAL" -gt 0 ] 2>/dev/null && echo "✅ totalItems is $TOTAL" || echo "❌ totalItems is: $TOTAL"
+
+echo
+```
+
+## Part 2: Outbox Page (Paginated)
+
+### Command
+
+```bash
+curl -s -H "Accept: application/activity+json" "https://erikcraddock.me/users/erik/outbox?cursor=0" | jq .
+```
+
+### Expected Response Structure
+
+```json
+{
+  "@context": "https://www.w3.org/ns/activitystreams",
+  "type": "OrderedCollectionPage",
+  "id": "https://erikcraddock.me/users/erik/outbox?cursor=0",
+  "partOf": "https://erikcraddock.me/users/erik/outbox",
+  "next": "https://erikcraddock.me/users/erik/outbox?cursor=<number>",
+  "orderedItems": [
+    {
+      "type": "Create",
+      "id": "https://erikcraddock.me/...",
+      "actor": "https://erikcraddock.me/users/erik",
+      "object": { ... }
+    }
+  ]
+}
+```
+
+### Verifications
+
+```bash
+PAGE=$(curl -s -H "Accept: application/activity+json" "https://erikcraddock.me/users/erik/outbox?cursor=0")
+
+echo "=== Outbox Page Tests ==="
+echo
+
+# Check id is https
+ID=$(echo "$PAGE" | jq -r '.id')
+[[ "$ID" == https://* ]] && echo "✅ id uses https" || echo "❌ id is: $ID"
+
+# Check partOf is https
+PARTOF=$(echo "$PAGE" | jq -r '.partOf')
+[[ "$PARTOF" == https://* ]] && echo "✅ partOf uses https" || echo "❌ partOf is: $PARTOF"
+
+# Check next is https (if present)
+NEXT=$(echo "$PAGE" | jq -r '.next // empty')
+if [ -n "$NEXT" ]; then
+  [[ "$NEXT" == https://* ]] && echo "✅ next uses https" || echo "❌ next is: $NEXT"
+else
+  echo "ℹ️  next not present (may be last page)"
+fi
+
+# Check type
+TYPE=$(echo "$PAGE" | jq -r '.type')
+[ "$TYPE" = "OrderedCollectionPage" ] && echo "✅ Type is OrderedCollectionPage" || echo "❌ Type is: $TYPE"
+
+# Check orderedItems exists and has items
+ITEMS=$(echo "$PAGE" | jq -r '.orderedItems | length')
+[ "$ITEMS" -gt 0 ] 2>/dev/null && echo "✅ orderedItems has $ITEMS items" || echo "❌ orderedItems is empty or missing"
+
+# Check first activity has https URLs
+FIRST_ACTIVITY_ID=$(echo "$PAGE" | jq -r '.orderedItems[0].id // empty')
+if [ -n "$FIRST_ACTIVITY_ID" ]; then
+  [[ "$FIRST_ACTIVITY_ID" == https://* ]] && echo "✅ First activity id uses https" || echo "❌ First activity id is: $FIRST_ACTIVITY_ID"
+
+  ACTOR=$(echo "$PAGE" | jq -r '.orderedItems[0].actor // empty')
+  [[ "$ACTOR" == https://* ]] && echo "✅ First activity actor uses https" || echo "❌ First activity actor is: $ACTOR"
+fi
+
+echo
+```
+
+## Quick All-in-One Check
+
+```bash
+echo "=== Outbox Endpoint Tests ==="
+echo
+
+# Collection
+OUTBOX=$(curl -s -H "Accept: application/activity+json" https://erikcraddock.me/users/erik/outbox)
+echo "--- Collection ---"
+echo "$OUTBOX" | jq -r '[.id, .first] | .[]' | while read url; do
+  [[ "$url" == https://* ]] && echo "✅ $url" || echo "❌ $url"
+done
+TOTAL=$(echo "$OUTBOX" | jq -r '.totalItems')
+echo "totalItems: $TOTAL"
+echo
+
+# Page
+PAGE=$(curl -s -H "Accept: application/activity+json" "https://erikcraddock.me/users/erik/outbox?cursor=0")
+echo "--- Page (cursor=0) ---"
+echo "$PAGE" | jq -r '[.id, .partOf, .next // empty] | .[] | select(. != "")' | while read url; do
+  [[ "$url" == https://* ]] && echo "✅ $url" || echo "❌ $url"
+done
+ITEMS=$(echo "$PAGE" | jq -r '.orderedItems | length')
+echo "orderedItems count: $ITEMS"
+
+echo
+echo "=== Done ==="
+```
+
+## Failure Scenarios
+
+If any test fails:
+
+1. **Non-https URLs**: Check proxy configuration, URL rewriting in federation code
+2. **Empty orderedItems**: Check if posts are published and federation is creating activities
+3. **totalItems is 0**: No published posts, or federation not tracking them


### PR DESCRIPTION
## Summary

Add manual integration tests for verifying ActivityPub endpoints on production return correct https URLs. These are agent-driven tests (markdown prompts) that run manually, not in CI.

## What's Added

- `integration-tests/activitypub-production/README.md` - Overview and when to run
- `integration-tests/activitypub-production/actor.md` - Tests for /users/erik
- `integration-tests/activitypub-production/outbox.md` - Tests for outbox collection + pages
- `integration-tests/activitypub-production/followers.md` - Tests for followers collection

## Why

Federation issues (especially http vs https URLs) can break Mastodon compatibility silently. These tests catch problems before users report them.

## How to Use

Run the curl commands in each file against production after deploying federation changes.

Task: #1424