### PR TITLE
feat: add release script to ensure version bump

### DIFF
--- a/.pi/skills/web-release/SKILL.md
+++ b/.pi/skills/web-release/SKILL.md
@@ -7,93 +7,89 @@ description: Create a new web release tag based on conventional commits. Use whe
 
 Create a new web release tag (`web-v*`) based on conventional commits since the last release.
 
+## Quick Reference
+
+```bash
+# The script handles: version bump, commit, tag, push
+# Path: ./scripts/release.sh (relative to this skill directory)
+./scripts/release.sh patch   # Bug fixes
+./scripts/release.sh minor   # New features
+./scripts/release.sh major   # Breaking changes
+./scripts/release.sh 1.2.3   # Explicit version
+```
+
 ## Instructions
 
-1. **Verify on main branch with no unpushed commits**:
-   - Verify you're on main branch: `git branch --show-current`
-   - If NOT on main, **STOP** and inform the user: "Releases must be created from the main branch. Please switch to main first."
-   - Fetch the latest from origin: `git fetch origin main`
-   - Check for unpushed commits: `git log origin/main..HEAD --oneline`
-   - If there are any unpushed commits, **STOP** and inform the user:
-     - "There are unpushed commits on the main branch. Please push or create a feature branch and submit a pull request before creating a release."
-     - List the unpushed commits so they can see what needs to be addressed
-     - Do NOT proceed with the release
+### 1. Verify on main branch
 
-2. **Get the current web release tag**:
-   - Run `git tag --list 'web-v*' --sort=-v:refname | head -1` to get the latest web tag
-   - If no web tags exist, assume starting from web-v0.0.0
+```bash
+git branch --show-current
+git fetch origin main
+git log origin/main..HEAD --oneline
+```
 
-3. **Get changes since the last tag**:
-   - Run `git log <latest-tag>..HEAD --oneline` to see commits since the last tag
-   - If there are no commits since the last tag, inform the user and stop
+- Must be on `main`
+- No unpushed commits (if any exist, stop and tell user to push or create PR)
 
-4. **Analyze commits to determine version bump**:
-   Using semantic versioning (MAJOR.MINOR.PATCH):
-   - **MAJOR** (breaking change): Look for commits with:
-     - BREAKING CHANGE: in the message
-     - An exclamation mark after the type, like `feat!:` or `fix!:`
+### 2. Get changes since last release
 
-   - **MINOR** (new feature): Look for commits with:
-     - `feat:` prefix (new features)
+```bash
+LATEST_TAG=$(git tag --list 'web-v*' --sort=-v:refname | head -1)
+git log ${LATEST_TAG}..HEAD --oneline
+```
 
-   - **PATCH** (bug fix): Look for commits with:
-     - `fix:` prefix (bug fixes)
-     - `perf:` prefix (performance improvements)
+If no commits since last tag, inform user and stop.
 
-   Other commit types (docs:, style:, refactor:, test:, chore:, ci:, build:) do not trigger a version bump on their own, but if mixed with feat: or fix: commits, the highest applicable bump wins.
+### 3. Analyze commits for version bump
 
-   Priority: MAJOR > MINOR > PATCH
+**MAJOR** (breaking): `BREAKING CHANGE:` in message, or `feat!:`, `fix!:`
+**MINOR** (feature): `feat:` prefix
+**PATCH** (fix): `fix:`, `perf:` prefix
 
-   If no version-bumping commits found, default to PATCH.
+Other types (docs, style, refactor, test, chore, ci, build) don't bump alone.
 
-5. **Calculate the new version**:
-   - Parse the current version, for example web-v1.2.3 becomes major=1, minor=2, patch=3
-   - Apply the appropriate bump:
-     - MAJOR: increment major, reset minor and patch to 0
-     - MINOR: increment minor, reset patch to 0
-     - PATCH: increment patch only
+Priority: MAJOR > MINOR > PATCH. Default to PATCH if unclear.
 
