### PR TITLE
fix: add API endpoint to send actor Update activity

### DIFF
--- a/src/federation/publish.ts
+++ b/src/federation/publish.ts
@@ -1,4 +1,4 @@
-import { Create, Delete, Update, Note, Article, Image } from "@fedify/fedify";
+import { Create, Delete, Update, Note, Article, Image, Person, Endpoints } from "@fedify/fedify";
 import { eq } from "drizzle-orm";
 import { db, posts, media } from "@/db";
 import { federation } from "./setup";
@@ -290,6 +290,69 @@ export async function sendUpdateActivity(postId: number): Promise<boolean> {
     return true;
   } catch (error) {
     logger.error("federation", `Failed to send Update activity for post ${postId}`, { error });
+    return false;
+  }
+}
+
+/**
+ * Send an Update activity for the actor profile to all followers.
+ *
+ * Should be called when actor profile changes (icon, name, summary, etc.).
+ * Remote servers should update their cached copy of the actor.
+ *
+ * @returns true if activity was sent, false if no followers
+ */
+export async function sendActorUpdateActivity(): Promise<boolean> {
+  const followers = getAllFollowers();
+  if (followers.length === 0) {
+    logger.debug("federation", "No followers to send actor Update to");
+    return true;
+  }
+
+  const ctx = federation.createContext(new URL(baseUrl), undefined);
+  const actorUri = ctx.getActorUri("erik");
+
+  // Get key pairs for the actor
+  const keys = await ctx.getActorKeyPairs("erik");
+
+  // Build the Person object (same as actor dispatcher)
+  const iconUrl = new URL("/images/erik-logo.png", baseUrl);
+  const bannerUrl = new URL("/images/banner.png", baseUrl);
+
+  const person = new Person({
+    id: actorUri,
+    preferredUsername: "erik",
+    name: "Erik Craddock",
+    summary: "Writer, coder, and musician — not always in that order.",
+    icon: new Image({ url: iconUrl, mediaType: "image/png" }),
+    image: new Image({ url: bannerUrl, mediaType: "image/png" }),
+    url: new URL("/", baseUrl),
+    inbox: ctx.getInboxUri("erik"),
+    outbox: ctx.getOutboxUri("erik"),
+    followers: ctx.getFollowersUri("erik"),
+    endpoints: new Endpoints({ sharedInbox: ctx.getInboxUri() }),
+    publicKey: keys[0].cryptographicKey,
+    assertionMethods: keys.map((key) => key.multikey),
+  });
+
+  const activityUri = new URL(`/users/erik#update-${Date.now()}`, baseUrl);
+  const activity = new Update({
+    id: activityUri,
+    actor: actorUri,
+    object: person,
+  });
+
+  logger.info("federation", `Sending actor Update activity to ${followers.length} followers`);
+
+  try {
+    await ctx.sendActivity({ identifier: "erik" }, "followers", activity, {
+      preferSharedInbox: true,
+    });
+
+    logger.info("federation", "Successfully queued actor Update activity");
+    return true;
+  } catch (error) {
+    logger.error("federation", "Failed to send actor Update activity", { error });
     return false;
   }
 }

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -22,7 +22,12 @@ import {
   deleteSource,
 } from "@/services/sources";
 import { listTags } from "@/services/tags";
-import { federatePost, sendDeleteActivity, sendUpdateActivity } from "@/federation/publish";
+import {
+  federatePost,
+  sendDeleteActivity,
+  sendUpdateActivity,
+  sendActorUpdateActivity,
+} from "@/federation/publish";
 
 export const api = new Hono();
 
@@ -677,6 +682,21 @@ api.delete("/media/:id", async (c) => {
     }
 
     return c.body(null, 204);
+  } catch (error) {
+    return c.json({ error: String(error) }, 500);
+  }
+});
+
+/**
+ * POST /api/federation/update-actor - Send actor Update activity to all followers
+ *
+ * Call this when actor profile changes (icon, banner, name, summary).
+ * Remote servers will re-fetch and cache the updated actor info.
+ */
+api.post("/federation/update-actor", async (c) => {
+  try {
+    const sent = await sendActorUpdateActivity();
+    return c.json({ success: sent });
   } catch (error) {
     return c.json({ error: String(error) }, 500);
   }


### PR DESCRIPTION
Adds POST /api/federation/update-actor to send Update activity for the actor to all followers, so remote servers refresh their cached icon/banner.

Fixes #1473