### PR TITLE
feat: add media attachments to ActivityPub article posts

### DIFF
--- a/src/federation/__tests__/outbox.test.ts
+++ b/src/federation/__tests__/outbox.test.ts
@@ -112,6 +112,40 @@ describe("postToObject", () => {
       expect(result.content).toContain("/posts/my-article");
     });
 
+    it("includes banner image as attachment", async () => {
+      const post = createPost({
+        type: "article",
+        title: "My Article",
+        banner_url: "http://example.com/image.jpg",
+        banner_alt: "A test image",
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+      const json = (await result.toJsonLd()) as Record<string, unknown>;
+      const attachment = json.attachment as Record<string, unknown>;
+
+      expect(attachment).toBeDefined();
+      expect(attachment.type).toBe("Document");
+      expect(attachment.url).toBe("http://example.com/image.jpg");
+      expect(attachment.mediaType).toBe("image/jpeg");
+      expect(attachment.name).toBe("A test image");
+    });
+
+    it("uses title as attachment name when no alt text", async () => {
+      const post = createPost({
+        type: "article",
+        title: "My Article Title",
+        banner_url: "http://example.com/image.png",
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+      const json = (await result.toJsonLd()) as Record<string, unknown>;
+      const attachment = json.attachment as Record<string, unknown>;
+
+      expect(attachment.name).toBe("My Article Title");
+      expect(attachment.mediaType).toBe("image/png");
+    });
+
     it("sets summary on articles", () => {
       const post = createPost({
         type: "article",

--- a/src/federation/outbox.ts
+++ b/src/federation/outbox.ts
@@ -1,9 +1,10 @@
 import { Create } from "@fedify/fedify";
-import { desc, isNotNull, count } from "drizzle-orm";
-import { db, posts } from "@/db";
+import { desc, isNotNull, count, eq } from "drizzle-orm";
+import { db, posts, media } from "@/db";
 import { logger } from "@/utils/logger";
 import { baseUrl, dateToInstant } from "./utils";
 import { postToObject, PublishedPost } from "./post-object";
+import { mediaUrl } from "@/services/media";
 
 // ActivityPub Public address
 const PUBLIC = new URL("https://www.w3.org/ns/activitystreams#Public");
@@ -17,7 +18,7 @@ export type { PublishedPost } from "./post-object";
  * Only returns posts that have been published (published_at is not null).
  */
 export function getPublishedPosts(limit: number = 20, offset: number = 0): PublishedPost[] {
-  return db
+  const results = db
     .select({
       id: posts.id,
       slug: posts.slug,
@@ -27,13 +28,30 @@ export function getPublishedPosts(limit: number = 20, offset: number = 0): Publi
       excerpt: posts.excerpt,
       url: posts.url,
       published_at: posts.published_at,
+      banner_s3_key: media.s3_key,
+      banner_alt: media.alt_text,
     })
     .from(posts)
+    .leftJoin(media, eq(posts.banner_image_id, media.id))
     .where(isNotNull(posts.published_at))
     .orderBy(desc(posts.published_at))
     .limit(limit)
     .offset(offset)
-    .all() as PublishedPost[];
+    .all();
+
+  // Transform to PublishedPost with banner URL
+  return results.map((r) => ({
+    id: r.id,
+    slug: r.slug,
+    type: r.type,
+    title: r.title,
+    content: r.content,
+    excerpt: r.excerpt,
+    url: r.url,
+    published_at: r.published_at!,
+    banner_url: r.banner_s3_key ? new URL(mediaUrl(r.banner_s3_key), baseUrl).href : null,
+    banner_alt: r.banner_alt,
+  }));
 }
 
 /**

--- a/src/federation/post-object.ts
+++ b/src/federation/post-object.ts
@@ -1,4 +1,4 @@
-import { Note, Article } from "@fedify/fedify";
+import { Note, Article, Document } from "@fedify/fedify";
 import { dateToInstant, baseUrl } from "./utils";
 
 // ActivityPub Public address
@@ -13,6 +13,8 @@ export interface PublishedPost {
   excerpt: string | null;
   url: string | null;
   published_at: Date;
+  banner_url?: string | null;
+  banner_alt?: string | null;
 }
 
 /**
@@ -42,6 +44,31 @@ export function postToObject(
     content = post.excerpt ? `${post.excerpt}\n\n${postUrl}` : postUrl;
   }
 
+  // Build attachments array for media (banner images on articles only)
+  const attachments: Document[] = [];
+  if (post.type === "article" && post.banner_url) {
+    // Determine media type from URL extension
+    const ext = post.banner_url.split(".").pop()?.toLowerCase();
+    const mediaType =
+      ext === "png"
+        ? "image/png"
+        : ext === "gif"
+          ? "image/gif"
+          : ext === "webp"
+            ? "image/webp"
+            : "image/jpeg";
+
+    const bannerUrlObj = new URL(post.banner_url);
+    attachments.push(
+      new Document({
+        id: bannerUrlObj,
+        url: bannerUrlObj,
+        mediaType,
+        name: post.banner_alt ?? post.title ?? undefined,
+      })
+    );
+  }
+
   return new ObjectClass({
     id: postUri,
     attribution: actorUri,
@@ -55,5 +82,6 @@ export function postToObject(
     summary: post.title && post.type !== "link" ? (post.excerpt ?? undefined) : undefined,
     published: post.published_at ? dateToInstant(new Date(post.published_at)) : undefined,
     url: postUri,
+    attachments: attachments.length > 0 ? attachments : undefined,
   });
 }


### PR DESCRIPTION
## Summary

Articles with banner images now include them as ActivityPub attachments, so the image appears when the post federates to Mastodon.

## Changes

- Add `banner_url` and `banner_alt` to `PublishedPost` interface
- Join with media table in `getPublishedPosts` to get banner info
- Add `Document` attachment for articles with banner images
- Determine mediaType from file extension (jpeg, png, gif, webp)
- Use alt text or title as attachment name

## Result

Article posts in the outbox now include attachments:
```json
{
  "type": "Article",
  "name": "Building a Home Studio on a Budget",
  "attachment": {
    "type": "Document",
    "mediaType": "image/jpeg",
    "url": "https://erikcraddock.me/media/posts/.../image.jpg",
    "name": "Building a Home Studio on a Budget"
  }
}
```

Only articles include attachments - notes and links don't have banners.

Closes #1476