### PR TITLE
feat: send Delete/Update activities for federated posts

### DIFF
--- a/src/federation/publish.ts
+++ b/src/federation/publish.ts
@@ -1,4 +1,4 @@
-import { Create, Note, Article, Image } from "@fedify/fedify";
+import { Create, Delete, Update, Note, Article, Image } from "@fedify/fedify";
 import { eq } from "drizzle-orm";
 import { db, posts, media } from "@/db";
 import { federation } from "./setup";
@@ -176,6 +176,120 @@ export async function federatePost(postId: number): Promise<boolean> {
     return true;
   } catch (error) {
     logger.error("federation", `Failed to send Create activity for post ${postId}`, { error });
+    return false;
+  }
+}
+
+/**
+ * Send a Delete activity for a post to all followers.
+ *
+ * Should be called when a previously published post is deleted.
+ * Remote servers should remove their cached copy.
+ *
+ * @param postId The ID of the deleted post
+ * @returns true if activity was sent, false if no followers
+ */
+export async function sendDeleteActivity(postId: number): Promise<boolean> {
+  const followers = getAllFollowers();
+  if (followers.length === 0) {
+    logger.debug("federation", `No followers to send Delete for post ${postId}`);
+    return true;
+  }
+
+  const ctx = federation.createContext(new URL(baseUrl), undefined);
+  const actorUri = ctx.getActorUri("erik");
+
+  // The object URI that was deleted
+  const objectUri = new URL(`/posts/${postId}`, baseUrl);
+  const activityUri = new URL(`/posts/${postId}#delete`, baseUrl);
+
+  const activity = new Delete({
+    id: activityUri,
+    actor: actorUri,
+    object: objectUri,
+  });
+
+  logger.info(
+    "federation",
+    `Sending Delete activity for post ${postId} to ${followers.length} followers`
+  );
+
+  try {
+    await ctx.sendActivity({ identifier: "erik" }, "followers", activity, {
+      preferSharedInbox: true,
+    });
+
+    logger.info("federation", `Successfully queued Delete activity for post ${postId}`);
+    return true;
+  } catch (error) {
+    logger.error("federation", `Failed to send Delete activity for post ${postId}`, { error });
+    return false;
+  }
+}
+
+/**
+ * Send an Update activity for a post to all followers.
+ *
+ * Should be called when a published post is edited.
+ * Remote servers should update their cached copy.
+ *
+ * @param postId The ID of the updated post
+ * @returns true if activity was sent, false if post not found or no followers
+ */
+export async function sendUpdateActivity(postId: number): Promise<boolean> {
+  // Get the post with banner info
+  const post = db
+    .select({
+      id: posts.id,
+      type: posts.type,
+      title: posts.title,
+      content: posts.content,
+      excerpt: posts.excerpt,
+      published_at: posts.published_at,
+      banner_image_id: posts.banner_image_id,
+    })
+    .from(posts)
+    .where(eq(posts.id, postId))
+    .get();
+
+  if (!post || !post.published_at) {
+    logger.warn("federation", `Cannot send Update for post ${postId}: not found or not published`);
+    return false;
+  }
+
+  const followers = getAllFollowers();
+  if (followers.length === 0) {
+    logger.debug("federation", `No followers to send Update for post ${postId}`);
+    return true;
+  }
+
+  const ctx = federation.createContext(new URL(baseUrl), undefined);
+  const actorUri = ctx.getActorUri("erik");
+  const followersUri = ctx.getFollowersUri("erik");
+
+  const activityUri = new URL(`/posts/${postId}#update-${Date.now()}`, baseUrl);
+  const object = postToObjectWithAttachment(post as PostWithBanner, actorUri, followersUri);
+
+  const activity = new Update({
+    id: activityUri,
+    actor: actorUri,
+    object: object,
+  });
+
+  logger.info(
+    "federation",
+    `Sending Update activity for post ${postId} to ${followers.length} followers`
+  );
+
+  try {
+    await ctx.sendActivity({ identifier: "erik" }, "followers", activity, {
+      preferSharedInbox: true,
+    });
+
+    logger.info("federation", `Successfully queued Update activity for post ${postId}`);
+    return true;
+  } catch (error) {
+    logger.error("federation", `Failed to send Update activity for post ${postId}`, { error });
     return false;
   }
 }

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -22,7 +22,7 @@ import {
   deleteSource,
 } from "@/services/sources";
 import { listTags } from "@/services/tags";
