### PR TITLE
feat: add articles page with pagination

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,67 +1,19 @@
 # Example Content
 
-This folder contains example articles and images for testing and development.
+Example articles and images for testing.
+
+## Seed Dev Database
+
+```bash
+./examples/seed-articles.sh
+```
+
+Requires dev server running (`make dev`) and `cli/dev-config.yaml` configured.
 
 ## Articles
 
-The `articles/` folder contains 7 sample articles in the markdown format expected by the `ec` CLI.
-
-### Format
-
-```yaml
----
-title: Article Title
-slug: article-slug
-type: article
-excerpt: A short summary of the article.
-tags: [tag1, tag2, tag3]
-banner: ./images/banner-image.jpg
----
-# Article content in markdown...
-```
-
-### Creating Articles
-
-To create these articles via the CLI:
-
-```bash
-# First, upload the banner image
-ec image upload examples/images/home-studio.jpg --key articles/home-studio.jpg
-
-# Then create the article (update banner to use the uploaded image URL)
-ec post create --file examples/articles/building-a-home-studio.md
-```
-
-Or manually update each article's `banner` field to point to the uploaded image URL before creating.
+7 sample articles in `articles/` covering writing, coding, and music topics.
 
 ## Images
 
-The `images/` folder contains banner images (1200x630px) for each article:
-
-- `home-studio.jpg` - Building a Home Studio
-- `typescript.jpg` - Why I Switched to TypeScript
-- `morning-pages.jpg` - The Art of Morning Pages
-- `guitar.jpg` - Learning Guitar at 40
-- `boring-tech.jpg` - In Defense of Boring Technology
-- `songwriting.jpg` - Writing Your First Song
-- `digital-garden.jpg` - Growing a Digital Garden
-
-## Topics
-
-The example articles cover the three themes of the site:
-
-**Writing:**
-
-- The Art of Morning Pages
-- Growing a Digital Garden
-
-**Coding:**
-
-- Why I Finally Switched to TypeScript
-- In Defense of Boring Technology
-
-**Music:**
-
-- Building a Home Studio on a Budget
-- Learning Guitar at 40
-- Writing Your First Song
+Banner images (1200x630px) in `images/` for each article.

