### PR TITLE
fix: output both content and contentMap for Mastodon compatibility

### DIFF
--- a/src/federation/post-object.ts
+++ b/src/federation/post-object.ts
@@ -88,8 +88,10 @@ export function postToObject(
     cc: followersUri,
     // Only set name for Articles (not links, not notes)
     name: post.title && post.type !== "link" ? post.title : undefined,
-    // Wrap content in LanguageString to set language, avoiding Mastodon's "Translate" link
-    content: new LanguageString(content, "en"),
+    // Use contents (plural) with both plain string and LanguageString to output both
+    // 'content' and 'contentMap' fields. Mastodon needs 'content' for Updates to work,
+    // and 'contentMap' tells it the language (avoiding "Translate" link).
+    contents: [content, new LanguageString(content, "en")],
     // Only set summary for Articles - for Notes it triggers CW behavior
     summary: post.title && post.type !== "link" ? (post.excerpt ?? undefined) : undefined,
     published: post.published_at ? dateToInstant(new Date(post.published_at)) : undefined,


### PR DESCRIPTION
## Problem

Using `LanguageString` for content outputs only `contentMap`, leaving `content` as null:

```json
{"contentMap": {"en": "..."}, "content": null}
```

Mastodon needs the `content` field - especially for Update activities to work properly.

## Solution

Use `contents` (plural) with both a plain string AND a LanguageString:

```typescript
contents: [content, new LanguageString(content, 'en')]
```

This outputs both:

```json
{"content": "...", "contentMap": {"en": "..."}}
```

## Testing

1. Edit a published post
2. Verify the Update is applied on Mastodon (content changes visible)
3. Verify 'Translate' link is gone (language is set)

Fixes task #1500