### PR TITLE
chore: bump CLI version to 0.3.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ec",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "CLI for erikcraddock.me content management",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Fix CLI version reporting - package.json was still at 0.1.0