### PR TITLE
fix: update package.json version on release

### DIFF
--- a/.pi/skills/web-release/SKILL.md
+++ b/.pi/skills/web-release/SKILL.md
@@ -65,12 +65,25 @@ Create a new web release tag (`web-v*`) based on conventional commits since the 
    - Alternative versions if applicable, such as web-v2.0.0 - Major release or web-v1.1.1 - Patch release
    - Cancel - Do not create a release
 
-7. **Create the tag** (if user approves):
-   - Create an annotated tag: `git tag -a <new-version> -m "Release <new-version>"`
-   - Ask if the user wants to push the tag to origin
+7. **Update package.json** (if user approves):
+   - Extract the semver from the tag (e.g., `web-v1.2.0` → `1.2.0`)
+   - Update the `version` field in `package.json` using jq or sed:
+     ```bash
+     # Using jq
+     jq --arg v "1.2.0" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+     ```
+   - Commit the version bump:
+     ```bash
+     git add package.json
+     git commit -m "chore: bump version to 1.2.0"
+     ```
 
-8. **Push the tag** (if requested):
-   - Run `git push origin <new-version>` to push the tag
+8. **Create the tag**:
+   - Create an annotated tag on the version bump commit: `git tag -a <new-version> -m "Release <new-version>"`
+   - Ask if the user wants to push the commit and tag to origin
+
+9. **Push the commit and tag** (if requested):
+   - Push both together: `git push origin main --follow-tags`
    - Confirm success to the user
    - Note: Pushing the tag will trigger the deploy workflow which builds and pushes the Docker image to Docker Hub
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erikcraddock.me",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "Personal website and blog that also acts as an activitypub actor",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes the health check returning wrong version (0.1.0 instead of 0.5.0).

## Changes

1. **Updated web-release skill** to bump `package.json` before creating tags:
   - Extract semver from tag name
   - Update `package.json` with new version
   - Commit the version bump
   - Create annotated tag on that commit
   - Push both commit and tag with `--follow-tags`

2. **Fixed current version drift** by updating `package.json` to 0.5.0

## Testing

- [x] All existing tests pass
- [x] Verified skill instructions are clear and complete

## Related

Fixes #1467