### PR TITLE
feat: add feed page with all post types

### DIFF
--- a/cli/src/commands/post/create.ts
+++ b/cli/src/commands/post/create.ts
@@ -14,6 +14,7 @@ interface CreateOptions {
   excerpt?: string;
   tags?: string[];
   type?: string;
+  url?: string;
 }
 
 function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolean } {
@@ -59,6 +60,10 @@ function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolea
       options.type = args[++i];
     } else if (arg.startsWith("--type=")) {
       options.type = arg.split("=").slice(1).join("=");
+    } else if (arg === "--url" && args[i + 1]) {
+      options.url = args[++i];
+    } else if (arg.startsWith("--url=")) {
+      options.url = arg.split("=").slice(1).join("=");
     }
 
     i++;
@@ -81,11 +86,12 @@ Options:
   --excerpt <text>    Short excerpt/summary
   --tags <tags>       Comma-separated list of tags
   --type <type>       Post type: article, link, note (default: article)
+  --url <url>         URL for link posts (required for links)
   --json              Output as JSON
   --help, -h          Show this help message
 
 File-based creation:
-  When using --file, frontmatter fields (title, slug, tags, excerpt, type, banner)
+  When using --file, frontmatter fields (title, slug, tags, excerpt, type, banner, url)
   are extracted from the markdown file. Command-line options override frontmatter.
 
   Local images (./path.jpg) are uploaded automatically.
@@ -124,6 +130,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
   let excerpt = options.excerpt;
   let tags = options.tags;
   let type = options.type;
+  let url = options.url;
   let banner: string | undefined;
   let bannerImageId: number | undefined;
 
@@ -145,6 +152,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     slug = options.slug ?? frontmatter.slug;
     excerpt = options.excerpt ?? frontmatter.excerpt;
     type = options.type ?? frontmatter.type;
+    url = options.url ?? frontmatter.url;
     banner = frontmatter.banner;
 
     // Merge tags: CLI tags override, or use frontmatter
@@ -208,6 +216,12 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     process.exit(1);
   }
 
+  if (postType === "link" && !url) {
+    console.error("❌ Links require a URL.");
+    console.error("   Use --url option or add 'url:' to frontmatter.");
+    process.exit(1);
+  }
+
   const result = await client.createPost({
     type: postType,
     slug,
@@ -215,6 +229,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     content,
     excerpt,
     tags,
+    url,
     banner_image_id: bannerImageId,
   });
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Example Content
 
-Example articles and images for testing.
+Example content for testing: articles, linkblogs, and notes.
 
 ## Seed Dev Database
 
@@ -10,10 +10,11 @@ Example articles and images for testing.
 
 Requires dev server running (`make dev`) and `cli/dev-config.yaml` configured.
 
-## Articles
+## Content
 
-7 sample articles in `articles/` covering writing, coding, and music topics.
-
-## Images
-
-Banner images (1200x630px) in `images/` for each article.
+| Folder      | Type    | Count | Description                        |
+| ----------- | ------- | ----- | ---------------------------------- |
+| `articles/` | article | 7     | Long-form posts with banner images |
+| `links/`    | link    | 3     | Linkblogs with commentary          |
+| `notes/`    | note    | 5     | Short thoughts                     |
+| `images/`   | -       | 7     | Banner images for articles         |

--- a/examples/links/creative-rhythm.md
+++ b/examples/links/creative-rhythm.md
@@ -1,0 +1,14 @@
+---
+slug: creative-rhythm
+type: link
+title: The importance of creative rhythm
+url: https://austinkleon.com/2023/05/15/the-importance-of-creative-rhythm/
+excerpt: Austin Kleon on why consistent creative habits matter more than inspiration.
+tags: [creativity, writing]
+---
+
+Austin Kleon nails something I've learned the hard way: waiting for inspiration is a trap. The rhythm of showing up daily matters more than the quality of any single session.
+
+> "The rhythm is the thing. The rhythm is what keeps you going."
+
+This applies to writing, coding, music—anything creative. The muse shows up _after_ you start working, not before.