-6. **Present findings to the user**:
-   Show:
-   - Current version
-   - Summary of changes (grouped by type)
-   - Recommended new version and why
-   - Ask if they want to proceed with the suggested version, a different bump level, or cancel
+### 4. Present options to user
 
-   Options should be:
-   - The recommended version, such as web-v1.2.0 - Minor release (Recommended)
-   - Alternative versions if applicable, such as web-v2.0.0 - Major release or web-v1.1.1 - Patch release
-   - Cancel - Do not create a release
+Show:
 
-7. **Update package.json** (if user approves):
-   - Extract the semver from the tag (e.g., `web-v1.2.0` → `1.2.0`)
-   - Update the `version` field in `package.json` using jq or sed:
-     ```bash
-     # Using jq
-     jq --arg v "1.2.0" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
-     ```
-   - Commit the version bump:
-     ```bash
-     git add package.json
-     git commit -m "chore: bump version to 1.2.0"
-     ```
+- Current version
+- Commits since last release (grouped by type)
+- Recommended bump and why
 
-8. **Create the tag**:
-   - Create an annotated tag on the version bump commit: `git tag -a <new-version> -m "Release <new-version>"`
-   - Ask if the user wants to push the commit and tag to origin
+Ask user to choose:
 
-9. **Push the commit and tag** (if requested):
-   - Push both together: `git push origin main --follow-tags`
-   - Confirm success to the user
-   - Note: Pushing the tag will trigger the deploy workflow which builds and pushes the Docker image to Docker Hub
+- Recommended version (e.g., "1.2.4 - Patch (Recommended)")
+- Alternative bumps if applicable
+- Cancel
+
+### 5. Run the release script
+
+Once user chooses, run `./scripts/release.sh` from this skill's directory:
+
+```bash
+.pi/skills/web-release/scripts/release.sh <patch|minor|major>
+```
+
+The script handles:
+
+1. Validates on main with no unpushed commits
+2. Updates package.json
+3. Commits the version bump
+4. Creates annotated tag
+5. Pushes commit and tag
+
+### 6. Confirm success
+
+After the script completes, note that GitHub Actions will:
+
+- Build Docker image for amd64 and arm64
+- Push to `evcraddock/erikcraddock-web` on Docker Hub
+- Tag with semver, timestamp, and `latest`
 
 ## Important Notes
 
 - NEVER force push or use `--force` flags
-- Always use annotated tags (`-a` flag) for releases
-- The tag message should be "Release {version}" where {version} is the new version number
-- If anything goes wrong, explain the error and do not proceed
-- After pushing the tag, the GitHub Actions workflow will:
-  - Build Docker image for amd64 and arm64
-  - Push to `evcraddock/erikcraddock-web` on Docker Hub
-  - Tag with semver, timestamp, and `latest`
+- The script creates annotated tags automatically
+- If script fails, read the error and do not retry blindly

