### PR TITLE
feat: add page listing all tags at /tags

### DIFF
--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -617,6 +617,47 @@ describe("pages routes", () => {
     });
   });
 
+  describe("GET /tags", () => {
+    it("returns 200 and displays tags page", async () => {
+      const app = getApp();
+      const res = await app.request("/tags");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("<h1");
+      expect(html).toContain("Tags");
+    });
+
+    it("displays tags with post counts", async () => {
+      const app = getApp();
+      const res = await app.request("/tags");
+      const html = await res.text();
+
+      // Should show tags that have posts
+      expect(html).toContain("Testing");
+      expect(html).toContain("TypeScript");
+    });
+
+    it("links tags to their tag pages", async () => {
+      const app = getApp();
+      const res = await app.request("/tags");
+      const html = await res.text();
+
+      expect(html).toContain('href="/tags/testing"');
+      expect(html).toContain('href="/tags/typescript"');
+    });
+
+    it("includes dark mode classes", async () => {
+      const app = getApp();
+      const res = await app.request("/tags");
+      const html = await res.text();
+
+      expect(html).toContain("dark:bg-gray-900");
+      expect(html).toContain("dark:text-gray-100");
+    });
+  });
+
   describe("GET /tags/:slug", () => {
     it("returns 200 and displays tag name as heading", async () => {
       const app = getApp();

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -7,6 +7,7 @@ import { NotFound } from "../templates/not-found";
 import { truncate } from "../utils/text";
 import { renderMarkdown } from "../utils/markdown";
 import { mediaUrl } from "../services/media";
+import { listTags } from "../services/tags";
 import { postToObject, PublishedPost } from "../federation/post-object";
 import { baseUrl } from "../federation/utils";
 
@@ -1280,6 +1281,42 @@ export function createPagesRoutes(db: Database): Hono {
           {/* Post content */}
           <div class="prose prose-gray max-w-none">{raw(renderMarkdown(post.content))}</div>
         </article>
+      </Layout>
+    );
+  });
+
+  // Tags listing page
+  pages.get("/tags", (c) => {
+    const allTags = listTags().filter((t) => t.count > 0);
+
+    return c.html(
+      <Layout title="Tags | erikcraddock.me">
+        {/* Back link */}
+        <a
+          href="/"
+          class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 text-sm mb-6 inline-block"
+        >
+          ← Back to home
+        </a>
+
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">Tags</h1>
+
+        {allTags.length === 0 ? (
+          <p class="text-gray-600 dark:text-gray-400">No tags yet.</p>
+        ) : (
+          <div class="flex flex-wrap gap-3">
+            {allTags.map((tag) => (
+              <a
+                key={tag.id}
+                href={`/tags/${tag.slug}`}
+                class="inline-flex items-center gap-2 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 px-4 py-2 rounded-lg transition-colors"
+              >
+                <span class="font-medium">{tag.name}</span>
+                <span class="text-sm text-gray-500 dark:text-gray-400">({tag.count})</span>
+              </a>
+            ))}
+          </div>
+        )}
       </Layout>
     );
   });


### PR DESCRIPTION
## Summary
Create a page at `/tags` that lists all tags with their post counts.

## Changes
- Added `/tags` route in pages.tsx
- Lists tags with at least one published post
- Shows post count for each tag
- Ordered by post count (most used first)
- Links to individual tag pages (`/tags/{slug}`)
- Uses existing `listTags()` service function

## Design
- Tags displayed as clickable badges/pills
- Shows count in parentheses: "Creativity (6)"
- Consistent styling with rest of site
- Dark mode support
- Back to home link

## Testing
- Added 4 tests for the new page
- All 352 tests pass

## Note
No navigation link added per user request - page is accessible directly at `/tags`.

## Task
Fixes #1522