### PR TITLE
fix: set language on ActivityPub content to avoid Translate link

### DIFF
--- a/src/federation/__tests__/outbox.test.ts
+++ b/src/federation/__tests__/outbox.test.ts
@@ -34,8 +34,8 @@ describe("postToObject", () => {
       expect(result).toBeInstanceOf(Note);
       expect(result.name).toBeFalsy();
       expect(result.summary).toBeFalsy();
-      // Content is rendered as HTML for Mastodon compatibility
-      expect(result.content).toBe("<p>This is a short note</p>\n");
+      // Content is rendered as HTML for Mastodon compatibility, wrapped in LanguageString
+      expect(String(result.content)).toBe("<p>This is a short note</p>\n");
     });
 
     it("does not set summary on notes (avoids CW behavior)", () => {
@@ -65,7 +65,7 @@ describe("postToObject", () => {
 
       expect(result).toBeInstanceOf(Note);
       // Content is HTML with clickable <a> tag so Mastodon can crawl for preview card
-      expect(result.content).toBe(
+      expect(String(result.content)).toBe(
         '<p>My commentary on this link</p>\n<p><a href="https://example.com/article">https://example.com/article</a></p>'
       );
     });
@@ -125,8 +125,8 @@ describe("postToObject", () => {
 
       expect(result).toBeInstanceOf(Article);
       expect(result.name).toBe("My Article");
-      expect(result.content).toContain("Brief excerpt");
-      expect(result.content).toContain("/posts/my-article");
+      expect(String(result.content)).toContain("Brief excerpt");
+      expect(String(result.content)).toContain("/posts/my-article");
     });
 
     it("includes banner image as attachment", async () => {
@@ -185,8 +185,8 @@ describe("postToObject", () => {
 
       const result = postToObject(post, actorUri, followersUri);
 
-      expect(result.content).toContain("/posts/no-excerpt-article");
-      expect(result.content).not.toContain("\n\n"); // Just URL, no excerpt prefix
+      expect(String(result.content)).toContain("/posts/no-excerpt-article");
+      expect(String(result.content)).not.toContain("\n\n"); // Just URL, no excerpt prefix
     });
   });
 

--- a/src/federation/post-object.ts
+++ b/src/federation/post-object.ts
@@ -1,4 +1,4 @@
-import { Note, Article, Document } from "@fedify/fedify";
+import { Note, Article, Document, LanguageString } from "@fedify/fedify";
 import { dateToInstant, baseUrl } from "./utils";
 import { renderMarkdown } from "../utils/markdown";
 
@@ -88,7 +88,8 @@ export function postToObject(
     cc: followersUri,
     // Only set name for Articles (not links, not notes)
     name: post.title && post.type !== "link" ? post.title : undefined,
-    content: content,
+    // Wrap content in LanguageString to set language, avoiding Mastodon's "Translate" link
+    content: new LanguageString(content, "en"),
     // Only set summary for Articles - for Notes it triggers CW behavior
     summary: post.title && post.type !== "link" ? (post.excerpt ?? undefined) : undefined,
     published: post.published_at ? dateToInstant(new Date(post.published_at)) : undefined,


### PR DESCRIPTION
## Problem

Mastodon shows a 'Translate' link on posts when the language isn't specified. We were setting `content` as a plain string without language information.

## Solution

Use Fedify's `LanguageString` to wrap content with 'en' language tag:

```typescript
content: new LanguageString(content, "en")
```

This produces ActivityPub JSON-LD with `contentMap`:
```json
{
  "contentMap": {
    "en": "<p>content here</p>"
  }
}
```

Mastodon will now know the content is in English and won't show 'Translate' for users with English interface.

Fixes task #1497