### PR TITLE
fix: use 1200x630 aspect ratio for post banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,35 @@ ec image delete 42              # Delete image
 
 Run `ec --help` or `ec <command> --help` for full usage.
 
+## Content Guidelines
+
+### Banner Images
+
+Banner images should be **1200x630 pixels** (1.91:1 aspect ratio). This is the Open Graph standard, which means banners also work well as social media preview cards when posts are shared.
+
+| Dimension | Value       |
+| --------- | ----------- |
+| Width     | 1200px      |
+| Height    | 630px       |
+| Aspect    | 1.91:1      |
+| Format    | PNG or JPEG |
+
+Images that don't match this ratio will be cropped (centered) to fit.
+
+### Creating Posts with Banners
+
+In your markdown frontmatter:
+
+```yaml
+---
+title: "My Post Title"
+slug: my-post
+banner: ./images/my-banner.png
+---
+```
+
+The CLI will upload the banner image and attach it to the post.
+
 ## Getting Started
 
 ### Prerequisites

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1043,7 +1043,7 @@ export function createPagesRoutes(db: Database): Hono {
             <img
               src={bannerUrl}
               alt={post.title || "Post banner"}
-              class="w-full h-64 object-cover rounded-lg mb-6"
+              class="w-full aspect-[1200/630] object-cover rounded-lg mb-6"
             />
           )}
 


### PR DESCRIPTION
## Summary
Use the Open Graph standard 1200x630 (1.91:1) aspect ratio for post banner images.

## Changes
- Change banner from fixed `h-64` to `aspect-[1200/630]` (1.91:1 ratio)
- Matches Open Graph standard for social media preview cards
- Add content guidelines to README documenting banner dimensions

## Testing
- Verified banner display with various image types (icons, infographics, styled text)
- All existing tests pass

Task: #1375