### PR TITLE
fix: use both RSA and Ed25519 keys for federation

### DIFF
--- a/src/federation/keys.ts
+++ b/src/federation/keys.ts
@@ -9,25 +9,29 @@ interface KeyPair {
   publicKey: CryptoKey;
 }
 
+// Key IDs in database
+const RSA_KEY_ID = 1; // For HTTP Signatures (legacy, widely supported)
+const ED25519_KEY_ID = 2; // For Object Integrity Proofs (modern standard)
+
 /**
- * Get or create the actor key pair.
- * Since this is a single-user blog, we only need one key pair.
- * The key pair is stored in the database in JWK format.
+ * Get or create a key pair of the specified algorithm.
  */
-export async function getOrCreateKeyPair(): Promise<KeyPair> {
-  // Try to load existing key pair
-  const existing = db.select().from(actorKeys).where(eq(actorKeys.id, 1)).get();
+async function getOrCreateKeyPairByAlgorithm(
+  id: number,
+  algorithm: "RSASSA-PKCS1-v1_5" | "Ed25519"
+): Promise<KeyPair> {
+  const existing = db.select().from(actorKeys).where(eq(actorKeys.id, id)).get();
 
   if (existing) {
-    logger.debug("federation", "Loading existing actor key pair");
+    logger.debug("federation", `Loading existing ${algorithm} key pair`);
     const privateKey = await importJwk(JSON.parse(existing.private_key), "private");
     const publicKey = await importJwk(JSON.parse(existing.public_key), "public");
     return { privateKey, publicKey };
   }
 
   // Generate new key pair
-  logger.info("federation", "Generating new actor key pair");
-  const keyPair = await generateCryptoKeyPair("Ed25519");
+  logger.info("federation", `Generating new ${algorithm} key pair`);
+  const keyPair = await generateCryptoKeyPair(algorithm);
 
   // Store in database as JWK
   const privateJwk = await exportJwk(keyPair.privateKey);
@@ -35,22 +39,41 @@ export async function getOrCreateKeyPair(): Promise<KeyPair> {
 
   db.insert(actorKeys)
     .values({
-      id: 1,
+      id,
       private_key: JSON.stringify(privateJwk),
       public_key: JSON.stringify(publicJwk),
       created_at: new Date(),
     })
     .run();
 
-  logger.info("federation", "Actor key pair generated and stored");
+  logger.info("federation", `${algorithm} key pair generated and stored`);
   return keyPair;
 }
 
 /**
- * Get the actor key pair if it exists, or null if not yet generated.
+ * Get or create all actor key pairs.
+ * Returns both RSA (for HTTP Signatures) and Ed25519 (for Object Integrity Proofs).
+ * RSA key is returned first as it's used for the legacy publicKey field.
+ */
+export async function getOrCreateKeyPairs(): Promise<KeyPair[]> {
+  const rsaKey = await getOrCreateKeyPairByAlgorithm(RSA_KEY_ID, "RSASSA-PKCS1-v1_5");
+  const ed25519Key = await getOrCreateKeyPairByAlgorithm(ED25519_KEY_ID, "Ed25519");
+  return [rsaKey, ed25519Key];
+}
+
+/**
+ * Get or create the RSA key pair (for backwards compatibility).
+ * @deprecated Use getOrCreateKeyPairs() instead
+ */
+export async function getOrCreateKeyPair(): Promise<KeyPair> {
+  return getOrCreateKeyPairByAlgorithm(RSA_KEY_ID, "RSASSA-PKCS1-v1_5");
+}
+
+/**
+ * Get the RSA key pair if it exists, or null if not yet generated.
  */
 export async function getKeyPair(): Promise<KeyPair | null> {
-  const existing = db.select().from(actorKeys).where(eq(actorKeys.id, 1)).get();
+  const existing = db.select().from(actorKeys).where(eq(actorKeys.id, RSA_KEY_ID)).get();
 
   if (!existing) {
     return null;

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -9,7 +9,7 @@ import {
   InProcessMessageQueue,
   type KvStore,
 } from "@fedify/fedify";
-import { getOrCreateKeyPair } from "./keys";
+import { getOrCreateKeyPairs } from "./keys";
 import { addFollower, removeFollower, getAllFollowers } from "./followers";
 import { getOutboxActivities, getPublishedPostCount } from "./outbox";
 import { getOrigin } from "./utils";
@@ -106,14 +106,15 @@ export function createFedifyFederation() {
         assertionMethods: keys.map((key) => key.multikey),
       });
     })
-    // Set up key pairs dispatcher - provides keys for HTTP signatures
+    // Set up key pairs dispatcher - provides keys for HTTP signatures and proofs
+    // Returns RSA key first (for HTTP Signatures) and Ed25519 (for Object Integrity Proofs)
     .setKeyPairsDispatcher(async (_ctx, identifier) => {
       if (identifier !== "erik") {
         return [];
       }
 
-      const keyPair = await getOrCreateKeyPair();
-      return [keyPair];
+      const keyPairs = await getOrCreateKeyPairs();
+      return keyPairs;
     });
 
   // Set up inbox listeners - handles incoming activities


### PR DESCRIPTION
## Problem

Fedify's HTTP Signatures only support RSA keys, but Object Integrity Proofs require Ed25519. We were only generating Ed25519, so requests weren't being signed.

## Solution

Generate and store both key types:
- RSA (id=1) for HTTP Signatures  
- Ed25519 (id=2) for Object Integrity Proofs

Both are returned from setKeyPairsDispatcher.

Task: #1448