### PR TITLE
feat: add cli-release skill with push verification

### DIFF
--- a/.pi/skills/cli-release/SKILL.md
+++ b/.pi/skills/cli-release/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: cli-release
+description: Create a new CLI release tag. Use when user says "cli release", "release cli", "new cli version", "release the cli", or similar.
+---
+
+# CLI Release
+
+Create a new CLI release tag (`cli-v*`) based on conventional commits since the last release.
+
+## Quick Reference
+
+```bash
+# The script handles: version bump, commit, tag, push, verify
+# Path: ./scripts/release.sh (relative to this skill directory)
+.pi/skills/cli-release/scripts/release.sh patch   # Bug fixes
+.pi/skills/cli-release/scripts/release.sh minor   # New features
+.pi/skills/cli-release/scripts/release.sh major   # Breaking changes
+.pi/skills/cli-release/scripts/release.sh 1.2.3   # Explicit version
+```
+
+## Instructions
+
+### 1. Verify on main branch
+
+```bash
+git branch --show-current
+git fetch origin main
+git log origin/main..HEAD --oneline
+```
+
+- Must be on `main`
+- No unpushed commits (if any exist, stop and tell user to push or create PR)
+
+### 2. Get changes since last release
+
+```bash
+LATEST_TAG=$(git tag --list 'cli-v*' --sort=-v:refname | head -1)
+git log ${LATEST_TAG}..HEAD --oneline -- cli/
+```
+
+Look at commits that touch the `cli/` directory.
+
+If no CLI commits since last tag, inform user and stop.
+
+### 3. Analyze commits for version bump
+
+**MAJOR** (breaking): `BREAKING CHANGE:` in message, or `feat!:`, `fix!:`
+**MINOR** (feature): `feat:` prefix
+**PATCH** (fix): `fix:`, `perf:` prefix
+
+Other types (docs, style, refactor, test, chore, ci, build) don't bump alone.
+
+Priority: MAJOR > MINOR > PATCH. Default to PATCH if unclear.
+
+### 4. Present options to user
+
+Show:
+
+- Current version
+- CLI commits since last release
+- Recommended bump and why
+
+Ask user to choose:
+
+- Recommended version (e.g., "0.5.0 - Minor (Recommended)")
+- Alternative bumps if applicable
+- Cancel
+
+### 5. Run the release script
+
+Once user chooses, run `./scripts/release.sh` from this skill's directory:
+
+```bash
+.pi/skills/cli-release/scripts/release.sh <patch|minor|major>
+```
+
+The script handles:
+
+1. Validates on main with no unpushed commits
+2. Updates cli/package.json
+3. Commits the version bump
+4. Creates annotated tag
+5. Pushes commit and tag
+6. **Verifies tag exists on remote** (fixes silent push failures)
+
+### 6. Confirm success
+
+After the script completes, note that GitHub Actions will:
+
+- Build CLI binaries for linux-x64, darwin-x64, darwin-arm64
+- Create GitHub release with binaries
+- Update install script availability
+
+## Important Notes
+
+- NEVER force push or use `--force` flags
+- The script creates annotated tags automatically
+- The script **verifies** the tag was pushed (checks remote)
+- If script fails, read the error and do not retry blindly
+- CLI version lives in `cli/package.json`, not root package.json

--- a/.pi/skills/cli-release/scripts/release.sh
+++ b/.pi/skills/cli-release/scripts/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Create a web release with proper version bumping.
+# Create a CLI release with proper version bumping and verification.
 #
 # Usage:
 #   ./scripts/release.sh patch|minor|major
@@ -9,10 +9,11 @@
 # This script:
 #   1. Validates we're on main with no unpushed commits
 #   2. Calculates or validates the new version
-#   3. Updates package.json
+#   3. Updates cli/package.json
 #   4. Commits the version bump
 #   5. Creates an annotated tag
 #   6. Pushes commit and tag to origin
+#   7. VERIFIES tag exists on remote (catches silent push failures)
 #
 set -euo pipefail
 