--- a/.pi/skills/web-release/scripts/release.sh
+++ b/.pi/skills/web-release/scripts/release.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Create a web release with proper version bumping.
+#
+# Usage:
+#   ./scripts/release.sh patch|minor|major
+#   ./scripts/release.sh <version>  (e.g., 1.2.3)
+#
+# This script:
+#   1. Validates we're on main with no unpushed commits
+#   2. Calculates or validates the new version
+#   3. Updates package.json
+#   4. Commits the version bump
+#   5. Creates an annotated tag
+#   6. Pushes commit and tag to origin
+#
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+die() {
+  echo -e "${RED}Error: $1${NC}" >&2
+  exit 1
+}
+
+info() {
+  echo -e "${GREEN}$1${NC}"
+}
+
+warn() {
+  echo -e "${YELLOW}$1${NC}"
+}
+
+# Validate arguments
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 patch|minor|major|<version>"
+  echo ""
+  echo "Examples:"
+  echo "  $0 patch    # 1.2.3 -> 1.2.4"
+  echo "  $0 minor    # 1.2.3 -> 1.3.0"
+  echo "  $0 major    # 1.2.3 -> 2.0.0"
+  echo "  $0 1.5.0    # Explicit version"
+  exit 1
+fi
+
+BUMP_ARG="$1"
+
+# Step 1: Validate we're on main
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  die "Must be on main branch (currently on '$CURRENT_BRANCH')"
+fi
+
+# Step 2: Fetch and check for unpushed commits
+git fetch origin main --quiet
+UNPUSHED=$(git log origin/main..HEAD --oneline)
+if [[ -n "$UNPUSHED" ]]; then
+  die "Unpushed commits on main:\n$UNPUSHED\n\nPush these or create a PR first."
+fi
+
+# Step 3: Get current version from latest tag
+LATEST_TAG=$(git tag --list 'web-v*' --sort=-v:refname | head -1)
+if [[ -z "$LATEST_TAG" ]]; then
+  CURRENT_VERSION="0.0.0"
+else
+  CURRENT_VERSION="${LATEST_TAG#web-v}"
+fi
+
+info "Current version: $CURRENT_VERSION"
+
+# Parse current version
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+# Step 4: Calculate new version
+if [[ "$BUMP_ARG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  # Explicit version provided
+  NEW_VERSION="$BUMP_ARG"
+elif [[ "$BUMP_ARG" == "patch" ]]; then
+  NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+elif [[ "$BUMP_ARG" == "minor" ]]; then
+  NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
+elif [[ "$BUMP_ARG" == "major" ]]; then
+  NEW_VERSION="$((MAJOR + 1)).0.0"
+else
+  die "Invalid argument: $BUMP_ARG (expected patch|minor|major or X.Y.Z)"
+fi
+
+NEW_TAG="web-v$NEW_VERSION"
+
+info "New version: $NEW_VERSION (tag: $NEW_TAG)"
+
+# Check if tag already exists
+if git tag --list | grep -q "^$NEW_TAG$"; then
+  die "Tag $NEW_TAG already exists"
+fi
+
+# Step 5: Update package.json
+CURRENT_PKG_VERSION=$(jq -r .version package.json)
+if [[ "$CURRENT_PKG_VERSION" != "$NEW_VERSION" ]]; then
+  info "Updating package.json: $CURRENT_PKG_VERSION -> $NEW_VERSION"
+  jq --arg v "$NEW_VERSION" '.version = $v' package.json > package.json.tmp
+  mv package.json.tmp package.json
+else
+  warn "package.json already at $NEW_VERSION"
+fi
+
+# Step 6: Commit the version bump (if there are changes)
+if ! git diff --quiet package.json; then
+  git add package.json
+  git commit -m "chore: bump version to $NEW_VERSION"
+  info "Committed version bump"
+else
+  warn "No changes to commit (package.json unchanged)"
+fi
+
+# Step 7: Create annotated tag
+git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+info "Created tag: $NEW_TAG"
+
+# Step 8: Push commit and tag
+info "Pushing to origin..."
+git push origin main --follow-tags
+
+info ""
+info "✅ Released $NEW_TAG"
+info ""
+info "GitHub Actions will now build and push the Docker image."


### PR DESCRIPTION
## Problem

The web-release skill has instructions to bump package.json, but the agent can skip steps. Result: package.json is at 1.1.2 while latest tag is web-v1.1.6.

## Solution

Add a release script that handles all mechanical steps atomically:

```bash
.pi/skills/web-release/scripts/release.sh patch|minor|major|<version>
```

The script:
1. Validates on main with no unpushed commits
2. Calculates new version (or uses explicit version)
3. Updates package.json
4. Commits the version bump
5. Creates annotated tag
6. Pushes commit and tag

The skill is simplified to: analyze commits → present options → run script.

## Testing

```bash
# Shows usage
.pi/skills/web-release/scripts/release.sh

# Would create 1.1.7 (current is 1.1.6)
.pi/skills/web-release/scripts/release.sh patch
```

Fixes task #1491