### PR TITLE
feat: conditionally hide More Articles button when <= 6 articles

### DIFF
--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { describe, it, expect, beforeAll } from "bun:test";
 import { mock } from "bun:test";
+import { Hono } from "hono";
 import { createTestDb } from "../../db/test-utils";
 import { posts, tags, postTags, sources, media } from "../../db/schema";
 
@@ -185,9 +186,41 @@ describe("pages routes", () => {
       expect(html).toContain('href="/posts/test-post"');
     });
 
-    it("displays More Articles button linking to /articles", async () => {
+    it("hides More Articles button when 6 or fewer articles", async () => {
       const app = getApp();
       const res = await app.request("/");
+      const html = await res.text();
+
+      // With only 2 published articles in test data, button should be hidden
+      expect(html).not.toContain("More Articles");
+    });
+
+    it("shows More Articles button when more than 6 articles", async () => {
+      // Create a separate db with 7 published articles
+      const manyArticlesDb = createTestDb();
+      const manyArticlesNow = new Date();
+
+      // Insert 7 published articles
+      for (let i = 1; i <= 7; i++) {
+        manyArticlesDb
+          .insert(posts)
+          .values({
+            id: i,
+            slug: `article-${i}`,
+            type: "article",
+            title: `Article ${i}`,
+            content: `Content for article ${i}`,
+            published_at: manyArticlesNow,
+            created_at: manyArticlesNow,
+            updated_at: manyArticlesNow,
+          })
+          .run();
+      }
+
+      const manyArticlesApp = new Hono();
+      manyArticlesApp.route("/", createPagesRoutes(manyArticlesDb));
+
+      const res = await manyArticlesApp.request("/");
       const html = await res.text();
 
       expect(html).toContain("More Articles");

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -200,9 +200,11 @@ function ArticleCard({
 function ArticleCardsSection({
   articles,
   getBannerUrl,
+  hasMore,
 }: {
   articles: Post[];
   getBannerUrl: (id: number) => string | null;
+  hasMore: boolean;
 }) {
   if (articles.length === 0) {
     return null;
@@ -219,23 +221,25 @@ function ArticleCardsSection({
         ))}
       </div>
 
-      {/* More Articles button */}
-      <div class="mt-8 text-center">
-        <a
-          href="/articles"
-          class="inline-flex items-center gap-2 px-6 py-3 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-lg transition-colors"
-        >
-          More Articles
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M9 5l7 7-7 7"
-            />
-          </svg>
-        </a>
-      </div>
+      {/* More Articles button - only show if there are more articles */}
+      {hasMore && (
+        <div class="mt-8 text-center">
+          <a
+            href="/articles"
+            class="inline-flex items-center gap-2 px-6 py-3 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-lg transition-colors"
+          >
+            More Articles
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          </a>
+        </div>
+      )}
     </section>
   );
 }
@@ -535,15 +539,21 @@ export function createPagesRoutes(db: Database): Hono {
   const pages = new Hono();
 
   // Home page
+  const HOME_ARTICLES_LIMIT = 6;
+
   pages.get("/", (c) => {
-    // Fetch recent articles (type=article, published, limit 6)
-    const recentArticles = db
+    // Fetch one extra article to check if there are more
+    const fetchedArticles = db
       .select()
       .from(posts)
       .where(and(eq(posts.type, "article"), isNotNull(posts.published_at)))
       .orderBy(desc(posts.published_at))
-      .limit(6)
+      .limit(HOME_ARTICLES_LIMIT + 1)
       .all();
+
+    // Check if there are more articles beyond what we display
+    const hasMoreArticles = fetchedArticles.length > HOME_ARTICLES_LIMIT;
+    const recentArticles = fetchedArticles.slice(0, HOME_ARTICLES_LIMIT);
 
     // Get all banner IDs for the articles
     const bannerIds = recentArticles
@@ -579,7 +589,11 @@ export function createPagesRoutes(db: Database): Hono {
     return c.html(
       <Layout title="Home | erikcraddock.me">
         <HeroSection />
-        <ArticleCardsSection articles={recentArticles} getBannerUrl={getBannerUrl} />
+        <ArticleCardsSection
+          articles={recentArticles}
+          getBannerUrl={getBannerUrl}
+          hasMore={hasMoreArticles}
+        />
       </Layout>
     );
   });


### PR DESCRIPTION
## Summary
On the home page, the "More Articles" button should only appear if there are more than 6 articles. Since the first 6 articles are shown on the front page, the button is unnecessary when all articles are already visible.

## Changes
- Added `hasMore` prop to `ArticleCardsSection` component
- Fetch 7 articles to check if more exist, display first 6
- Conditionally render button only when `hasMore` is true

## Testing
- Added test: hides button when ≤ 6 articles
- Added test: shows button when > 6 articles
- Verified visually in browser

## Task
Fixes #1512