@@ -39,10 +40,10 @@ if [[ $# -ne 1 ]]; then
   echo "Usage: $0 patch|minor|major|<version>"
   echo ""
   echo "Examples:"
-  echo "  $0 patch    # 1.2.3 -> 1.2.4"
-  echo "  $0 minor    # 1.2.3 -> 1.3.0"
-  echo "  $0 major    # 1.2.3 -> 2.0.0"
-  echo "  $0 1.5.0    # Explicit version"
+  echo "  $0 patch    # 0.4.0 -> 0.4.1"
+  echo "  $0 minor    # 0.4.0 -> 0.5.0"
+  echo "  $0 major    # 0.4.0 -> 1.0.0"
+  echo "  $0 0.5.0    # Explicit version"
   exit 1
 fi
 
@@ -62,11 +63,11 @@ if [[ -n "$UNPUSHED" ]]; then
 fi
 
 # Step 3: Get current version from latest tag
-LATEST_TAG=$(git tag --list 'web-v*' --sort=-v:refname | head -1)
+LATEST_TAG=$(git tag --list 'cli-v*' --sort=-v:refname | head -1)
 if [[ -z "$LATEST_TAG" ]]; then
   CURRENT_VERSION="0.0.0"
 else
-  CURRENT_VERSION="${LATEST_TAG#web-v}"
+  CURRENT_VERSION="${LATEST_TAG#cli-v}"
 fi
 
 info "Current version: $CURRENT_VERSION"
@@ -88,7 +89,7 @@ else
   die "Invalid argument: $BUMP_ARG (expected patch|minor|major or X.Y.Z)"
 fi
 
-NEW_TAG="web-v$NEW_VERSION"
+NEW_TAG="cli-v$NEW_VERSION"
 
 info "New version: $NEW_VERSION (tag: $NEW_TAG)"
 
@@ -102,27 +103,31 @@ if git ls-remote --tags origin | grep -q "refs/tags/$NEW_TAG$"; then
   die "Tag $NEW_TAG already exists on remote"
 fi
 
-# Step 5: Update package.json
-CURRENT_PKG_VERSION=$(jq -r .version package.json)
+# Step 5: Update cli/package.json
+if [[ ! -f cli/package.json ]]; then
+  die "cli/package.json not found"
+fi
+
+CURRENT_PKG_VERSION=$(jq -r .version cli/package.json)
 if [[ "$CURRENT_PKG_VERSION" != "$NEW_VERSION" ]]; then
-  info "Updating package.json: $CURRENT_PKG_VERSION -> $NEW_VERSION"
-  jq --arg v "$NEW_VERSION" '.version = $v' package.json > package.json.tmp
-  mv package.json.tmp package.json
+  info "Updating cli/package.json: $CURRENT_PKG_VERSION -> $NEW_VERSION"
+  jq --arg v "$NEW_VERSION" '.version = $v' cli/package.json > cli/package.json.tmp
+  mv cli/package.json.tmp cli/package.json
 else
-  warn "package.json already at $NEW_VERSION"
+  warn "cli/package.json already at $NEW_VERSION"
 fi
 
 # Step 6: Commit the version bump (if there are changes)
-if ! git diff --quiet package.json; then
-  git add package.json
-  git commit -m "chore: bump version to $NEW_VERSION"
+if ! git diff --quiet cli/package.json; then
+  git add cli/package.json
+  git commit -m "chore(cli): bump version to $NEW_VERSION"
   info "Committed version bump"
 else
-  warn "No changes to commit (package.json unchanged)"
+  warn "No changes to commit (cli/package.json unchanged)"
 fi
 
 # Step 7: Create annotated tag
-git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+git tag -a "$NEW_TAG" -m "CLI Release $NEW_TAG"
 info "Created tag: $NEW_TAG"
 
 # Step 8: Push commit and tag
@@ -142,4 +147,4 @@ info ""
 info "✅ Released $NEW_TAG"
 info "✅ Verified tag exists on remote"
 info ""
-info "GitHub Actions will now build and push the Docker image."
+info "GitHub Actions will now build CLI binaries and create a release."


### PR DESCRIPTION
## Summary

Creates a new `cli-release` skill mirroring the web-release pattern, and adds push verification to both scripts.

## Changes

### New: cli-release skill
- `.pi/skills/cli-release/SKILL.md` - Skill documentation
- `.pi/skills/cli-release/scripts/release.sh` - Release script

Usage:
```bash
.pi/skills/cli-release/scripts/release.sh patch   # 0.4.0 -> 0.4.1
.pi/skills/cli-release/scripts/release.sh minor   # 0.4.0 -> 0.5.0
.pi/skills/cli-release/scripts/release.sh major   # 0.4.0 -> 1.0.0
```

### Updated: web-release script
Added the same verification logic for consistency.

### Push Verification (both scripts)
Both scripts now:
1. Check if tag exists on remote **before** creating locally
2. **Verify** tag was pushed **after** `git push`
3. Fail loudly if tag didn't make it to remote

This catches silent push failures caused by SSH timeouts during pre-push hooks.

## Problem Solved

From task #1490:
> During CLI release, the tag push can fail silently if the pre-push hook is interrupted (e.g., by SSH connection timeout during tests).

Now the script will fail with a clear error:
```
Error: Tag cli-v0.5.0 was NOT pushed to remote!

This can happen if pre-push hooks timeout.
Manually push with: git push origin cli-v0.5.0
```

Fixes task #1490