### PR TITLE
fix: set og:url to external URL for link posts

### DIFF
--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -559,6 +559,29 @@ describe("pages routes", () => {
       const html = await res.text();
       expect(html).not.toContain('class="w-full h-64 object-cover');
     });
+
+    it("sets og:url to external URL for link posts", async () => {
+      const app = getApp();
+      const res = await app.request("/posts/test-link");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      // Link posts should have og:url pointing to the external article
+      expect(html).toContain('property="og:url" content="https://example.com/article"');
+    });
+
+    it("sets og:url to site URL for article posts", async () => {
+      const app = getApp();
+      const res = await app.request("/posts/test-post");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      // Article posts should have og:url pointing to the site
+      expect(html).toContain('property="og:url"');
+      expect(html).toContain("/posts/test-post");
+    });
   });
 
   describe("GET /tags/:slug", () => {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1015,7 +1015,8 @@ export function createPagesRoutes(db: Database): Hono {
 
     const title = post.title || (isNote ? "Note" : "Post");
     const description = post.excerpt || truncate(post.content, 160);
-    const canonicalUrl = `/posts/${slug}`;
+    // For link posts, use external URL for OG tags so Mastodon generates correct preview
+    const canonicalUrl = post.type === "link" && post.url ? post.url : `/posts/${slug}`;
 
     return c.html(
       <Layout


### PR DESCRIPTION
Mastodon generates preview cards by fetching the ActivityPub `id` URL and extracting OpenGraph metadata. For link posts, we now set `og:url` to the external article URL so Mastodon shows the correct preview.

## Changes

- `src/routes/pages.tsx`: For link posts with a `url`, use external URL for `canonicalUrl` (which becomes `og:url`)
- Added tests for og:url on link vs article posts

## Why This Might NOT Work

1. Mastodon might ignore `og:url` and use the URL it fetched
2. Existing posts are cached - need new slug to test
3. Could affect SEO if `og:url` differs from actual page URL

## Testing

Need to:
1. Delete existing test post
2. Republish with a NEW slug (not reused)
3. Check Mastodon for correct preview

Fixes #1493