### PR TITLE
fix: use Ed25519 keys for ActivityPub signatures

### DIFF
--- a/src/federation/keys.ts
+++ b/src/federation/keys.ts
@@ -27,7 +27,7 @@ export async function getOrCreateKeyPair(): Promise<KeyPair> {
 
   // Generate new key pair
   logger.info("federation", "Generating new actor key pair");
-  const keyPair = await generateCryptoKeyPair("RSASSA-PKCS1-v1_5");
+  const keyPair = await generateCryptoKeyPair("Ed25519");
 
   // Store in database as JWK
   const privateJwk = await exportJwk(keyPair.privateKey);


### PR DESCRIPTION
## Summary

Switch from RSA to Ed25519 keys for ActivityPub signatures. Ed25519 is required for Object Integrity Proofs - Mastodon rejects Accept activities without proofs.

## Changes

- Change key generation from `RSASSA-PKCS1-v1_5` to `Ed25519`

## Post-deploy action required

Delete existing RSA key from database to trigger Ed25519 key regeneration:
```sql
DELETE FROM actor_keys WHERE id = 1;
```

Task: #1448