### PR TITLE
feat: include tags as hashtags in federated posts

### DIFF
--- a/src/federation/__tests__/outbox.test.ts
+++ b/src/federation/__tests__/outbox.test.ts
@@ -207,4 +207,86 @@ describe("postToObject", () => {
       expect(result.published).toBeDefined();
     });
   });
+
+  describe("hashtags", () => {
+    it("includes tags as ActivityPub Hashtag objects", async () => {
+      const post = createPost({
+        type: "note",
+        title: null,
+        content: "A post with tags",
+        tags: [
+          { name: "Coding", slug: "coding" },
+          { name: "TypeScript", slug: "typescript" },
+        ],
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+      const json = (await result.toJsonLd()) as Record<string, unknown>;
+      const tags = json.tag as Array<Record<string, unknown>>;
+
+      expect(tags).toBeDefined();
+      expect(tags.length).toBe(2);
+      expect(tags[0].type).toBe("Hashtag");
+      expect(tags[0].name).toBe("#coding");
+      expect(tags[0].href).toContain("/tags/coding");
+      expect(tags[1].type).toBe("Hashtag");
+      expect(tags[1].name).toBe("#typescript");
+      expect(tags[1].href).toContain("/tags/typescript");
+    });
+
+    it("converts tag names to lowercase hashtags", async () => {
+      const post = createPost({
+        type: "article",
+        title: "Tagged Article",
+        tags: [{ name: "AI", slug: "ai" }],
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+      const json = (await result.toJsonLd()) as Record<string, unknown>;
+      // Single tag is an object, not an array
+      const tag = json.tag as Record<string, unknown>;
+
+      expect(tag.name).toBe("#ai");
+    });
+
+    it("removes spaces from tag names", async () => {
+      const post = createPost({
+        type: "note",
+        title: null,
+        tags: [{ name: "Machine Learning", slug: "machine-learning" }],
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+      const json = (await result.toJsonLd()) as Record<string, unknown>;
+      // Single tag is an object, not an array
+      const tag = json.tag as Record<string, unknown>;
+
+      expect(tag.name).toBe("#machinelearning");
+    });
+
+    it("does not include tags property when no tags", async () => {
+      const post = createPost({
+        type: "note",
+        title: null,
+        tags: [],
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+      const json = (await result.toJsonLd()) as Record<string, unknown>;
+
+      expect(json.tag).toBeUndefined();
+    });
+
+    it("does not include tags property when tags is undefined", async () => {
+      const post = createPost({
+        type: "note",
+        title: null,
+      });
+
+      const result = postToObject(post, actorUri, followersUri);
+      const json = (await result.toJsonLd()) as Record<string, unknown>;
+
+      expect(json.tag).toBeUndefined();
+    });
+  });
 });

--- a/src/federation/outbox.ts
+++ b/src/federation/outbox.ts
@@ -1,9 +1,9 @@
 import { Create } from "@fedify/fedify";
 import { desc, isNotNull, count, eq } from "drizzle-orm";
-import { db, posts, media } from "@/db";
+import { db, posts, media, postTags, tags } from "@/db";
 import { logger } from "@/utils/logger";
 import { baseUrl, dateToInstant } from "./utils";
-import { postToObject, PublishedPost } from "./post-object";
+import { postToObject, PublishedPost, PostTag } from "./post-object";
 import { mediaUrl } from "@/services/media";
 
 // ActivityPub Public address
@@ -40,7 +40,31 @@ export function getPublishedPosts(limit: number = 20, offset: number = 0): Publi
     .offset(offset)
     .all();
 
-  // Transform to PublishedPost with banner URL
+  // Fetch tags for all posts in a single query
+  const postIds = results.map((r) => r.id);
+  const allTags =
+    postIds.length > 0
+      ? db
+          .select({
+            postId: postTags.post_id,
+            name: tags.name,
+            slug: tags.slug,
+          })
+          .from(postTags)
+          .innerJoin(tags, eq(postTags.tag_id, tags.id))
+          .all()
+          .filter((t) => postIds.includes(t.postId))
+      : [];
+
+  // Create a map of post_id -> tags
+  const tagsMap = new Map<number, PostTag[]>();
+  for (const t of allTags) {
+    const existing = tagsMap.get(t.postId) || [];
+    existing.push({ name: t.name, slug: t.slug });
+    tagsMap.set(t.postId, existing);
+  }
+
+  // Transform to PublishedPost with banner URL and tags
   return results.map((r) => ({
     id: r.id,
     slug: r.slug,
@@ -53,6 +77,7 @@ export function getPublishedPosts(limit: number = 20, offset: number = 0): Publi
     updated_at: r.updated_at,
     banner_url: r.banner_s3_key ? new URL(mediaUrl(r.banner_s3_key), baseUrl).href : null,
     banner_alt: r.banner_alt,
+    tags: tagsMap.get(r.id) || [],
   }));
 }
 

--- a/src/federation/post-object.ts
+++ b/src/federation/post-object.ts
@@ -1,9 +1,14 @@
-import { Note, Article, Document, LanguageString } from "@fedify/fedify";
+import { Note, Article, Document, LanguageString, Hashtag } from "@fedify/fedify";
 import { dateToInstant, baseUrl } from "./utils";
 import { renderMarkdown } from "../utils/markdown";
 
 // ActivityPub Public address
 const PUBLIC = new URL("https://www.w3.org/ns/activitystreams#Public");
+
+export interface PostTag {
+  name: string;
+  slug: string;
+}
 
 export interface PublishedPost {
   id: number;
@@ -17,6 +22,7 @@ export interface PublishedPost {
   updated_at: Date;
   banner_url?: string | null;
   banner_alt?: string | null;
+  tags?: PostTag[];
 }
 
 /**
@@ -81,6 +87,15 @@ export function postToObject(
     );
   }
 
+  // Build hashtags array from post tags
+  const hashtags: Hashtag[] = (post.tags ?? []).map(
+    (tag) =>
+      new Hashtag({
+        href: new URL(`/tags/${tag.slug}`, baseUrl),
+        name: `#${tag.name.toLowerCase().replace(/\s+/g, "")}`,
+      })
+  );
+
   return new ObjectClass({
     id: postUri,
     attribution: actorUri,
@@ -100,5 +115,7 @@ export function postToObject(
     // For links, url points to external article so Mastodon links there and generates preview
     url: post.type === "link" && post.url ? new URL(post.url) : postUri,
     attachments: attachments.length > 0 ? attachments : undefined,
+    // Include tags as ActivityPub Hashtag objects for discoverability
+    tags: hashtags.length > 0 ? hashtags : undefined,
   });
 }

--- a/src/federation/publish.ts
+++ b/src/federation/publish.ts
@@ -1,11 +1,11 @@
 import { Create, Delete, Update, Image, Person, Endpoints } from "@fedify/fedify";
 import { eq } from "drizzle-orm";
-import { db, posts, media } from "@/db";
+import { db, posts, media, postTags, tags } from "@/db";
 import { federation } from "./setup";
 import { getAllFollowers } from "./followers";
 import { logger } from "@/utils/logger";
 import { dateToInstant, baseUrl } from "./utils";
-import { postToObject, PublishedPost } from "./post-object";
+import { postToObject, PublishedPost, PostTag } from "./post-object";
 import { mediaUrl } from "@/services/media";
 
 // ActivityPub Public address
@@ -39,6 +39,17 @@ function getPublishedPostById(postId: number): PublishedPost | null {
     return null;
   }
 
+  // Fetch tags for this post
+  const postTagsResult: PostTag[] = db
+    .select({
+      name: tags.name,
+      slug: tags.slug,
+    })
+    .from(postTags)
+    .innerJoin(tags, eq(postTags.tag_id, tags.id))
+    .where(eq(postTags.post_id, postId))
+    .all();
+
   return {
     id: result.id,
     slug: result.slug,
@@ -51,6 +62,7 @@ function getPublishedPostById(postId: number): PublishedPost | null {
     updated_at: result.updated_at,
     banner_url: result.banner_s3_key ? new URL(mediaUrl(result.banner_s3_key), baseUrl).href : null,
     banner_alt: result.banner_alt,
+    tags: postTagsResult,
   };
 }
 


### PR DESCRIPTION
## Summary
When posts are federated to Mastodon/fediverse, tags are now included as ActivityPub Hashtag objects for improved discoverability.

## Changes
- Added `PostTag` interface and `tags` field to `PublishedPost`
- Convert tags to ActivityPub Hashtag objects in `postToObject`
- Updated `getPublishedPostById` in publish.ts to fetch post tags
- Updated `getPublishedPosts` in outbox.ts to efficiently fetch tags for all posts

## ActivityPub Format
Tags are converted to proper Hashtag objects:
```json
{
  "type": "Hashtag",
  "href": "https://erikcraddock.me/tags/coding",
  "name": "#coding"
}
```

## Tag Name Conversion
- Converted to lowercase: "AI" → "#ai"
- Spaces removed: "Machine Learning" → "#machinelearning"
- Links to tag page on site

## Testing
- Added 5 new tests for hashtag functionality
- All 348 tests pass

## Task
Fixes #1521