### PR TITLE
feat: support published_at on post creation for imports

### DIFF
--- a/cli/src/commands/link/create.ts
+++ b/cli/src/commands/link/create.ts
@@ -130,6 +130,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
   let source = options.source;
   let banner: string | undefined;
   let bannerImageId: number | undefined;
+  let publishedAt: string | undefined; // For imports - original publish date from frontmatter
 
   if (options.file) {
     // File-based creation
@@ -151,6 +152,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     excerpt = options.excerpt ?? frontmatter.excerpt;
     source = options.source ?? frontmatter.source;
     banner = frontmatter.banner;
+    publishedAt = frontmatter.date; // For imports - set original publish date
 
     // Merge tags: CLI tags override, or use frontmatter
     tags = options.tags ?? frontmatter.tags;
@@ -223,6 +225,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     tags,
     source_id: sourceId,
     banner_image_id: bannerImageId,
+    published_at: publishedAt,
   });
 
   if (result.error) {
@@ -240,7 +243,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     if (post.title) {
       console.log(`   Title: ${post.title}`);
     }
-    console.log(`   Status: draft`);
+    console.log(`   Status: ${post.published_at ? "published" : "draft"}`);
     if (post.tags.length > 0) {
       console.log(`   Tags: ${post.tags.join(", ")}`);
     }

--- a/cli/src/commands/note/create.ts
+++ b/cli/src/commands/note/create.ts
@@ -89,6 +89,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
   let content = options.content;
   let banner: string | undefined;
   let bannerImageId: number | undefined;
+  let publishedAt: string | undefined; // For imports - original publish date from frontmatter
 
   if (options.file) {
     // File-based creation
@@ -106,6 +107,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     // Use frontmatter values, allow CLI overrides
     slug = options.slug ?? frontmatter.slug;
     banner = frontmatter.banner;
+    publishedAt = frontmatter.date; // For imports - set original publish date
 
     // Process images
     const imageRefs = detectImages(banner, bodyContent, basePath);
@@ -157,6 +159,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     slug,
     content,
     banner_image_id: bannerImageId,
+    published_at: publishedAt,
   });
 
   if (result.error) {
@@ -170,7 +173,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     console.log(JSON.stringify(post, null, 2));
   } else {
     console.log(`✅ Note created: ${post.slug}`);
-    console.log(`   Status: draft`);
+    console.log(`   Status: ${post.published_at ? "published" : "draft"}`);
     if (options.file) {
       console.log(`   Source: ${options.file}`);
     }

--- a/cli/src/commands/post/create.ts
+++ b/cli/src/commands/post/create.ts
@@ -133,6 +133,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
   let url = options.url;
   let banner: string | undefined;
   let bannerImageId: number | undefined;
+  let publishedAt: string | undefined; // For imports - original publish date from frontmatter
 
   if (options.file) {
     // File-based creation
@@ -154,6 +155,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     type = options.type ?? frontmatter.type;
     url = options.url ?? frontmatter.url;
     banner = frontmatter.banner;
+    publishedAt = frontmatter.date; // For imports - set original publish date
 
     // Merge tags: CLI tags override, or use frontmatter
     tags = options.tags ?? frontmatter.tags;
@@ -231,6 +233,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     tags,
     url,
     banner_image_id: bannerImageId,
+    published_at: publishedAt,
   });
 
   if (result.error) {
@@ -246,7 +249,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     console.log(`✅ Post created: ${post.slug}`);
     console.log(`   Title: ${post.title || "(no title)"}`);
     console.log(`   Type: ${post.type}`);
-    console.log(`   Status: draft`);
+    console.log(`   Status: ${post.published_at ? "published" : "draft"}`);
     if (post.tags.length > 0) {
       console.log(`   Tags: ${post.tags.join(", ")}`);
     }

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -86,6 +86,7 @@ export class ApiClient {
     source_id?: number;
     tags?: string[];
     banner_image_id?: number;
+    published_at?: string; // ISO date string for imports
   }): Promise<ApiResponse<Post>> {
     return this.request<Post>("POST", "/posts", data);
   }