--- a/examples/links/htmx-simplicity.md
+++ b/examples/links/htmx-simplicity.md
@@ -1,0 +1,17 @@
+---
+slug: htmx-simplicity
+type: link
+title: HTMX and the return to simplicity
+url: https://htmx.org/essays/a-real-world-react-to-htmx-port/
+excerpt: A team's experience porting from React to HTMX—and why they're not looking back.
+tags: [coding, web]
+---
+
+This case study is wild. A real production app, ported from React to HTMX:
+
+- 67% less code
+- No build step
+- Faster page loads
+- Dramatically simpler mental model
+
+I'm not saying HTMX is right for everything. But it's a good reminder that the JavaScript-heavy SPA approach isn't the only way to build interactive web apps. Sometimes the "old" way of server-rendered HTML is actually better.

--- a/examples/links/sqlite-is-enough.md
+++ b/examples/links/sqlite-is-enough.md
@@ -1,0 +1,14 @@
+---
+slug: sqlite-is-enough
+type: link
+title: SQLite is probably all you need
+url: https://www.epicweb.dev/why-you-should-probably-be-using-sqlite
+excerpt: Kent C. Dodds makes the case for SQLite as your default database choice.
+tags: [coding, databases]
+---
+
+This resonates with everything I believe about choosing boring technology. Kent argues that SQLite handles far more than most developers assume—up to millions of requests per day on modest hardware.
+
+The key insight: most apps never need horizontal scaling. We reach for Postgres or MySQL out of habit, not necessity. SQLite eliminates an entire category of infrastructure complexity.
+
+I've been running SQLite in production for this site and several side projects. Zero regrets.

--- a/examples/notes/code-comments.md
+++ b/examples/notes/code-comments.md
@@ -1,0 +1,7 @@
+---
+slug: code-comments
+type: note
+tags: [coding]
+---
+
+Hot take: most code comments are apologies for unclear code. If you need a comment to explain _what_ the code does, you probably need to rewrite the code. Comments should explain _why_, not _what_.

--- a/examples/notes/guitar-calluses.md
+++ b/examples/notes/guitar-calluses.md
@@ -1,0 +1,7 @@
+---
+slug: guitar-calluses
+type: note
+tags: [music]
+---
+
+Finally have proper guitar calluses after three months of daily practice. Funny how something that used to hurt is now a point of pride. The fingers remember what the mind forgets.

--- a/examples/notes/morning-coffee.md
+++ b/examples/notes/morning-coffee.md
@@ -1,0 +1,7 @@
+---
+slug: morning-coffee
+type: note
+tags: [life]
+---
+
+There's something meditative about the morning coffee ritual. The grinding, the brewing, the waiting. It's five minutes of enforced patience before the day demands speed.

--- a/examples/notes/shipping-beats-perfect.md
+++ b/examples/notes/shipping-beats-perfect.md
@@ -1,0 +1,7 @@
+---
+slug: shipping-beats-perfect
+type: note
+tags: [creativity]
+---
+
+Shipped a feature today that I'm only 80% happy with. But it's live, people are using it, and I learned things I couldn't have learned by planning longer. Perfect is the enemy of done.

--- a/examples/notes/walking-ideas.md
+++ b/examples/notes/walking-ideas.md
@@ -1,0 +1,7 @@
+---
+slug: walking-ideas
+type: note
+tags: [creativity, life]
+---
+
+Best ideas come on walks. Not runs, not bike rides—walks. Something about the pace matches the rhythm of thinking. Nietzsche was onto something.

--- a/examples/seed-articles.sh
+++ b/examples/seed-articles.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Seed the dev database with example articles.
+# Seed the dev database with example content.
 # Requires: dev server running (make dev) and cli/dev-config.yaml configured.
 #
 
