### PR TITLE
fix: correct social media links on home and about pages

### DIFF
--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -774,6 +774,7 @@ export function createPagesRoutes(db: Database): Hono {
       },
       { name: "Facebook", url: "https://www.facebook.com/evcraddock", icon: <FacebookIcon /> },
       { name: "YouTube", url: "https://youtube.com/@ErikCraddock", icon: <YouTubeIcon /> },
+      { name: "RSS", url: "/feed.xml", icon: <RssIcon /> },
     ];
 
     return c.html(

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -78,9 +78,13 @@ function RssIcon() {
 function HeroSection() {
   const socialLinks = [
     { name: "GitHub", url: "https://github.com/evcraddock", icon: <GitHubIcon /> },
-    { name: "LinkedIn", url: "https://linkedin.com/in/erikvancraddock", icon: <LinkedInIcon /> },
-    { name: "Facebook", url: "https://facebook.com/erikvancraddock", icon: <FacebookIcon /> },
-    { name: "YouTube", url: "https://youtube.com/@erikvancraddock", icon: <YouTubeIcon /> },
+    {
+      name: "LinkedIn",
+      url: "https://www.linkedin.com/in/erik-craddock-42aa9815",
+      icon: <LinkedInIcon />,
+    },
+    { name: "Facebook", url: "https://www.facebook.com/evcraddock", icon: <FacebookIcon /> },
+    { name: "YouTube", url: "https://youtube.com/@ErikCraddock", icon: <YouTubeIcon /> },
     { name: "RSS", url: "/feed.xml", icon: <RssIcon /> },
   ];
 
@@ -763,9 +767,13 @@ export function createPagesRoutes(db: Database): Hono {
   pages.get("/about", (c) => {
     const socialLinks = [
       { name: "GitHub", url: "https://github.com/evcraddock", icon: <GitHubIcon /> },
-      { name: "LinkedIn", url: "https://linkedin.com/in/erikvancraddock", icon: <LinkedInIcon /> },
-      { name: "Facebook", url: "https://facebook.com/erikvancraddock", icon: <FacebookIcon /> },
-      { name: "YouTube", url: "https://youtube.com/@erikvancraddock", icon: <YouTubeIcon /> },
+      {
+        name: "LinkedIn",
+        url: "https://www.linkedin.com/in/erik-craddock-42aa9815",
+        icon: <LinkedInIcon />,
+      },
+      { name: "Facebook", url: "https://www.facebook.com/evcraddock", icon: <FacebookIcon /> },
+      { name: "YouTube", url: "https://youtube.com/@ErikCraddock", icon: <YouTubeIcon /> },
     ];
 
     return c.html(


### PR DESCRIPTION
## Summary
Fixes incorrect social media URLs on the home page and about page.

## Changes
- **LinkedIn**: Updated to correct profile URL (`erik-craddock-42aa9815`)
- **Facebook**: Fixed username (`evcraddock` instead of `erikvancraddock`)
- **YouTube**: Fixed channel (`@ErikCraddock` instead of `@erikvancraddock`)

## Testing
- Verified links render correctly on home page
- Verified links render correctly on about page
- All existing tests pass

Fixes #1525