--- a/examples/seed-articles.sh
+++ b/examples/seed-articles.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Seed the dev database with example articles.
+# Requires: dev server running (make dev) and cli/dev-config.yaml configured.
+#
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+EC="bun cli/src/index.ts --config cli/dev-config.yaml"
+
+echo "Creating articles..."
+
+for article in examples/articles/*.md; do
+  slug=$(basename "$article" .md)
+  echo "  $slug"
+  $EC post create --file "$article" 2>/dev/null || true
+done
+
+echo ""
+echo "Publishing articles..."
+
+for article in examples/articles/*.md; do
+  slug=$(basename "$article" .md)
+  $EC post publish "$slug" 2>/dev/null || true
+done
+
+echo ""
+echo "Done."

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -144,11 +144,12 @@ describe("pages routes", () => {
       expect(html).toContain("dark:border-gray-700");
     });
 
-    it("includes navigation link to Sources", async () => {
+    it("includes navigation links to Articles and Sources", async () => {
       const app = getApp();
       const res = await app.request("/");
       const html = await res.text();
 
+      expect(html).toContain('href="/articles"');
       expect(html).toContain('href="/sources"');
       // About link removed from nav but page still accessible
       expect(html).not.toContain('href="/about"');
@@ -222,6 +223,72 @@ describe("pages routes", () => {
 
       expect(html).toContain("dark:bg-gray-900");
       expect(html).toContain("dark:text-gray-100");
+    });
+  });
+
+  describe("GET /articles", () => {
+    it("returns 200 and displays articles page", async () => {
+      const app = getApp();
+      const res = await app.request("/articles");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("<h1");
+      expect(html).toContain("Articles");
+    });
+
+    it("displays article posts with links to post pages", async () => {
+      const app = getApp();
+      const res = await app.request("/articles");
+      const html = await res.text();
+
+      // Should contain article
+      expect(html).toContain("Test Post");
+      expect(html).toContain('href="/posts/test-post"');
+    });
+
+    it("only shows articles, not links or notes", async () => {
+      const app = getApp();
+      const res = await app.request("/articles");
+      const html = await res.text();
+
+      expect(html).toContain("Test Post"); // article
+      expect(html).not.toContain("Test Link Post"); // link
+      expect(html).not.toContain("Short note content"); // note
+    });
+
+    it("includes dark mode classes", async () => {
+      const app = getApp();
+      const res = await app.request("/articles");
+      const html = await res.text();
+
+      expect(html).toContain("dark:bg-gray-900");
+      expect(html).toContain("dark:text-gray-100");
+    });
+
+    it("redirects invalid page numbers to /articles", async () => {
+      const app = getApp();
+      const res = await app.request("/articles?page=0");
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/articles");
+    });
+
+    it("redirects negative page numbers to /articles", async () => {
+      const app = getApp();
+      const res = await app.request("/articles?page=-1");
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/articles");
+    });
+
+    it("redirects non-numeric page to /articles", async () => {
+      const app = getApp();
+      const res = await app.request("/articles?page=abc");
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/articles");
     });
   });
 

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -234,6 +234,68 @@ function ArticleCardsSection({
   );
 }
 
+/** Pagination component */
+function Pagination({
+  currentPage,
+  totalPages,
+  baseUrl,
+}: {
+  currentPage: number;
+  totalPages: number;
+  baseUrl: string;
+}) {
+  const prevUrl = currentPage > 1 ? `${baseUrl}?page=${currentPage - 1}` : null;
+  const nextUrl = currentPage < totalPages ? `${baseUrl}?page=${currentPage + 1}` : null;
+
+  // Clean up URL for page 1 (no query param needed)
+  const cleanPrevUrl = currentPage === 2 ? baseUrl : prevUrl;
+
+  return (
+    <div class="flex flex-col items-center gap-4 mt-8">
+      {/* Page indicator */}
+      <p class="text-gray-600 dark:text-gray-400">
+        Page {currentPage} of {totalPages}
+      </p>
+
+      {/* Navigation */}
+      <div class="flex gap-4">
+        {cleanPrevUrl ? (
+          <a
+            href={cleanPrevUrl}
+            class="inline-flex items-center gap-2 px-4 py-2 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-lg transition-colors"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            Previous
+          </a>
+        ) : null}
+        {nextUrl ? (
+          <a
+            href={nextUrl}
+            class="inline-flex items-center gap-2 px-4 py-2 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-lg transition-colors"
+          >
+            Next
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          </a>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 /** Reusable post card component */
 function PostCard({ post }: { post: PostWithSource }) {
   const isLink = post.type === "link";
@@ -390,6 +452,102 @@ export function createPagesRoutes(db: Database): Hono {
       <Layout title="Home | erikcraddock.me">
         <HeroSection />
         <ArticleCardsSection articles={recentArticles} getBannerUrl={getBannerUrl} />
+      </Layout>
+    );
+  });
+
+  // Articles page with pagination
+  const ARTICLES_PER_PAGE = 12;
+
+  pages.get("/articles", (c) => {
+    // Get page number from query string
+    const pageParam = c.req.query("page");
+    const page = pageParam ? parseInt(pageParam, 10) : 1;
+
+    // Validate page number
+    if (isNaN(page) || page < 1) {
+      return c.redirect("/articles");
+    }
+
+    // Count total articles
+    const countResult = db
+      .select({ count: posts.id })
+      .from(posts)
+      .where(and(eq(posts.type, "article"), isNotNull(posts.published_at)))
+      .all();
+    const totalArticles = countResult.length;
+    const totalPages = Math.ceil(totalArticles / ARTICLES_PER_PAGE);
+
+    // Handle no articles
+    if (totalArticles === 0) {
+      return c.html(
+        <Layout title="Articles | erikcraddock.me">
+          <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">Articles</h1>
+          <p class="text-gray-600 dark:text-gray-400">No articles yet.</p>
+        </Layout>
+      );
+    }
+
+    // Handle page out of range
+    if (page > totalPages) {
+      return c.redirect(`/articles?page=${totalPages}`);
+    }
+
+    // Fetch articles for current page
+    const offset = (page - 1) * ARTICLES_PER_PAGE;
+    const pageArticles = db
+      .select()
+      .from(posts)
+      .where(and(eq(posts.type, "article"), isNotNull(posts.published_at)))
+      .orderBy(desc(posts.published_at))
+      .limit(ARTICLES_PER_PAGE)
+      .offset(offset)
+      .all();
+
+    // Get banner URLs
+    const bannerIds = pageArticles
+      .map((a) => a.banner_image_id)
+      .filter((id): id is number => id !== null);
+
+    const bannerMedia =
+      bannerIds.length > 0
+        ? db
+            .select()
+            .from(media)
+            .where(isNotNull(media.id))
+            .all()
+            .filter((m) => bannerIds.includes(m.id))
+        : [];
+
+    const bannerUrlMap = new Map<number, string>();
+    for (const m of bannerMedia) {
+      bannerUrlMap.set(m.id, mediaUrl(m.s3_key));
+    }
+
+    const getBannerUrl = (id: number) => bannerUrlMap.get(id) || null;
+
+    return c.html(
+      <Layout title={`Articles${page > 1 ? ` - Page ${page}` : ""} | erikcraddock.me`}>
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">Articles</h1>
+
+        {/* Pagination indicator at top */}
+        {totalPages > 1 && (
+          <p class="text-center text-gray-600 dark:text-gray-400 mb-6">
+            Page {page} of {totalPages}
+          </p>
+        )}
+
+        {/* Article cards grid */}
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {pageArticles.map((article) => (
+            <ArticleCard key={article.id} post={article} getBannerUrl={getBannerUrl} />
+          ))}
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <Pagination currentPage={page} totalPages={totalPages} baseUrl="/articles" />
+        )}
       </Layout>
     );
   });

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -69,6 +69,12 @@ export function Layout({ title, children, ogImage, description }: LayoutProps) {
             </a>
             <div class="flex items-center gap-6">
               <a
+                href="/articles"
+                class="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+              >
+                Articles
+              </a>
+              <a
                 href="/sources"
                 class="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
               >


### PR DESCRIPTION
## Summary

Adds a dedicated articles page at `/articles` with pagination support.

## Changes

### New Route
- `/articles` - paginated list of all articles
- 12 articles per page
- URL structure: `/articles`, `/articles?page=2`, etc.

### Pagination Component
- "Page X of Y" indicator
- Previous/Next navigation buttons
- Clean URL for page 1 (no `?page=1`)

### Navigation
- Added "Articles" link to main navigation (before Sources)

### Edge Cases
- Invalid page numbers redirect to `/articles`
- Page exceeding total redirects to last page
- Empty state shows "No articles yet"

## Testing

- [x] All 318 tests pass (7 new tests added)
- [x] Visual verification in dark mode
- [x] Visual verification in light mode
- [x] Navigation link visible
- [x] Pagination component renders correctly

Closes #1471