### PR TITLE
fix: add to/cc addressing to Delete activity and add federation delete command

### DIFF
--- a/cli/src/commands/federation/delete.ts
+++ b/cli/src/commands/federation/delete.ts
@@ -1,0 +1,82 @@
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function showDeleteHelp(): void {
+  console.log(`ec federation delete - Send Delete activity for a URI
+
+Usage: ec federation delete <uri> [options]
+
+Arguments:
+  uri                 The full URI to delete (e.g., https://erikcraddock.me/posts/4)
+
+Options:
+  --json              Output as JSON
+  --help, -h          Show this help message
+
+Use this to:
+- Delete posts that were federated with old URIs
+- Clean up posts during development
+- Remove posts from remote servers after local deletion
+
+Examples:
+  ec federation delete https://erikcraddock.me/posts/4
+  ec federation delete https://erikcraddock.me/posts/old-slug
+`);
+}
+
+export async function deleteFederated(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  let uri: string | undefined;
+  let help = false;
+
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (!arg.startsWith("-")) {
+      uri = arg;
+    }
+  }
+
+  if (help) {
+    showDeleteHelp();
+    return;
+  }
+
+  if (!uri) {
+    console.error("❌ Missing uri argument.");
+    console.error("Usage: ec federation delete <uri>");
+    process.exit(1);
+  }
+
+  // Validate URI format
+  try {
+    new URL(uri);
+  } catch {
+    console.error(`❌ Invalid URI: ${uri}`);
+    process.exit(1);
+  }
+
+  const config = await loadConfig(globalOptions.configPath);
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+
+  const result = await client.federationDelete(uri);
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(result.data, null, 2));
+  } else {
+    console.log(`✅ Delete activity sent for: ${uri}`);
+  }
+}

