### PR TITLE
fix: improve ActivityPub post formatting for Mastodon

### DIFF
--- a/src/federation/__tests__/outbox.test.ts
+++ b/src/federation/__tests__/outbox.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "bun:test";
+import { Note, Article } from "@fedify/fedify";
+import { postToObject, PublishedPost } from "../post-object";
+
+const actorUri = new URL("http://localhost:5000/users/erik");
+const followersUri = new URL("http://localhost:5000/users/erik/followers");
+
+function createPost(overrides: Partial<PublishedPost>): PublishedPost {
+  return {
+    id: 1,
+    slug: "test-post",
+    type: "article",
+    title: "Test Title",
+    content: "Test content",
+    excerpt: "Test excerpt",
+    url: null,
+    published_at: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+describe("postToObject", () => {
+  describe("Note posts", () => {
+    it("converts note to Note type with full content", () => {
+      const post = createPost({
+        type: "note",
+        title: null,
+        content: "This is a short note",
+        excerpt: null,
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result).toBeInstanceOf(Note);
+      expect(result.name).toBeFalsy();
+      expect(result.summary).toBeFalsy();
+      expect(result.content).toBe("This is a short note");
+    });
+
+    it("does not set summary on notes (avoids CW behavior)", () => {
+      const post = createPost({
+        type: "note",
+        title: null,
+        content: "Note content",
+        excerpt: "Some excerpt", // Even if excerpt exists, should not be used
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result.summary).toBeFalsy();
+    });
+  });
+
+  describe("Link posts", () => {
+    it("converts link to Note type with commentary and external URL", () => {
+      const post = createPost({
+        type: "link",
+        title: "Link Title",
+        content: "My commentary on this link",
+        url: "https://example.com/article",
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result).toBeInstanceOf(Note);
+      expect(result.content).toBe("My commentary on this link\n\nhttps://example.com/article");
+    });
+
+    it("does not set name on link posts (Note type)", () => {
+      const post = createPost({
+        type: "link",
+        title: "Link Title",
+        content: "Commentary",
+        url: "https://example.com",
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result.name).toBeFalsy();
+    });
+
+    it("does not set summary on link posts (avoids CW behavior)", () => {
+      const post = createPost({
+        type: "link",
+        title: "Link Title",
+        content: "Commentary",
+        excerpt: "Some excerpt",
+        url: "https://example.com",
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result.summary).toBeFalsy();
+    });
+  });
+
+  describe("Article posts", () => {
+    it("converts article to Article type with excerpt and site URL", () => {
+      const post = createPost({
+        type: "article",
+        slug: "my-article",
+        title: "My Article",
+        content: "Full article content here...",
+        excerpt: "Brief excerpt",
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result).toBeInstanceOf(Article);
+      expect(result.name).toBe("My Article");
+      expect(result.content).toContain("Brief excerpt");
+      expect(result.content).toContain("/posts/my-article");
+    });
+
+    it("sets summary on articles", () => {
+      const post = createPost({
+        type: "article",
+        title: "My Article",
+        excerpt: "Article excerpt",
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result.summary).toBe("Article excerpt");
+    });
+
+    it("uses just URL if no excerpt", () => {
+      const post = createPost({
+        type: "article",
+        slug: "no-excerpt-article",
+        title: "Article Without Excerpt",
+        excerpt: null,
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result.content).toContain("/posts/no-excerpt-article");
+      expect(result.content).not.toContain("\n\n"); // Just URL, no excerpt prefix
+    });
+  });
+
+  describe("common properties", () => {
+    it("sets attribution to actor URI", () => {
+      const post = createPost({ type: "note", title: null });
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result.attributionId?.href).toBe(actorUri.href);
+    });
+
+    it("sets published date", () => {
+      const publishedAt = new Date("2026-02-01T12:00:00Z");
+      const post = createPost({ type: "note", title: null, published_at: publishedAt });
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result.published).toBeDefined();
+    });
+  });
+});

--- a/src/federation/outbox.ts
+++ b/src/federation/outbox.ts
@@ -1,21 +1,15 @@
-import { Create, Note, Article } from "@fedify/fedify";
+import { Create } from "@fedify/fedify";
 import { desc, isNotNull, count } from "drizzle-orm";
 import { db, posts } from "@/db";
 import { logger } from "@/utils/logger";
-import { dateToInstant, baseUrl } from "./utils";
+import { baseUrl, dateToInstant } from "./utils";
+import { postToObject, PublishedPost } from "./post-object";
 
 // ActivityPub Public address
 const PUBLIC = new URL("https://www.w3.org/ns/activitystreams#Public");
 
-export interface PublishedPost {
-  id: number;
-  type: string;
-  title: string | null;
-  content: string;
-  excerpt: string | null;
-  url: string | null;
-  published_at: Date;
-}
+// Re-export for backward compatibility
+export { postToObject, PublishedPost } from "./post-object";
 
 /**
  * Get published posts for the outbox, ordered by published_at descending.
@@ -25,6 +19,7 @@ export function getPublishedPosts(limit: number = 20, offset: number = 0): Publi
   return db
     .select({
       id: posts.id,
+      slug: posts.slug,
       type: posts.type,
       title: posts.title,
       content: posts.content,
@@ -50,33 +45,6 @@ export function getPublishedPostCount(): number {
     .where(isNotNull(posts.published_at))
     .get();
   return result?.count ?? 0;
-}
-
-/**
- * Convert a post to an ActivityPub object (Note or Article).
- */
-export function postToObject(
-  post: PublishedPost,
-  actorUri: URL,
-  followersUri: URL
-): Note | Article {
-  const postUri = new URL(`/posts/${post.id}`, baseUrl);
-
-  // Use Article for posts with titles, Note for everything else (notes, links)
-  const ObjectClass = post.title ? Article : Note;
-
-  return new ObjectClass({
-    id: postUri,
-    attribution: actorUri,
-    // Addressing: public posts visible to everyone, CC'd to followers
-    to: PUBLIC,
-    cc: followersUri,
-    name: post.title ?? undefined,
-    content: post.content,
-    summary: post.excerpt ?? undefined,
-    published: post.published_at ? dateToInstant(new Date(post.published_at)) : undefined,
-    url: postUri,
-  });
 }
 
 /**

--- a/src/federation/post-object.ts
+++ b/src/federation/post-object.ts
@@ -1,0 +1,59 @@
+import { Note, Article } from "@fedify/fedify";
+import { dateToInstant, baseUrl } from "./utils";
+
+// ActivityPub Public address
+const PUBLIC = new URL("https://www.w3.org/ns/activitystreams#Public");
+
+export interface PublishedPost {
+  id: number;
+  slug: string;
+  type: string;
+  title: string | null;
+  content: string;
+  excerpt: string | null;
+  url: string | null;
+  published_at: Date;
+}
+
+/**
+ * Convert a post to an ActivityPub object (Note or Article).
+ */
+export function postToObject(
+  post: PublishedPost,
+  actorUri: URL,
+  followersUri: URL
+): Note | Article {
+  const postUri = new URL(`/posts/${post.id}`, baseUrl);
+
+  // Use Article for articles (posts with titles that aren't links)
+  // Use Note for notes and links (links are commentary + URL, displayed inline)
+  const ObjectClass = post.title && post.type !== "link" ? Article : Note;
+
+  // Build content based on post type:
+  // - Notes: full content (short by nature)
+  // - Links: commentary + external URL (Mastodon generates preview card)
+  // - Articles: excerpt + link to article (Mastodon generates preview card from our site)
+  let content = post.content;
+  const postUrl = new URL(`/posts/${post.slug}`, baseUrl).href;
+
+  if (post.type === "link" && post.url) {
+    content = `${post.content}\n\n${post.url}`;
+  } else if (post.type === "article") {
+    content = post.excerpt ? `${post.excerpt}\n\n${postUrl}` : postUrl;
+  }
+
+  return new ObjectClass({
+    id: postUri,
+    attribution: actorUri,
+    // Addressing: public posts visible to everyone, CC'd to followers
+    to: PUBLIC,
+    cc: followersUri,
+    // Only set name for Articles (not links, not notes)
+    name: post.title && post.type !== "link" ? post.title : undefined,
+    content: content,
+    // Only set summary for Articles - for Notes it triggers CW behavior
+    summary: post.title && post.type !== "link" ? (post.excerpt ?? undefined) : undefined,
+    published: post.published_at ? dateToInstant(new Date(post.published_at)) : undefined,
+    url: postUri,
+  });
+}


### PR DESCRIPTION
## Summary

Fixes how posts appear when federated to Mastodon/Fediverse clients.

## Changes

### Notes
- Remove `summary` field - was triggering Content Warning ("Show more") behavior
- Full content displayed inline

### Links  
- Use `Note` type instead of `Article` (displays inline in timeline)
- Content = commentary + external URL
- Mastodon auto-generates preview card from the URL

### Articles
- Content = excerpt + URL to erikcraddock.me
- Mastodon auto-generates preview card from site's Open Graph metadata
- Drives traffic to website for full article

## How it works

| Post Type | ActivityPub Type | Content | Preview Card |
|-----------|------------------|---------|--------------|
| Note | `Note` | Full text | None |
| Link | `Note` | Commentary + URL | External site |
| Article | `Article` | Excerpt + URL | erikcraddock.me |

## Testing
- [x] All 324 tests pass
- [x] Verified outbox output for all three post types

Closes #1474