-import { federatePost } from "@/federation/publish";
+import { federatePost, sendDeleteActivity, sendUpdateActivity } from "@/federation/publish";
 
 export const api = new Hono();
 
@@ -235,6 +235,11 @@ api.put("/posts/:id", async (c) => {
       return c.json({ error: "Post not found" }, 404);
     }
 
+    // Send Update activity if post is published
+    if (post.published_at) {
+      await sendUpdateActivity(post.id);
+    }
+
     return c.json({ data: post });
   } catch (error) {
     return c.json({ error: String(error) }, 400);
@@ -244,17 +249,26 @@ api.put("/posts/:id", async (c) => {
 /**
  * DELETE /api/posts/:id - Delete post
  */
-api.delete("/posts/:id", (c) => {
+api.delete("/posts/:id", async (c) => {
   const id = parseInt(c.req.param("id"), 10);
 
   if (isNaN(id)) {
     return c.json({ error: "Invalid post ID" }, 400);
   }
 
+  // Check if post was published before deleting
+  const existingPost = getPost(id);
+  const wasPublished = existingPost?.published_at;
+
   const deleted = deletePost(id);
 
   if (!deleted) {
     return c.json({ error: "Post not found" }, 404);
+  }
+
+  // Send Delete activity if post was previously published
+  if (wasPublished) {
+    await sendDeleteActivity(id);
   }
 
   return c.body(null, 204);
@@ -369,6 +383,11 @@ api.put("/posts/by-slug/:slug", async (c) => {
       return c.json({ error: "Post not found" }, 404);
     }
 
+    // Send Update activity if post is published
+    if (post.published_at) {
+      await sendUpdateActivity(post.id);
+    }
+
     return c.json({ data: post });
   } catch (error) {
     return c.json({ error: String(error) }, 400);
@@ -378,7 +397,7 @@ api.put("/posts/by-slug/:slug", async (c) => {
 /**
  * DELETE /api/posts/by-slug/:slug - Delete post by slug
  */
-api.delete("/posts/by-slug/:slug", (c) => {
+api.delete("/posts/by-slug/:slug", async (c) => {
   const slug = c.req.param("slug");
 
   const existingPost = getPostBySlug(slug);
@@ -387,10 +406,19 @@ api.delete("/posts/by-slug/:slug", (c) => {
     return c.json({ error: "Post not found" }, 404);
   }
 
-  const deleted = deletePost(existingPost.id);
+  // Remember if post was published for federation
+  const wasPublished = !!existingPost.published_at;
+  const postId = existingPost.id;
+
+  const deleted = deletePost(postId);
 
   if (!deleted) {
     return c.json({ error: "Post not found" }, 404);
+  }
+
+  // Send Delete activity if post was previously published
+  if (wasPublished) {
+    await sendDeleteActivity(postId);
   }
 
   return c.body(null, 204);


### PR DESCRIPTION
## Problem

When posts are deleted or edited locally, the federated copies on remote servers (Mastodon, etc.) remain unchanged. We only send `Create` activities on publish.

## Solution

- **Delete activity**: When a previously published post is deleted, send a `Delete` activity to all followers
- **Update activity**: When a published post is edited, send an `Update` activity with the updated content

## Implementation

- Added `sendDeleteActivity(postId)` function in `publish.ts`
- Added `sendUpdateActivity(postId)` function in `publish.ts`
- Called from both `PUT /api/posts/:id` and `PUT /api/posts/by-slug/:slug`
- Called from both `DELETE /api/posts/:id` and `DELETE /api/posts/by-slug/:slug`
- Only sends if post was previously published (draft posts ignored)

## Notes

- These are "best effort" - remote servers may not honor them
- Uses Fedify's built-in delivery with shared inbox optimization

Fixes #1456