@@ -11,18 +11,32 @@ cd "$(dirname "$0")/.."
 EC="bun cli/src/index.ts --config cli/dev-config.yaml"
 
 echo "Creating articles..."
-
-for article in examples/articles/*.md; do
-  slug=$(basename "$article" .md)
+for f in examples/articles/*.md; do
+  slug=$(basename "$f" .md)
   echo "  $slug"
-  $EC post create --file "$article" 2>/dev/null || true
+  $EC post create --file "$f" 2>/dev/null || true
 done
 
 echo ""
-echo "Publishing articles..."
+echo "Creating links..."
+for f in examples/links/*.md; do
+  slug=$(basename "$f" .md)
+  echo "  $slug"
+  $EC post create --file "$f" 2>/dev/null || true
+done
 
-for article in examples/articles/*.md; do
-  slug=$(basename "$article" .md)
+echo ""
+echo "Creating notes..."
+for f in examples/notes/*.md; do
+  slug=$(basename "$f" .md)
+  echo "  $slug"
+  $EC post create --file "$f" 2>/dev/null || true
+done
+
+echo ""
+echo "Publishing all posts..."
+for f in examples/articles/*.md examples/links/*.md examples/notes/*.md; do
+  slug=$(basename "$f" .md)
   $EC post publish "$slug" 2>/dev/null || true
 done
 

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -68,6 +68,17 @@ testDb
       created_at: now,
       updated_at: now,
     },
+    {
+      id: 6,
+      slug: "test-link",
+      type: "link",
+      title: "Test Link Post",
+      content: "This is commentary on an external link.",
+      url: "https://example.com/article",
+      published_at: now,
+      created_at: now,
+      updated_at: now,
+    },
   ])
   .run();
 
@@ -144,12 +155,13 @@ describe("pages routes", () => {
       expect(html).toContain("dark:border-gray-700");
     });
 
-    it("includes navigation links to Articles and Sources", async () => {
+    it("includes navigation links to Articles, Feed, and Sources", async () => {
       const app = getApp();
       const res = await app.request("/");
       const html = await res.text();
 
       expect(html).toContain('href="/articles"');
+      expect(html).toContain('href="/feed"');
       expect(html).toContain('href="/sources"');
       // About link removed from nav but page still accessible
       expect(html).not.toContain('href="/about"');
@@ -289,6 +301,66 @@ describe("pages routes", () => {
 
       expect(res.status).toBe(302);
       expect(res.headers.get("Location")).toBe("/articles");
+    });
+  });
+
+  describe("GET /feed", () => {
+    it("returns 200 and displays feed page", async () => {
+      const app = getApp();
+      const res = await app.request("/feed");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("<h1");
+      expect(html).toContain("Feed");
+    });
+
+    it("displays all post types (articles, links, notes)", async () => {
+      const app = getApp();
+      const res = await app.request("/feed");
+      const html = await res.text();
+
+      // Should contain article
+      expect(html).toContain("Test Post");
+      // Should contain link post
+      expect(html).toContain("Test Link Post");
+      // Should contain note
+      expect(html).toContain("Short note content");
+    });
+
+    it("shows article posts with Read more link", async () => {
+      const app = getApp();
+      const res = await app.request("/feed");
+      const html = await res.text();
+
+      expect(html).toContain("Read more →");
+      expect(html).toContain('href="/posts/test-post"');
+    });
+
+    it("shows note posts with left border styling", async () => {
+      const app = getApp();
+      const res = await app.request("/feed");
+      const html = await res.text();
+
+      expect(html).toContain("border-l-4");
+    });
+
+    it("includes dark mode classes", async () => {
+      const app = getApp();
+      const res = await app.request("/feed");
+      const html = await res.text();
+
+      expect(html).toContain("dark:bg-gray-900");
+      expect(html).toContain("dark:text-gray-100");
+    });
+
+    it("redirects invalid page numbers to /feed", async () => {
+      const app = getApp();
+      const res = await app.request("/feed?page=0");
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/feed");
     });
   });
 

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -296,6 +296,128 @@ function Pagination({
   );
 }
 
+/** Feed post component - renders differently based on post type */
+function FeedPost({ post }: { post: PostWithSource }) {
+  const formattedDate = post.published_at
+    ? new Date(post.published_at).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : null;
+
+  // Note: full content, left border
+  if (post.type === "note") {
+    return (
+      <article class="bg-gray-50 dark:bg-transparent border-l-4 border-gray-400 dark:border-gray-600 pl-4 py-4 pr-4 rounded-r-lg">
+        <div class="prose prose-gray dark:prose-invert max-w-none mb-3">
+          {raw(renderMarkdown(post.content))}
+        </div>
+        <div class="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+          <time>{formattedDate}</time>
+          <span class="text-gray-300 dark:text-gray-600">•</span>
+          <span class="text-gray-400 dark:text-gray-500">Note</span>
+        </div>
+      </article>
+    );
+  }
+
+  // Link: full content, source attribution (similar to articles but with full content)
+  if (post.type === "link") {
+    return (
+      <article class="bg-white dark:bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+        {/* Title if present */}
+        {post.title && (
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+            <a href={`/posts/${post.slug}`} class="hover:text-blue-600 dark:hover:text-blue-400">
+              {post.title}
+            </a>
+          </h2>
+        )}
+
+        {/* Source link under title */}
+        {post.url && (
+          <a
+            href={post.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 text-sm mb-3 inline-flex items-center gap-1"
+          >
+            <span class="truncate max-w-md">{new URL(post.url).hostname}</span>
+            <svg
+              class="w-3 h-3 flex-shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+              />
+            </svg>
+          </a>
+        )}
+
+        {/* Full content */}
+        <div class="prose prose-gray dark:prose-invert max-w-none mb-4">
+          {raw(renderMarkdown(post.content))}
+        </div>
+
+        {/* Meta */}
+        <div class="flex flex-wrap items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+          <time>{formattedDate}</time>
+          <span class="text-gray-300 dark:text-gray-600">•</span>
+          <span class="text-gray-400 dark:text-gray-500">Link</span>
+          {post.source && (
+            <>
+              <span class="text-gray-300 dark:text-gray-600">•</span>
+              <span>
+                via{" "}
+                <a
+                  href={post.source.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="hover:text-gray-700 dark:hover:text-gray-300"
+                >
+                  {post.source.name}
+                </a>
+              </span>
+            </>
+          )}
+        </div>
+      </article>
+    );
+  }
+
+  // Article: title + excerpt + "Read more" link
+  return (
+    <article class="bg-white dark:bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+      <a href={`/posts/${post.slug}`} class="block group">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 mb-2">
+          {post.title}
+        </h2>
+        <p class="text-gray-600 dark:text-gray-400 mb-3">
+          {post.excerpt || truncate(post.content, 200)}
+        </p>
+      </a>
+      <div class="flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+        <time>{formattedDate}</time>
+        <span class="text-gray-300 dark:text-gray-600">•</span>
+        <span class="text-gray-400 dark:text-gray-500">Article</span>
+        <span class="text-gray-300 dark:text-gray-600">•</span>
+        <a
+          href={`/posts/${post.slug}`}
+          class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+        >
+          Read more →
+        </a>
+      </div>
+    </article>
+  );
+}
+
 /** Reusable post card component */
 function PostCard({ post }: { post: PostWithSource }) {
   const isLink = post.type === "link";
@@ -547,6 +669,89 @@ export function createPagesRoutes(db: Database): Hono {
         {/* Pagination */}
         {totalPages > 1 && (
           <Pagination currentPage={page} totalPages={totalPages} baseUrl="/articles" />
+        )}
+      </Layout>
+    );
+  });
+
+  // Feed page - all post types with full content for notes/links, excerpts for articles
+  const FEED_POSTS_PER_PAGE = 10;
+
+  pages.get("/feed", (c) => {
+    // Get page number from query string
+    const pageParam = c.req.query("page");
+    const page = pageParam ? parseInt(pageParam, 10) : 1;
+
+    // Validate page number
+    if (isNaN(page) || page < 1) {
+      return c.redirect("/feed");
+    }
+
+    // Count total posts
+    const countResult = db
+      .select({ count: posts.id })
+      .from(posts)
+      .where(isNotNull(posts.published_at))
+      .all();
+    const totalPosts = countResult.length;
+    const totalPages = Math.ceil(totalPosts / FEED_POSTS_PER_PAGE);
+
+    // Handle no posts
+    if (totalPosts === 0) {
+      return c.html(
+        <Layout title="Feed | erikcraddock.me">
+          <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">Feed</h1>
+          <p class="text-gray-600 dark:text-gray-400">No posts yet.</p>
+        </Layout>
+      );
+    }
+
+    // Handle page out of range
+    if (page > totalPages) {
+      return c.redirect(`/feed?page=${totalPages}`);
+    }
+
+    // Fetch posts for current page with source info
+    const offset = (page - 1) * FEED_POSTS_PER_PAGE;
+    const results = db
+      .select({
+        post: posts,
+        source: sources,
+      })
+      .from(posts)
+      .leftJoin(sources, eq(posts.source_id, sources.id))
+      .where(isNotNull(posts.published_at))
+      .orderBy(desc(posts.published_at))
+      .limit(FEED_POSTS_PER_PAGE)
+      .offset(offset)
+      .all();
+
+    const pagePosts: PostWithSource[] = results.map((row) => ({
+      ...row.post,
+      source: row.source,
+    }));
+
+    return c.html(
+      <Layout title={`Feed${page > 1 ? ` - Page ${page}` : ""} | erikcraddock.me`}>
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">Feed</h1>
+
+        {/* Page indicator at top */}
+        {totalPages > 1 && (
+          <p class="text-center text-gray-600 dark:text-gray-400 mb-6">
+            Page {page} of {totalPages}
+          </p>
+        )}
+
+        {/* Posts list */}
+        <div class="space-y-8">
+          {pagePosts.map((post) => (
+            <FeedPost key={post.id} post={post} />
+          ))}
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <Pagination currentPage={page} totalPages={totalPages} baseUrl="/feed" />
         )}
       </Layout>
     );

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -75,6 +75,12 @@ export function Layout({ title, children, ogImage, description }: LayoutProps) {
                 Articles
               </a>
               <a
+                href="/feed"
+                class="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+              >
+                Feed
+              </a>
+              <a
                 href="/sources"
                 class="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
               >


### PR DESCRIPTION
## Summary

Adds a Feed page at `/feed` showing all published posts with type-specific display.

## Content Display by Type

| Type | Display |
|------|---------|
| **Notes** | Full content inline, left border styling |
| **Links** | Full content + source URL, card style |
| **Articles** | Title + excerpt + "Read more" link |

## Changes

### New Route
- `/feed` - paginated feed of all post types
- 10 posts per page
- Type-specific `FeedPost` component

### Navigation
- Added "Feed" link between Articles and Sources

### CLI Fix
- Added `--url` option and frontmatter support for link posts

### Example Content
- 3 example linkblogs in `examples/links/`
- 5 example notes in `examples/notes/`
- Updated seed script to include all content types

### Styling
- Consistent card styling in light/dark modes
- Links and articles use bordered cards
- Notes use left border accent
- Blockquotes have subtle background

## Testing

- [x] All 324 tests pass
- [x] Visual verification in dark mode
- [x] Visual verification in light mode
- [x] Link post fixture added to tests

Closes #1472