### PR TITLE
fix: use slug instead of numeric ID for ActivityPub post URIs

### DIFF
--- a/src/federation/outbox.ts
+++ b/src/federation/outbox.ts
@@ -74,10 +74,10 @@ export function postToCreateActivity(
   actorUri: URL,
   followersUri: URL
 ): Create {
-  const activityUri = new URL(`/posts/${post.id}#create`, baseUrl);
+  const activityUri = new URL(`/posts/${post.slug}#create`, baseUrl);
   const object = postToObject(post, actorUri, followersUri);
 
-  logger.debug("federation", `Converting post ${post.id} to Create activity`);
+  logger.debug("federation", `Converting post ${post.slug} to Create activity`);
 
   return new Create({
     id: activityUri,

--- a/src/federation/post-object.ts
+++ b/src/federation/post-object.ts
@@ -25,7 +25,7 @@ export function postToObject(
   actorUri: URL,
   followersUri: URL
 ): Note | Article {
-  const postUri = new URL(`/posts/${post.id}`, baseUrl);
+  const postUri = new URL(`/posts/${post.slug}`, baseUrl);
 
   // Use Article for articles (posts with titles that aren't links)
   // Use Note for notes and links (links are commentary + URL, displayed inline)

--- a/src/federation/publish.ts
+++ b/src/federation/publish.ts
@@ -11,6 +11,7 @@ import { dateToInstant, baseUrl } from "./utils";
  */
 interface PostWithBanner {
   id: number;
+  slug: string;
   type: string;
   title: string | null;
   content: string;
@@ -66,7 +67,7 @@ export function postToObjectWithAttachment(
   actorUri: URL,
   followersUri: URL
 ): Note | Article {
-  const postUri = new URL(`/posts/${post.id}`, baseUrl);
+  const postUri = new URL(`/posts/${post.slug}`, baseUrl);
 
   // Use Article for posts with titles, Note for everything else
   const ObjectClass = post.title ? Article : Note;
@@ -99,7 +100,7 @@ export function postToObjectWithAttachment(
  * Convert a post to a Create activity.
  */
 function postToCreateActivity(post: PostWithBanner, actorUri: URL, followersUri: URL): Create {
-  const activityUri = new URL(`/posts/${post.id}#create`, baseUrl);
+  const activityUri = new URL(`/posts/${post.slug}#create`, baseUrl);
   const object = postToObjectWithAttachment(post, actorUri, followersUri);
 
   return new Create({
@@ -130,6 +131,7 @@ export async function federatePost(postId: number): Promise<boolean> {
   const post = db
     .select({
       id: posts.id,
+      slug: posts.slug,
       type: posts.type,
       title: posts.title,
       content: posts.content,
@@ -189,19 +191,19 @@ export async function federatePost(postId: number): Promise<boolean> {
  * @param postId The ID of the deleted post
  * @returns true if activity was sent, false if no followers
  */
-export async function sendDeleteActivity(postId: number): Promise<boolean> {
+export async function sendDeleteActivity(slug: string): Promise<boolean> {
   const followers = getAllFollowers();
   if (followers.length === 0) {
-    logger.debug("federation", `No followers to send Delete for post ${postId}`);
+    logger.debug("federation", `No followers to send Delete for post ${slug}`);
     return true;
   }
 
   const ctx = federation.createContext(new URL(baseUrl), undefined);
   const actorUri = ctx.getActorUri("erik");
 
-  // The object URI that was deleted
-  const objectUri = new URL(`/posts/${postId}`, baseUrl);
-  const activityUri = new URL(`/posts/${postId}#delete`, baseUrl);
+  // The object URI that was deleted (must match the URI used when created)
+  const objectUri = new URL(`/posts/${slug}`, baseUrl);
+  const activityUri = new URL(`/posts/${slug}#delete`, baseUrl);
 
   const activity = new Delete({
     id: activityUri,
@@ -211,7 +213,7 @@ export async function sendDeleteActivity(postId: number): Promise<boolean> {
 
   logger.info(
     "federation",
-    `Sending Delete activity for post ${postId} to ${followers.length} followers`
+    `Sending Delete activity for post ${slug} to ${followers.length} followers`
   );
 
   try {
@@ -219,10 +221,10 @@ export async function sendDeleteActivity(postId: number): Promise<boolean> {
       preferSharedInbox: true,
     });
 
-    logger.info("federation", `Successfully queued Delete activity for post ${postId}`);
+    logger.info("federation", `Successfully queued Delete activity for post ${slug}`);
     return true;
   } catch (error) {
-    logger.error("federation", `Failed to send Delete activity for post ${postId}`, { error });
+    logger.error("federation", `Failed to send Delete activity for post ${slug}`, { error });
     return false;
   }
 }
@@ -241,6 +243,7 @@ export async function sendUpdateActivity(postId: number): Promise<boolean> {
   const post = db
     .select({
       id: posts.id,
+      slug: posts.slug,
       type: posts.type,
       title: posts.title,
       content: posts.content,
@@ -267,7 +270,7 @@ export async function sendUpdateActivity(postId: number): Promise<boolean> {
   const actorUri = ctx.getActorUri("erik");
   const followersUri = ctx.getFollowersUri("erik");
 
-  const activityUri = new URL(`/posts/${postId}#update-${Date.now()}`, baseUrl);
+  const activityUri = new URL(`/posts/${post.slug}#update-${Date.now()}`, baseUrl);
   const object = postToObjectWithAttachment(post as PostWithBanner, actorUri, followersUri);
 
   const activity = new Update({

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -264,6 +264,7 @@ api.delete("/posts/:id", async (c) => {
   // Check if post was published before deleting
   const existingPost = getPost(id);
   const wasPublished = existingPost?.published_at;
+  const slug = existingPost?.slug;
 
   const deleted = deletePost(id);
 
@@ -272,8 +273,8 @@ api.delete("/posts/:id", async (c) => {
   }
 
   // Send Delete activity if post was previously published
-  if (wasPublished) {
-    await sendDeleteActivity(id);
+  if (wasPublished && slug) {
+    await sendDeleteActivity(slug);
   }
 
   return c.body(null, 204);
@@ -423,7 +424,7 @@ api.delete("/posts/by-slug/:slug", async (c) => {
 
   // Send Delete activity if post was previously published
   if (wasPublished) {
-    await sendDeleteActivity(postId);
+    await sendDeleteActivity(slug);
   }
 
   return c.body(null, 204);


### PR DESCRIPTION
## Problem

Post URIs were using numeric IDs (`/posts/4`) but web routes use slugs (`/posts/on-the-hiring-line`), causing 404s when Mastodon tried to dereference posts.

## Solution

Changed all ActivityPub post URIs to use slug:
- `post-object.ts`: use post.slug for postUri
- `publish.ts`: add slug to PostWithBanner, use slug for all URIs
- `outbox.ts`: use post.slug for activity URIs
- `api.tsx`: pass slug to sendDeleteActivity

Fixes #1474