### PR TITLE
Check slug before uploading post images

### DIFF
--- a/cli/src/commands/post/__tests__/create.test.ts
+++ b/cli/src/commands/post/__tests__/create.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const originalExit = process.exit;
+const originalConsoleError = console.error;
+const originalConsoleLog = console.log;
+
+const mockLoadConfig = mock(async () => ({
+  api_url: "https://api.example.com",
+  api_key: "ek_test",
+}));
+
+const mockGetPost = mock(async () => ({ error: "Post not found" }));
+const mockCreatePost = mock(async () => ({
+  data: {
+    slug: "new-post",
+    title: "New Post",
+    type: "article",
+    published_at: null,
+    tags: [],
+  },
+}));
+const mockProcessImages = mock(async () => ({
+  urlMap: new Map([["./hero.jpg", "https://cdn.example.com/hero.jpg"]]),
+  idMap: new Map([["./hero.jpg", 42]]),
+}));
+const mockDetectImages = mock(() => [
+  {
+    original: "./hero.jpg",
+    type: "local" as const,
+    localPath: "/tmp/hero.jpg",
+  },
+]);
+const mockRewriteContent = mock((content: string) => content);
+
+mock.module("../../../lib/config", () => ({
+  loadConfig: mockLoadConfig,
+}));
+
+mock.module("../../../lib/api", () => ({
+  ApiClient: class {
+    getPost = mockGetPost;
+    createPost = mockCreatePost;
+  },
+}));
+
+mock.module("../../../lib/images", () => ({
+  detectImages: mockDetectImages,
+  processImages: mockProcessImages,
+  rewriteContent: mockRewriteContent,
+}));
+
+describe("ec post create", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ec-post-create-"));
+    mockLoadConfig.mockClear();
+    mockGetPost.mockClear();
+    mockCreatePost.mockClear();
+    mockProcessImages.mockClear();
+    mockDetectImages.mockClear();
+    mockRewriteContent.mockClear();
+
+    console.error = mock(() => {});
+    console.log = mock(() => {});
+    process.exit = ((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as typeof process.exit;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+    process.exit = originalExit;
+  });
+
+  it("checks for an existing slug before uploading images from a file", async () => {
+    mockGetPost.mockResolvedValueOnce({
+      data: {
+        id: 1,
+        slug: "existing-post",
+        type: "article",
+        title: "Existing Post",
+        content: "Content",
+        excerpt: "Excerpt",
+        url: null,
+        source_id: null,
+        published_at: null,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        tags: [],
+      },
+    });
+
+    const filePath = path.join(tempDir, "article.md");
+    fs.writeFileSync(
+      filePath,
+      `---\ntitle: Existing Post\nslug: existing-post\n---\n\n![hero](./hero.jpg)\n\nHello`
+    );
+
+    const { create } = await import("../create");
+
+    await expect(create(["--file", filePath], {})).rejects.toThrow("process.exit:1");
+
+    expect(mockGetPost).toHaveBeenCalledWith("existing-post");
+    expect(mockProcessImages).not.toHaveBeenCalled();
+    expect(mockCreatePost).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith("❌ Error: Slug 'existing-post' already exists");
+  });
+
+  it("continues to image processing when the slug does not exist", async () => {
+    const filePath = path.join(tempDir, "article.md");
+    fs.writeFileSync(
+      filePath,
+      `---\ntitle: New Post\nslug: new-post\n---\n\n![hero](./hero.jpg)\n\nHello`
+    );
+
+    const { create } = await import("../create");
+
+    await create(["--file", filePath], {});
+
+    expect(mockGetPost).toHaveBeenCalledWith("new-post");
+    expect(mockProcessImages).toHaveBeenCalled();
+    expect(mockCreatePost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: "new-post",
+        title: "New Post",
+        type: "article",
+      })
+    );
+  });
+});

--- a/cli/src/commands/post/create.ts
+++ b/cli/src/commands/post/create.ts
@@ -72,6 +72,20 @@ function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolea
   return { options, help };
 }
 
+async function ensureSlugAvailable(client: ApiClient, slug: string): Promise<void> {
+  const existing = await client.getPost(slug);
+
+  if (existing.data) {
+    console.error(`❌ Error: Slug '${slug}' already exists`);
+    process.exit(1);
+  }
+
+  if (existing.error && !existing.error.includes("404") && !existing.error.includes("not found")) {
+    console.error(`❌ Error checking slug: ${existing.error}`);
+    process.exit(1);
+  }
+}
+
 function showCreateHelp(): void {
   console.log(`ec post create - Create a new post
 
@@ -170,6 +184,8 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
         console.error("   Add 'slug:' to frontmatter or use --slug option.");
         process.exit(1);
       }
+
+      await ensureSlugAvailable(client, slug);
 
       console.log(`📤 Processing ${localImages.length} image(s)...`);
 


### PR DESCRIPTION
## Summary
- check whether a post slug already exists before the CLI uploads images
- stop early on duplicate slugs so S3 uploads are not orphaned
- add CLI tests covering the duplicate-slug and happy-path flows

## Testing
- make check
- bun test cli/src/commands/post/__tests__/create.test.ts cli/src/__tests__/api-posts.test.ts

Task: #task-59f7d422