--- a/cli/src/lib/markdown.ts
+++ b/cli/src/lib/markdown.ts
@@ -13,6 +13,7 @@ export interface PostFrontmatter {
   type?: string;
   url?: string;
   source?: string;
+  date?: string; // For imports - original publish date
 }
 
 export interface ParsedMarkdown {

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -210,6 +210,61 @@ describe("POST /api/posts - slug validation", () => {
     const json = await res.json();
     expect(json.data.slug).toBe("valid-slug-123");
   });
+
+  it("creates post as draft when no published_at provided", async () => {
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "article",
+        slug: "draft-post",
+        title: "Draft Post",
+        content: "Content",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.published_at).toBeNull();
+  });
+
+  it("creates post as published when published_at is provided", async () => {
+    const publishDate = "2024-03-15T10:30:00Z";
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "article",
+        slug: "published-post",
+        title: "Published Post",
+        content: "Content",
+        published_at: publishDate,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    // Compare as Date objects to handle format differences (e.g., .000Z vs Z)
+    expect(new Date(json.data.published_at).getTime()).toBe(new Date(publishDate).getTime());
+  });
+
+  it("rejects invalid published_at date", async () => {
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "article",
+        slug: "invalid-date-post",
+        title: "Post",
+        content: "Content",
+        published_at: "not-a-date",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("not a valid date");
+  });
 });
 
 describe("GET /api/posts/by-slug/:slug", () => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -113,7 +113,18 @@ api.post("/posts", async (c) => {
   const body = await c.req.json();
 
   // Validate type
-  const { type, slug, title, content, excerpt, url, source_id, tags, banner_image_id } = body;
+  const {
+    type,
+    slug,
+    title,
+    content,
+    excerpt,
+    url,
+    source_id,
+    tags,
+    banner_image_id,
+    published_at,
+  } = body;
 
   if (!type || !["article", "link", "note"].includes(type)) {
     return c.json({ error: "Invalid or missing type. Must be article, link, or note" }, 400);
@@ -175,6 +186,18 @@ api.post("/posts", async (c) => {
     return c.json({ error: "source_id must be a number" }, 400);
   }
 
+  // Validate published_at if provided (ISO date string)
+  let publishedAtDate: Date | null = null;
+  if (published_at !== undefined && published_at !== null) {
+    if (typeof published_at !== "string") {
+      return c.json({ error: "published_at must be an ISO date string" }, 400);
+    }
+    publishedAtDate = new Date(published_at);
+    if (isNaN(publishedAtDate.getTime())) {
+      return c.json({ error: "published_at is not a valid date" }, 400);
+    }
+  }
+
   try {
     const post = createPost({
       type,
@@ -186,6 +209,7 @@ api.post("/posts", async (c) => {
       source_id: source_id ?? null,
       tags: tags || [],
       banner_image_id: banner_image_id ?? null,
+      published_at: publishedAtDate,
     });
 
     return c.json({ data: post }, 201);

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -135,6 +135,7 @@ export interface CreatePostInput {
   source_id?: number | null;
   tags?: string[]; // Tag slugs
   banner_image_id?: number | null;
+  published_at?: Date | null; // For imports - set to create as already published
 }
 
 /**
@@ -184,6 +185,7 @@ export function createPost(input: CreatePostInput) {
     source_id,
     tags: tagSlugs,
     banner_image_id,
+    published_at,
   } = input;
 
   // Validate banner_image_id if provided
@@ -208,6 +210,7 @@ export function createPost(input: CreatePostInput) {
   const now = new Date();
 
   // Create the post
+  // If published_at is provided, use it for updated_at too (for imports)
   const post = db
     .insert(posts)
     .values({
@@ -219,8 +222,9 @@ export function createPost(input: CreatePostInput) {
       url: url ?? null,
       source_id: source_id ?? null,
       banner_image_id: banner_image_id ?? null,
-      created_at: now,
-      updated_at: now,
+      created_at: published_at ?? now,
+      updated_at: published_at ?? now,
+      published_at: published_at ?? null,
     })
     .returning()
     .get();


### PR DESCRIPTION
## Summary

Enables creating posts with a specific publish date, for importing old content with original dates preserved.

## API Changes

- `POST /api/posts` accepts optional `published_at` field (ISO date string)
- If provided, creates post as published with that date
- Sets `created_at` and `updated_at` to the same date for consistency
- If not provided, creates as draft (existing behavior)

## CLI Changes

- Parse `date:` from frontmatter in markdown files
- Pass to API as `published_at`
- Works for `ec post create`, `ec link create`, `ec note create`
- Status output shows 'published' when date is set

## Example

```yaml
---
title: My Old Post  
slug: my-old-post
date: 2024-03-15
---
Content here...
```

```bash
bun cli/src/index.ts post create --file old-post.md
# Creates as published with date 2024-03-15
```

## Testing

- Added API tests for published_at behavior
- Manual testing with frontmatter date confirmed working

Fixes task #1503
Unblocks task #1375 (Import old posts)