### PR TITLE
fix: send HTML content in ActivityPub for Mastodon preview cards

### DIFF
--- a/src/federation/__tests__/outbox.test.ts
+++ b/src/federation/__tests__/outbox.test.ts
@@ -21,7 +21,7 @@ function createPost(overrides: Partial<PublishedPost>): PublishedPost {
 
 describe("postToObject", () => {
   describe("Note posts", () => {
-    it("converts note to Note type with full content", () => {
+    it("converts note to Note type with full content as HTML", () => {
       const post = createPost({
         type: "note",
         title: null,
@@ -34,7 +34,8 @@ describe("postToObject", () => {
       expect(result).toBeInstanceOf(Note);
       expect(result.name).toBeFalsy();
       expect(result.summary).toBeFalsy();
-      expect(result.content).toBe("This is a short note");
+      // Content is rendered as HTML for Mastodon compatibility
+      expect(result.content).toBe("<p>This is a short note</p>\n");
     });
 
     it("does not set summary on notes (avoids CW behavior)", () => {
@@ -52,7 +53,7 @@ describe("postToObject", () => {
   });
 
   describe("Link posts", () => {
-    it("converts link to Note type with commentary and external URL", () => {
+    it("converts link to Note type with HTML commentary and clickable URL", () => {
       const post = createPost({
         type: "link",
         title: "Link Title",
@@ -63,7 +64,10 @@ describe("postToObject", () => {
       const result = postToObject(post, actorUri, followersUri);
 
       expect(result).toBeInstanceOf(Note);
-      expect(result.content).toBe("My commentary on this link\n\nhttps://example.com/article");
+      // Content is HTML with clickable <a> tag so Mastodon can crawl for preview card
+      expect(result.content).toBe(
+        '<p>My commentary on this link</p>\n<p><a href="https://example.com/article">https://example.com/article</a></p>'
+      );
     });
 
     it("does not set name on link posts (Note type)", () => {

--- a/src/federation/post-object.ts
+++ b/src/federation/post-object.ts
@@ -1,5 +1,6 @@
 import { Note, Article, Document } from "@fedify/fedify";
 import { dateToInstant, baseUrl } from "./utils";
+import { renderMarkdown } from "../utils/markdown";
 
 // ActivityPub Public address
 const PUBLIC = new URL("https://www.w3.org/ns/activitystreams#Public");
@@ -31,17 +32,27 @@ export function postToObject(
   // Use Note for notes and links (links are commentary + URL, displayed inline)
   const ObjectClass = post.title && post.type !== "link" ? Article : Note;
 
-  // Build content based on post type:
-  // - Notes: full content (short by nature)
-  // - Links: commentary + external URL (Mastodon generates preview card)
-  // - Articles: excerpt + link to article (Mastodon generates preview card from our site)
-  let content = post.content;
+  // Build content as HTML based on post type:
+  // - Notes: full content rendered as HTML
+  // - Links: commentary HTML + external URL as clickable link (Mastodon crawls first link for preview)
+  // - Articles: excerpt HTML + link to article
+  // Mastodon expects HTML content and parses <a> tags to find links for preview cards.
   const postUrl = new URL(`/posts/${post.slug}`, baseUrl).href;
+  let content: string;
 
   if (post.type === "link" && post.url) {
-    content = `${post.content}\n\n${post.url}`;
+    // Link posts: render commentary as HTML, append external URL as visible link
+    const commentaryHtml = renderMarkdown(post.content);
+    content = `${commentaryHtml}<p><a href="${post.url}">${post.url}</a></p>`;
   } else if (post.type === "article") {
-    content = post.excerpt ? `${post.excerpt}\n\n${postUrl}` : postUrl;
+    // Articles: render excerpt as HTML, append link to our site
+    const excerptHtml = post.excerpt ? renderMarkdown(post.excerpt) : "";
+    content = excerptHtml
+      ? `${excerptHtml}<p><a href="${postUrl}">${postUrl}</a></p>`
+      : `<p><a href="${postUrl}">${postUrl}</a></p>`;
+  } else {
+    // Notes: render full content as HTML
+    content = renderMarkdown(post.content);
   }
 
   // Build attachments array for media (banner images on articles only)


### PR DESCRIPTION
## Problem

PR #86 set og:url to the external URL, but Mastodon still wasn't generating preview cards for the external link. Investigation revealed:

- **Mastodon expects HTML content** with `<a>` tags
- Mastodon parses the first `<a href>` in content to crawl for preview cards
- We were sending plain text, which Mastodon couldn't parse

## Solution

Convert content to HTML before sending via ActivityPub:

- Render markdown content using `renderMarkdown()`
- For link posts: HTML commentary + external URL as clickable `<a>` tag
- For articles: HTML excerpt + site URL as clickable `<a>` tag  
- For notes: HTML content

## Testing

1. Delete existing test post
2. Create new link post with fresh slug
3. Publish and verify Mastodon generates preview for external URL

Fixes task #1493