### PR TITLE
fix: add 'updated' timestamp to ActivityPub objects

### DIFF
--- a/src/federation/__tests__/outbox.test.ts
+++ b/src/federation/__tests__/outbox.test.ts
@@ -15,6 +15,7 @@ function createPost(overrides: Partial<PublishedPost>): PublishedPost {
     excerpt: "Test excerpt",
     url: null,
     published_at: new Date("2026-01-01"),
+    updated_at: new Date("2026-01-01"),
     ...overrides,
   };
 }

--- a/src/federation/outbox.ts
+++ b/src/federation/outbox.ts
@@ -28,6 +28,7 @@ export function getPublishedPosts(limit: number = 20, offset: number = 0): Publi
       excerpt: posts.excerpt,
       url: posts.url,
       published_at: posts.published_at,
+      updated_at: posts.updated_at,
       banner_s3_key: media.s3_key,
       banner_alt: media.alt_text,
     })
@@ -49,6 +50,7 @@ export function getPublishedPosts(limit: number = 20, offset: number = 0): Publi
     excerpt: r.excerpt,
     url: r.url,
     published_at: r.published_at!,
+    updated_at: r.updated_at,
     banner_url: r.banner_s3_key ? new URL(mediaUrl(r.banner_s3_key), baseUrl).href : null,
     banner_alt: r.banner_alt,
   }));

--- a/src/federation/post-object.ts
+++ b/src/federation/post-object.ts
@@ -14,6 +14,7 @@ export interface PublishedPost {
   excerpt: string | null;
   url: string | null;
   published_at: Date;
+  updated_at: Date;
   banner_url?: string | null;
   banner_alt?: string | null;
 }
@@ -95,6 +96,7 @@ export function postToObject(
     // Only set summary for Articles - for Notes it triggers CW behavior
     summary: post.title && post.type !== "link" ? (post.excerpt ?? undefined) : undefined,
     published: post.published_at ? dateToInstant(new Date(post.published_at)) : undefined,
+    updated: post.updated_at ? dateToInstant(new Date(post.updated_at)) : undefined,
     // For links, url points to external article so Mastodon links there and generates preview
     url: post.type === "link" && post.url ? new URL(post.url) : postUri,
     attachments: attachments.length > 0 ? attachments : undefined,

--- a/src/federation/publish.ts
+++ b/src/federation/publish.ts
@@ -26,6 +26,7 @@ function getPublishedPostById(postId: number): PublishedPost | null {
       excerpt: posts.excerpt,
       url: posts.url,
       published_at: posts.published_at,
+      updated_at: posts.updated_at,
       banner_s3_key: media.s3_key,
       banner_alt: media.alt_text,
     })
@@ -47,6 +48,7 @@ function getPublishedPostById(postId: number): PublishedPost | null {
     excerpt: result.excerpt,
     url: result.url,
     published_at: result.published_at,
+    updated_at: result.updated_at,
     banner_url: result.banner_s3_key ? new URL(mediaUrl(result.banner_s3_key), baseUrl).href : null,
     banner_alt: result.banner_alt,
   };

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -925,6 +925,7 @@ export function createPagesRoutes(db: Database): Hono {
           excerpt: posts.excerpt,
           url: posts.url,
           published_at: posts.published_at,
+          updated_at: posts.updated_at,
           banner_image_id: posts.banner_image_id,
         })
         .from(posts)
@@ -955,6 +956,7 @@ export function createPagesRoutes(db: Database): Hono {
         excerpt: post.excerpt,
         url: post.url,
         published_at: post.published_at,
+        updated_at: post.updated_at,
         banner_url: bannerUrl,
         banner_alt: bannerAlt,
       };


### PR DESCRIPTION
## Problem

Mastodon may require an `updated` timestamp on ActivityPub objects to process Update activities. Without it, Updates might be ignored even when delivered successfully.

## Solution

Add `updated_at` field throughout the ActivityPub object creation:

- Add `updated_at` to `PublishedPost` interface
- Include `updated_at` in database queries (publish.ts, outbox.ts, pages.tsx)
- Set `updated` field on ActivityPub Note/Article objects

## Testing

1. Edit a published post
2. Verify the outbox shows `updated` timestamp
3. Check if Mastodon applies the Update

Fixes task #1501