### PR TITLE
fix: add to/cc addressing to Update activity

### DIFF
--- a/src/federation/publish.ts
+++ b/src/federation/publish.ts
@@ -256,6 +256,9 @@ export async function sendUpdateActivity(postId: number): Promise<boolean> {
   const activity = new Update({
     id: activityUri,
     actor: actorUri,
+    // Addressing: public posts visible to everyone, CC'd to followers
+    to: PUBLIC,
+    cc: followersUri,
     object: object,
   });
 


### PR DESCRIPTION
## Problem

Update activities were missing `to` and `cc` addressing, causing them to not be delivered properly to followers when editing posts.

## Solution

Added the same addressing pattern used by Create activities:

```typescript
const activity = new Update({
  id: activityUri,
  actor: actorUri,
  to: PUBLIC,
  cc: followersUri,
  object: object,
});
```

## Testing

Edit a published post and verify the Update is delivered to Mastodon followers.

Fixes task #1499