--- a/cli/src/commands/federation/index.ts
+++ b/cli/src/commands/federation/index.ts
@@ -1,0 +1,43 @@
+import type { GlobalOptions } from "../../types";
+import { deleteFederated } from "./delete";
+
+export function showFederationHelp(): void {
+  console.log(`ec federation - Manage ActivityPub federation
+
+Usage: ec federation <command> [options]
+
+Commands:
+  delete <uri>      Send Delete activity for a URI
+
+Options:
+  --help, -h        Show help for a command
+
+Examples:
+  ec federation delete https://erikcraddock.me/posts/4
+  ec federation delete https://erikcraddock.me/posts/old-slug
+`);
+}
+
+export async function federationCommand(args: string[], options: GlobalOptions): Promise<void> {
+  if (args.length === 0) {
+    showFederationHelp();
+    return;
+  }
+
+  const [subcmd, ...rest] = args;
+
+  if (options.help) {
+    rest.push("--help");
+  }
+
+  switch (subcmd) {
+    case "delete":
+      await deleteFederated(rest, options);
+      break;
+
+    default:
+      console.error(`Unknown federation command: ${subcmd}`);
+      console.error("Run 'ec federation --help' for usage.");
+      process.exit(1);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -8,6 +8,7 @@ import { noteCommand } from "./commands/note";
 import { sourceCommand, showSourceHelp } from "./commands/source";
 import { tagCommand, showTagHelp } from "./commands/tag";
 import { imageCommand, showImageHelp } from "./commands/image";
+import { federationCommand, showFederationHelp } from "./commands/federation";
 import type { GlobalOptions } from "./types";
 
 export function parseArgs(args: string[]): {
@@ -66,6 +67,7 @@ Commands:
   source          Manage sources (list, show, create, edit, delete)
   tag             Manage tags (list)
   image           Manage images (upload, delete)
+  federation      Manage ActivityPub federation (delete)
   version         Show CLI version
   help            Show this help message
 
@@ -215,6 +217,14 @@ async function main(): Promise<void> {
         return;
       }
       await imageCommand(command.slice(1), options);
+      break;
+
+    case "federation":
+      if (options.help && !subcmd) {
+        showFederationHelp();
+        return;
+      }
+      await federationCommand(command.slice(1), options);
       break;
 
     default:

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -206,6 +206,12 @@ export class ApiClient {
   async listTags(): Promise<ApiResponse<TagWithCount[]>> {
     return this.request<TagWithCount[]>("GET", "/tags");
   }
+
+  // Federation methods
+
+  async federationDelete(uri: string): Promise<ApiResponse<{ success: boolean; uri: string }>> {
+    return this.request<{ success: boolean; uri: string }>("POST", "/federation/delete", { uri });
+  }
 }
 
 function getMimeType(filename: string): string {

--- a/src/federation/publish.ts
+++ b/src/federation/publish.ts
@@ -200,6 +200,7 @@ export async function sendDeleteActivity(slug: string): Promise<boolean> {
 
   const ctx = federation.createContext(new URL(baseUrl), undefined);
   const actorUri = ctx.getActorUri("erik");
+  const followersUri = ctx.getFollowersUri("erik");
 
   // The object URI that was deleted (must match the URI used when created)
   const objectUri = new URL(`/posts/${slug}`, baseUrl);
@@ -209,6 +210,8 @@ export async function sendDeleteActivity(slug: string): Promise<boolean> {
     id: activityUri,
     actor: actorUri,
     object: objectUri,
+    to: PUBLIC,
+    cc: followersUri,
   });
 
   logger.info(
@@ -225,6 +228,55 @@ export async function sendDeleteActivity(slug: string): Promise<boolean> {
     return true;
   } catch (error) {
     logger.error("federation", `Failed to send Delete activity for post ${slug}`, { error });
+    return false;
+  }
+}
+
+/**
+ * Send a Delete activity for an arbitrary URI.
+ *
+ * Use this to delete posts that were federated with old URIs,
+ * or to clean up posts during development.
+ *
+ * @param uri The full URI of the object to delete (e.g., https://erikcraddock.me/posts/4)
+ * @returns true if activity was sent, false if no followers
+ */
+export async function sendDeleteActivityForUri(uri: string): Promise<boolean> {
+  const followers = getAllFollowers();
+  if (followers.length === 0) {
+    logger.debug("federation", `No followers to send Delete for URI ${uri}`);
+    return true;
+  }
+
+  const ctx = federation.createContext(new URL(baseUrl), undefined);
+  const actorUri = ctx.getActorUri("erik");
+  const followersUri = ctx.getFollowersUri("erik");
+
+  const objectUri = new URL(uri);
+  const activityUri = new URL(`${uri}#delete-${Date.now()}`);
+
+  const activity = new Delete({
+    id: activityUri,
+    actor: actorUri,
+    object: objectUri,
+    to: PUBLIC,
+    cc: followersUri,
+  });
+
+  logger.info(
+    "federation",
+    `Sending Delete activity for URI ${uri} to ${followers.length} followers`
+  );
+
+  try {
+    await ctx.sendActivity({ identifier: "erik" }, "followers", activity, {
+      preferSharedInbox: true,
+    });
+
+    logger.info("federation", `Successfully queued Delete activity for URI ${uri}`);
+    return true;
+  } catch (error) {
+    logger.error("federation", `Failed to send Delete activity for URI ${uri}`, { error });
     return false;
   }
 }

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -25,6 +25,7 @@ import { listTags } from "@/services/tags";
 import {
   federatePost,
   sendDeleteActivity,
+  sendDeleteActivityForUri,
   sendUpdateActivity,
   sendActorUpdateActivity,
 } from "@/federation/publish";
@@ -698,6 +699,37 @@ api.post("/federation/update-actor", async (c) => {
   try {
     const sent = await sendActorUpdateActivity();
     return c.json({ success: sent });
+  } catch (error) {
+    return c.json({ error: String(error) }, 500);
+  }
+});
+
+/**
+ * POST /api/federation/delete - Send Delete activity for an arbitrary URI
+ *
+ * Use this to delete posts that were federated with old URIs,
+ * or to clean up posts during development.
+ *
+ * Body: { "uri": "https://erikcraddock.me/posts/4" }
+ */
+api.post("/federation/delete", async (c) => {
+  try {
+    const body = await c.req.json();
+    const { uri } = body;
+
+    if (!uri || typeof uri !== "string") {
+      return c.json({ error: "uri is required and must be a string" }, 400);
+    }
+
+    // Validate it's a valid URL
+    try {
+      new URL(uri);
+    } catch {
+      return c.json({ error: "uri must be a valid URL" }, 400);
+    }
+
+    const sent = await sendDeleteActivityForUri(uri);
+    return c.json({ success: sent, uri });
   } catch (error) {
     return c.json({ error: String(error) }, 500);
   }


### PR DESCRIPTION
## Problem

1. Delete activities were missing `to`/`cc` addressing, causing Mastodon to ignore them
2. Old posts federated with numeric IDs can't be deleted because URIs changed to slugs

## Solution

1. Add `to: PUBLIC` and `cc: followersUri` to Delete activity
2. Add `sendDeleteActivityForUri()` for arbitrary URI deletion  
3. Add `POST /api/federation/delete` endpoint
4. Add `ec federation delete <uri>` CLI command

## Usage

```bash
# Delete a post by its old numeric ID URI
ec federation delete https://erikcraddock.me/posts/4

# Or via API
curl -X POST https://erikcraddock.me/api/federation/delete \
  -H 'Authorization: Bearer $API_KEY' \
  -H 'Content-Type: application/json' \
  -d '{"uri": "https://erikcraddock.me/posts/4"}'
```

Fixes #1487