### PR TITLE
feat: add og:url and og:site_name meta tags

### DIFF
--- a/src/federation/outbox.ts
+++ b/src/federation/outbox.ts
@@ -9,7 +9,8 @@ import { postToObject, PublishedPost } from "./post-object";
 const PUBLIC = new URL("https://www.w3.org/ns/activitystreams#Public");
 
 // Re-export for backward compatibility
-export { postToObject, PublishedPost } from "./post-object";
+export { postToObject } from "./post-object";
+export type { PublishedPost } from "./post-object";
 
 /**
  * Get published posts for the outbox, ordered by published_at descending.

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -952,12 +952,14 @@ export function createPagesRoutes(db: Database): Hono {
 
     const title = post.title || (isNote ? "Note" : "Post");
     const description = post.excerpt || truncate(post.content, 160);
+    const canonicalUrl = `/posts/${slug}`;
 
     return c.html(
       <Layout
         title={`${title} | erikcraddock.me`}
         ogImage={bannerUrl ?? undefined}
         description={description}
+        canonicalUrl={canonicalUrl}
       >
         <article
           class={`max-w-none ${isNote ? "pl-4 border-l-4 border-l-gray-300 dark:border-l-gray-600" : ""}`}

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -6,6 +6,7 @@ interface LayoutProps {
   children: Child;
   ogImage?: string;
   description?: string;
+  canonicalUrl?: string;
 }
 
 // Inline script to prevent flash of wrong theme
@@ -18,8 +19,13 @@ const themeScript = `
 })();
 `;
 
-export function Layout({ title, children, ogImage, description }: LayoutProps) {
+export function Layout({ title, children, ogImage, description, canonicalUrl }: LayoutProps) {
   const siteUrl = process.env.SITE_URL || "https://erikcraddock.me";
+  const fullCanonicalUrl = canonicalUrl
+    ? canonicalUrl.startsWith("http")
+      ? canonicalUrl
+      : `${siteUrl}${canonicalUrl}`
+    : undefined;
 
   return (
     <html lang="en" class="overflow-y-scroll">
@@ -29,8 +35,10 @@ export function Layout({ title, children, ogImage, description }: LayoutProps) {
         <title>{title}</title>
         {description && <meta name="description" content={description} />}
         {/* Open Graph tags */}
+        <meta property="og:site_name" content="Erik Craddock" />
         <meta property="og:title" content={title} />
         {description && <meta property="og:description" content={description} />}
+        {fullCanonicalUrl && <meta property="og:url" content={fullCanonicalUrl} />}
         {ogImage && (
           <meta
             property="og:image"


### PR DESCRIPTION
## Summary

Completes Open Graph meta tags for rich link previews on social media.

## Changes

- Add `og:site_name` ("Erik Craddock") to all pages
- Add `og:url` with canonical URL to post pages
- Add `canonicalUrl` prop to Layout component
- Fix type export for `PublishedPost` interface

## Result

Post pages now include all recommended OG tags:
```html
<meta property="og:site_name" content="Erik Craddock"/>
<meta property="og:title" content="..."/>
<meta property="og:description" content="..."/>
<meta property="og:url" content="https://erikcraddock.me/posts/..."/>
<meta property="og:image" content="..."/>
<meta property="og:type" content="article"/>
```

Plus Twitter Card tags for X/Twitter previews.

Closes #1475