### PR TITLE
fix: set url to external URL for link posts

### DIFF
--- a/src/federation/__tests__/outbox.test.ts
+++ b/src/federation/__tests__/outbox.test.ts
@@ -92,6 +92,19 @@ describe("postToObject", () => {
 
       expect(result.summary).toBeFalsy();
     });
+
+    it("sets url to external URL for link posts", () => {
+      const post = createPost({
+        type: "link",
+        title: "Link Title",
+        content: "Commentary",
+        url: "https://example.com/article",
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+
+      expect(result.url?.href).toBe("https://example.com/article");
+    });
   });
 
   describe("Article posts", () => {

--- a/src/federation/post-object.ts
+++ b/src/federation/post-object.ts
@@ -81,7 +81,8 @@ export function postToObject(
     // Only set summary for Articles - for Notes it triggers CW behavior
     summary: post.title && post.type !== "link" ? (post.excerpt ?? undefined) : undefined,
     published: post.published_at ? dateToInstant(new Date(post.published_at)) : undefined,
-    url: postUri,
+    // For links, url points to external article so Mastodon links there and generates preview
+    url: post.type === "link" && post.url ? new URL(post.url) : postUri,
     attachments: attachments.length > 0 ? attachments : undefined,
   });
 }


### PR DESCRIPTION
Link posts should point to the external article URL, not the site's post page.

This allows Mastodon to:
1. Link directly to the external article when clicking the post
2. Generate a preview card for the external article

Fixes task #1486