### PR TITLE
feat: add public health check endpoint

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { Context, Next } from "hono";
 import { pages } from "./routes/pages";
 import { feed } from "./routes/feed";
+import { health } from "./routes/health";
 import { auth } from "./routes/auth";
 import { admin } from "./routes/admin";
 import { api } from "./routes/api";
@@ -116,6 +117,7 @@ if (isBun) {
 // Mount routes
 app.route("/", pages);
 app.route("/", feed);
+app.route("/", health);
 app.route("/", auth);
 app.route("/admin", admin);
 app.route("/api", api);

--- a/src/routes/__tests__/health.test.ts
+++ b/src/routes/__tests__/health.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import { health } from "../health";
+
+const app = new Hono();
+app.route("/", health);
+
+describe("GET /health", () => {
+  it("returns 200 OK", async () => {
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns JSON with status ok", async () => {
+    const res = await app.request("/health");
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+  });
+
+  it("returns version string", async () => {
+    const res = await app.request("/health");
+    const body = await res.json();
+    expect(typeof body.version).toBe("string");
+    expect(body.version).not.toBe("");
+  });
+
+  it("returns ISO 8601 timestamp", async () => {
+    const res = await app.request("/health");
+    const body = await res.json();
+    expect(typeof body.timestamp).toBe("string");
+    // Verify it's a valid ISO date
+    const date = new Date(body.timestamp);
+    expect(date.toISOString()).toBe(body.timestamp);
+  });
+
+  it("returns correct content-type", async () => {
+    const res = await app.request("/health");
+    expect(res.headers.get("content-type")).toContain("application/json");
+  });
+});

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// Read version from package.json at startup
+let version = "unknown";
+try {
+  const packageJson = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf-8"));
+  version = packageJson.version || "unknown";
+} catch {
+  // Fallback if package.json can't be read
+}
+
+const health = new Hono();
+
+/**
+ * Public health check endpoint.
+ * Returns app status, version, and current timestamp.
+ */
+health.get("/health", (c) => {
+  return c.json({
+    status: "ok",
+    version,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+export { health };


### PR DESCRIPTION
## Summary

Add public health check endpoint at `GET /health`.

## Response

```json
{
  "status": "ok",
  "version": "0.1.0",
  "timestamp": "2026-02-01T00:00:00.000Z"
}
```

## Features

- No authentication required
- Version from package.json
- ISO 8601 timestamp
- Useful for monitoring, load balancers, deployment verification

Fixes #1422