### PR TITLE
Add OG preview cards to link post pages

### DIFF
--- a/drizzle/0005_unusual_hellcat.sql
+++ b/drizzle/0005_unusual_hellcat.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `posts` ADD `og_title` text;--> statement-breakpoint
+ALTER TABLE `posts` ADD `og_description` text;--> statement-breakpoint
+ALTER TABLE `posts` ADD `og_image_url` text;--> statement-breakpoint
+ALTER TABLE `posts` ADD `og_site_name` text;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,726 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0f01da3c-532a-40d9-b9ca-798bc0ab9b17",
+  "prevId": "24df9c17-fcb6-4cd8-95bf-202f91692a86",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1769784644301,
       "tag": "0004_amused_ted_forrester",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1776905887006,
+      "tag": "0005_unusual_hellcat",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -9,6 +9,10 @@ export const posts = sqliteTable("posts", {
   content: text("content").notNull(),
   excerpt: text("excerpt"),
   url: text("url"), // for link type posts
+  og_title: text("og_title"),
+  og_description: text("og_description"),
+  og_image_url: text("og_image_url"),
+  og_site_name: text("og_site_name"),
   source_id: integer("source_id").references(() => sources.id),
   banner_image_id: integer("banner_image_id").references(() => media.id, { onDelete: "set null" }),
   published_at: integer("published_at", { mode: "timestamp" }),

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 
 // Create test db immediately
 const testDb = createTestDb();
+const originalFetch = global.fetch;
 
 // Mock modules
 mock.module("@/db", () => ({
@@ -52,6 +53,7 @@ beforeEach(() => {
   testDb.delete(tags).run();
   testDb.delete(posts).run();
   testDb.delete(sources).run();
+  global.fetch = originalFetch;
 });
 
 const authHeader = { Authorization: "Bearer ek_test" };
@@ -263,6 +265,49 @@ describe("POST /api/posts - slug validation", () => {
     expect(json.data.published_at).toBeNull();
   });
 
+  it("stores link preview metadata for link posts", async () => {
+    global.fetch = mock(
+      async () =>
+        new Response(
+          `
+          <html>
+            <head>
+              <meta property="og:title" content="Preview Title" />
+              <meta property="og:description" content="Preview Description" />
+              <meta property="og:image" content="https://example.com/preview.jpg" />
+              <meta property="og:site_name" content="Example Site" />
+            </head>
+          </html>
+        `,
+          {
+            status: 200,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+            },
+          }
+        )
+    ) as unknown as typeof fetch;
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "link",
+        slug: "preview-link",
+        title: "Preview Link",
+        url: "https://example.com/article",
+        content: "Commentary",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.og_title).toBe("Preview Title");
+    expect(json.data.og_description).toBe("Preview Description");
+    expect(json.data.og_image_url).toBe("https://example.com/preview.jpg");
+    expect(json.data.og_site_name).toBe("Example Site");
+  });
+
   it("creates post as published when published_at is provided", async () => {
     const publishDate = "2024-03-15T10:30:00Z";
     const res = await api.request("/posts", {
@@ -462,6 +507,55 @@ describe("POST /api/posts/by-slug/:slug/publish", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.published_at).not.toBeNull();
+  });
+
+  it("backfills link preview metadata when publishing a link post", async () => {
+    global.fetch = mock(
+      async () =>
+        new Response(
+          `
+          <html>
+            <head>
+              <meta property="og:title" content="Published Preview" />
+              <meta property="og:description" content="Published description" />
+              <meta property="og:image" content="https://example.com/published.jpg" />
+              <meta property="og:site_name" content="Example Site" />
+            </head>
+          </html>
+        `,
+          {
+            status: 200,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+            },
+          }
+        )
+    ) as unknown as typeof fetch;
+
+    testDb
+      .insert(posts)
+      .values({
+        slug: "publish-link",
+        type: "link",
+        title: "Publish Link",
+        content: "Commentary",
+        url: "https://example.com/article",
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .run();
+
+    const res = await api.request("/posts/by-slug/publish-link/publish", {
+      method: "POST",
+      headers: authHeader,
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.og_title).toBe("Published Preview");
+    expect(json.data.og_description).toBe("Published description");
+    expect(json.data.og_image_url).toBe("https://example.com/published.jpg");
+    expect(json.data.og_site_name).toBe("Example Site");
   });
 
   it("returns 404 for non-existent slug", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-import { describe, it, expect, beforeAll } from "bun:test";
+import { describe, it, expect, beforeAll, afterEach } from "bun:test";
 import { mock } from "bun:test";
 import { Hono } from "hono";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
 import { createTestDb } from "../../db/test-utils";
 import { posts, tags, postTags, sources, media } from "../../db/schema";
 
@@ -76,6 +82,10 @@ testDb
       title: "Test Link Post",
       content: "This is commentary on an external link.",
       url: "https://example.com/article",
+      og_title: "Example Article",
+      og_description: "A rich preview description.",
+      og_image_url: "https://example.com/preview.jpg",
+      og_site_name: "Example Site",
       published_at: now,
       created_at: now,
       updated_at: now,
@@ -602,6 +612,70 @@ describe("pages routes", () => {
       const html = await res.text();
       // Link posts should have og:url pointing to the external article
       expect(html).toContain('property="og:url" content="https://example.com/article"');
+    });
+
+    it("renders an OG preview card for link posts", async () => {
+      const app = getApp();
+      const res = await app.request("/posts/test-link");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("Example Article");
+      expect(html).toContain("A rich preview description.");
+      expect(html).toContain("Example Site");
+      expect(html).toContain('src="https://example.com/preview.jpg"');
+      expect(html).toContain('href="https://example.com/article"');
+    });
+
+    it("backfills OG preview metadata for older link posts during page render", async () => {
+      global.fetch = mock(
+        async () =>
+          new Response(
+            `
+            <html>
+              <head>
+                <meta property="og:title" content="Fetched Preview Title" />
+                <meta property="og:description" content="Fetched preview description." />
+                <meta property="og:image" content="https://example.com/fetched.jpg" />
+                <meta property="og:site_name" content="Fetched Site" />
+              </head>
+            </html>
+          `,
+            {
+              status: 200,
+              headers: {
+                "content-type": "text/html; charset=utf-8",
+              },
+            }
+          )
+      ) as unknown as typeof fetch;
+
+      const renderTime = new Date();
+      testDb
+        .insert(posts)
+        .values({
+          slug: "backfill-link",
+          type: "link",
+          title: "Backfill Link",
+          content: "Commentary for old link post.",
+          url: "https://example.com/old-link",
+          published_at: renderTime,
+          created_at: renderTime,
+          updated_at: renderTime,
+        })
+        .run();
+
+      const app = getApp();
+      const res = await app.request("/posts/backfill-link");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("Fetched Preview Title");
+      expect(html).toContain("Fetched preview description.");
+      expect(html).toContain("Fetched Site");
+      expect(html).toContain('src="https://example.com/fetched.jpg"');
     });
 
     it("sets og:url to site URL for article posts", async () => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -26,6 +26,8 @@ import {
   deleteSource,
 } from "@/services/sources";
 import { listTags } from "@/services/tags";
+import { fetchLinkPreview } from "@/services/link-preview";
+import { logger } from "@/utils/logger";
 import {
   federatePost,
   sendDeleteActivity,
@@ -147,6 +149,10 @@ const PostSchema = z
     content: z.string().openapi({ example: "# Hello" }),
     excerpt: NullableStringSchema,
     url: NullableStringSchema,
+    og_title: NullableStringSchema,
+    og_description: NullableStringSchema,
+    og_image_url: NullableStringSchema,
+    og_site_name: NullableStringSchema,
     source_id: z.number().int().nullable(),
     banner_image_id: z.number().int().nullable(),
     banner_url: NullableStringSchema,
@@ -264,6 +270,38 @@ const registerProtectedRoute = protectedApi.openapi.bind(protectedApi) as unknow
   route: unknown,
   handler: (c: Context) => unknown
 ) => unknown;
+
+function hasStoredLinkPreview(post: {
+  og_title?: string | null;
+  og_description?: string | null;
+  og_image_url?: string | null;
+  og_site_name?: string | null;
+}): boolean {
+  return Boolean(post.og_title || post.og_description || post.og_image_url || post.og_site_name);
+}
+
+async function getLinkPreviewData(url: string | null | undefined): Promise<{
+  og_title: string | null;
+  og_description: string | null;
+  og_image_url: string | null;
+  og_site_name: string | null;
+} | null> {
+  if (!url) {
+    return null;
+  }
+
+  const preview = await fetchLinkPreview(url);
+  if (!preview) {
+    return null;
+  }
+
+  return {
+    og_title: preview.title,
+    og_description: preview.description,
+    og_image_url: preview.imageUrl,
+    og_site_name: preview.siteName,
+  };
+}
 
 registerProtectedRoute(
   protectedRoute({
@@ -466,13 +504,19 @@ registerProtectedRoute(
     }
 
     try {
+      const normalizedUrl = url?.trim() || null;
+      const linkPreview = type === "link" ? await getLinkPreviewData(normalizedUrl) : null;
       const post = createPost({
         type,
         slug,
         title: title?.trim() || null,
         content: content.trim(),
         excerpt: excerpt?.trim() || null,
-        url: url?.trim() || null,
+        url: normalizedUrl,
+        og_title: linkPreview?.og_title,
+        og_description: linkPreview?.og_description,
+        og_image_url: linkPreview?.og_image_url,
+        og_site_name: linkPreview?.og_site_name,
         source_id: source_id ?? null,
         tags: tags || [],
         banner_image_id: banner_image_id ?? null,
@@ -589,11 +633,37 @@ registerProtectedRoute(
     }
 
     try {
+      const existingPost = getPost(id);
+      const nextUrl = url !== undefined ? url?.trim() || null : existingPost?.url;
+      const linkPreview =
+        existingPost?.type === "link" && (url !== undefined || !hasStoredLinkPreview(existingPost))
+          ? await getLinkPreviewData(nextUrl)
+          : null;
       const post = updatePost(id, {
         title: title !== undefined ? title?.trim() || null : undefined,
         content: content?.trim(),
         excerpt: excerpt !== undefined ? excerpt?.trim() || null : undefined,
         url: url !== undefined ? url?.trim() || null : undefined,
+        og_title:
+          existingPost?.type === "link" &&
+          (url !== undefined || !hasStoredLinkPreview(existingPost))
+            ? (linkPreview?.og_title ?? null)
+            : undefined,
+        og_description:
+          existingPost?.type === "link" &&
+          (url !== undefined || !hasStoredLinkPreview(existingPost))
+            ? (linkPreview?.og_description ?? null)
+            : undefined,
+        og_image_url:
+          existingPost?.type === "link" &&
+          (url !== undefined || !hasStoredLinkPreview(existingPost))
+            ? (linkPreview?.og_image_url ?? null)
+            : undefined,
+        og_site_name:
+          existingPost?.type === "link" &&
+          (url !== undefined || !hasStoredLinkPreview(existingPost))
+            ? (linkPreview?.og_site_name ?? null)
+            : undefined,
         source_id,
         tags,
         banner_image_id,
@@ -692,6 +762,28 @@ registerProtectedRoute(
     const id = parseInt(c.req.param("id") ?? "", 10);
     if (isNaN(id)) {
       return c.json({ error: "Invalid post ID" }, 400);
+    }
+
+    const existingPost = getPost(id);
+    if (!existingPost) {
+      return c.json({ error: "Post not found" }, 404);
+    }
+
+    if (existingPost.type === "link" && existingPost.url && !hasStoredLinkPreview(existingPost)) {
+      try {
+        const linkPreview = await getLinkPreviewData(existingPost.url);
+        updatePost(id, {
+          og_title: linkPreview?.og_title ?? null,
+          og_description: linkPreview?.og_description ?? null,
+          og_image_url: linkPreview?.og_image_url ?? null,
+          og_site_name: linkPreview?.og_site_name ?? null,
+        });
+      } catch (error) {
+        logger.warn("link-preview", "Failed to backfill link preview on publish", {
+          postId: id,
+          error: String(error),
+        });
+      }
     }
 
     const post = publishPost(id);
@@ -843,11 +935,32 @@ registerProtectedRoute(
     }
 
     try {
+      const nextUrl = url !== undefined ? url?.trim() || null : existingPost.url;
+      const linkPreview =
+        existingPost.type === "link" && (url !== undefined || !hasStoredLinkPreview(existingPost))
+          ? await getLinkPreviewData(nextUrl)
+          : null;
       const post = updatePost(existingPost.id, {
         title: title !== undefined ? title?.trim() || null : undefined,
         content: content?.trim(),
         excerpt: excerpt !== undefined ? excerpt?.trim() || null : undefined,
         url: url !== undefined ? url?.trim() || null : undefined,
+        og_title:
+          existingPost.type === "link" && (url !== undefined || !hasStoredLinkPreview(existingPost))
+            ? (linkPreview?.og_title ?? null)
+            : undefined,
+        og_description:
+          existingPost.type === "link" && (url !== undefined || !hasStoredLinkPreview(existingPost))
+            ? (linkPreview?.og_description ?? null)
+            : undefined,
+        og_image_url:
+          existingPost.type === "link" && (url !== undefined || !hasStoredLinkPreview(existingPost))
+            ? (linkPreview?.og_image_url ?? null)
+            : undefined,
+        og_site_name:
+          existingPost.type === "link" && (url !== undefined || !hasStoredLinkPreview(existingPost))
+            ? (linkPreview?.og_site_name ?? null)
+            : undefined,
         source_id,
         tags,
         banner_image_id,
@@ -939,6 +1052,23 @@ registerProtectedRoute(
     const existingPost = getPostBySlug(slug);
     if (!existingPost) {
       return c.json({ error: "Post not found" }, 404);
+    }
+
+    if (existingPost.type === "link" && existingPost.url && !hasStoredLinkPreview(existingPost)) {
+      try {
+        const linkPreview = await getLinkPreviewData(existingPost.url);
+        updatePost(existingPost.id, {
+          og_title: linkPreview?.og_title ?? null,
+          og_description: linkPreview?.og_description ?? null,
+          og_image_url: linkPreview?.og_image_url ?? null,
+          og_site_name: linkPreview?.og_site_name ?? null,
+        });
+      } catch (error) {
+        logger.warn("link-preview", "Failed to backfill link preview on publish", {
+          postId: existingPost.id,
+          error: String(error),
+        });
+      }
     }
 
     const post = publishPost(existingPost.id);

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -8,8 +8,10 @@ import { truncate } from "../utils/text";
 import { renderMarkdown } from "../utils/markdown";
 import { mediaUrl } from "../services/media";
 import { listTags } from "../services/tags";
+import { fetchLinkPreview } from "../services/link-preview";
 import { postToObject, PublishedPost } from "../federation/post-object";
 import { baseUrl } from "../federation/utils";
+import { logger } from "../utils/logger";
 
 // Database type for dependency injection
 type Database = typeof defaultDb;
@@ -22,6 +24,31 @@ type PostWithSource = Post & { source?: Source | null };
 
 /** Max length for showing full note content inline */
 const NOTE_INLINE_MAX_LENGTH = 280;
+
+function hasStoredLinkPreview(post: {
+  og_title?: string | null;
+  og_description?: string | null;
+  og_image_url?: string | null;
+  og_site_name?: string | null;
+}): boolean {
+  return Boolean(post.og_title || post.og_description || post.og_image_url || post.og_site_name);
+}
+
+function getLinkPreviewSiteLabel(url: string | null, siteName: string | null): string | null {
+  if (siteName) {
+    return siteName;
+  }
+
+  if (!url) {
+    return null;
+  }
+
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
 
 /** Social link icons */
 function GitHubIcon() {
@@ -1171,10 +1198,40 @@ export function createPagesRoutes(db: Database): Hono {
       );
     }
 
-    const post = result.post;
+    let post = result.post;
     const source = result.source;
     const isLink = post.type === "link";
     const isNote = post.type === "note";
+
+    if (isLink && post.url && !hasStoredLinkPreview(post)) {
+      const preview = await fetchLinkPreview(post.url);
+
+      if (preview) {
+        db.update(posts)
+          .set({
+            og_title: preview.title,
+            og_description: preview.description,
+            og_image_url: preview.imageUrl,
+            og_site_name: preview.siteName,
+            updated_at: new Date(),
+          })
+          .where(eq(posts.id, post.id))
+          .run();
+
+        post = {
+          ...post,
+          og_title: preview.title,
+          og_description: preview.description,
+          og_image_url: preview.imageUrl,
+          og_site_name: preview.siteName,
+        };
+      } else {
+        logger.debug("link-preview", "No preview metadata found during page render", {
+          postId: post.id,
+          url: post.url,
+        });
+      }
+    }
 
     // Query tags for this post
     const postTagsResult = db
@@ -1199,6 +1256,10 @@ export function createPagesRoutes(db: Database): Hono {
 
     const title = post.title || (isNote ? "Note" : "Post");
     const description = post.excerpt || truncate(post.content, 160);
+    const linkPreviewSiteLabel = getLinkPreviewSiteLabel(post.url, post.og_site_name);
+    const hasLinkPreview = Boolean(
+      isLink && (post.og_title || post.og_description || post.og_image_url || linkPreviewSiteLabel)
+    );
     // For link posts, use external URL for OG tags so Mastodon generates correct preview
     const canonicalUrl = post.type === "link" && post.url ? post.url : `/posts/${slug}`;
 
@@ -1277,6 +1338,40 @@ export function createPagesRoutes(db: Database): Hono {
 
             {postTagsResult.length > 0 && <TagBadges tags={postTagsResult} />}
           </div>
+
+          {isLink && post.url && hasLinkPreview && (
+            <a
+              href={post.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="group mb-8 block overflow-hidden rounded-xl border border-gray-200 bg-white transition hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:bg-gray-800 dark:hover:border-gray-600"
+            >
+              {post.og_image_url && (
+                <img
+                  src={post.og_image_url}
+                  alt={post.og_title || "Link preview image"}
+                  class="h-56 w-full object-cover"
+                />
+              )}
+              <div class="p-4">
+                {linkPreviewSiteLabel && (
+                  <p class="mb-2 text-sm uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    {linkPreviewSiteLabel}
+                  </p>
+                )}
+                {post.og_title && (
+                  <h2 class="mb-2 text-xl font-semibold text-gray-900 group-hover:text-blue-600 dark:text-gray-100 dark:group-hover:text-blue-400">
+                    {post.og_title}
+                  </h2>
+                )}
+                {post.og_description && (
+                  <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">
+                    {post.og_description}
+                  </p>
+                )}
+              </div>
+            </a>
+          )}
 
           {/* Post content */}
           <div class="prose prose-gray max-w-none">{raw(renderMarkdown(post.content))}</div>

--- a/src/services/__tests__/link-preview.test.ts
+++ b/src/services/__tests__/link-preview.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { fetchLinkPreview } from "../link-preview";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("fetchLinkPreview", () => {
+  it("extracts Open Graph metadata from HTML", async () => {
+    global.fetch = mock(
+      async () =>
+        new Response(
+          `
+          <html>
+            <head>
+              <meta property="og:title" content="Example Article" />
+              <meta property="og:description" content="An example description" />
+              <meta property="og:image" content="/images/card.jpg" />
+              <meta property="og:site_name" content="Example Site" />
+            </head>
+          </html>
+        `,
+          {
+            status: 200,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+            },
+          }
+        )
+    ) as unknown as typeof fetch;
+
+    const preview = await fetchLinkPreview("https://example.com/posts/test");
+
+    expect(preview).toEqual({
+      title: "Example Article",
+      description: "An example description",
+      imageUrl: "https://example.com/images/card.jpg",
+      siteName: "Example Site",
+    });
+  });
+
+  it("falls back to title tag and hostname when og tags are missing", async () => {
+    global.fetch = mock(
+      async () =>
+        new Response(
+          `
+          <html>
+            <head>
+              <title>Fallback Title</title>
+              <meta name="description" content="Fallback description" />
+            </head>
+          </html>
+        `,
+          {
+            status: 200,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+            },
+          }
+        )
+    ) as unknown as typeof fetch;
+
+    const preview = await fetchLinkPreview("https://www.example.com/articles/fallback");
+
+    expect(preview).toEqual({
+      title: "Fallback Title",
+      description: "Fallback description",
+      imageUrl: null,
+      siteName: "example.com",
+    });
+  });
+
+  it("returns null for non-html responses", async () => {
+    global.fetch = mock(
+      async () =>
+        new Response("{}", {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        })
+    ) as unknown as typeof fetch;
+
+    const preview = await fetchLinkPreview("https://example.com/data.json");
+
+    expect(preview).toBeNull();
+  });
+});

--- a/src/services/link-preview.ts
+++ b/src/services/link-preview.ts
@@ -1,0 +1,128 @@
+import { logger } from "@/utils/logger";
+
+export interface LinkPreview {
+  title: string | null;
+  description: string | null;
+  imageUrl: string | null;
+  siteName: string | null;
+}
+
+function extractMetaContent(html: string, name: string): string | null {
+  const patterns = [
+    new RegExp(
+      `<meta[^>]+(?:property|name)=["']${escapeRegExp(name)}["'][^>]+content=["']([^"']+)["'][^>]*>`,
+      "i"
+    ),
+    new RegExp(
+      `<meta[^>]+content=["']([^"']+)["'][^>]+(?:property|name)=["']${escapeRegExp(name)}["'][^>]*>`,
+      "i"
+    ),
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1]) {
+      return decodeHtmlEntities(match[1].trim());
+    }
+  }
+
+  return null;
+}
+
+function extractTitleTag(html: string): string | null {
+  const match = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+  return match?.[1] ? decodeHtmlEntities(match[1].trim()) : null;
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function resolveUrl(maybeUrl: string | null, baseUrl: string): string | null {
+  if (!maybeUrl) {
+    return null;
+  }
+
+  try {
+    return new URL(maybeUrl, baseUrl).toString();
+  } catch {
+    return null;
+  }
+}
+
+function getFallbackSiteName(url: string): string | null {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchLinkPreview(url: string): Promise<LinkPreview | null> {
+  try {
+    const response = await fetch(url, {
+      redirect: "follow",
+      headers: {
+        "user-agent": "erikcraddock.me link preview bot/1.0",
+        accept: "text/html,application/xhtml+xml",
+      },
+    });
+
+    if (!response.ok) {
+      logger.warn("link-preview", "Failed to fetch link preview", {
+        url,
+        status: response.status,
+      });
+      return null;
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!contentType.includes("text/html")) {
+      return null;
+    }
+
+    const html = await response.text();
+    const finalUrl = response.url || url;
+
+    const title =
+      extractMetaContent(html, "og:title") ??
+      extractMetaContent(html, "twitter:title") ??
+      extractTitleTag(html);
+    const description =
+      extractMetaContent(html, "og:description") ??
+      extractMetaContent(html, "description") ??
+      extractMetaContent(html, "twitter:description");
+    const imageUrl = resolveUrl(
+      extractMetaContent(html, "og:image") ?? extractMetaContent(html, "twitter:image"),
+      finalUrl
+    );
+    const siteName = extractMetaContent(html, "og:site_name") ?? getFallbackSiteName(finalUrl);
+
+    if (!title && !description && !imageUrl && !siteName) {
+      return null;
+    }
+
+    return {
+      title,
+      description,
+      imageUrl,
+      siteName,
+    };
+  } catch (error) {
+    logger.warn("link-preview", "Error fetching link preview", {
+      url,
+      error: String(error),
+    });
+    return null;
+  }
+}

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -132,6 +132,10 @@ export interface CreatePostInput {
   content: string;
   excerpt?: string | null;
   url?: string | null;
+  og_title?: string | null;
+  og_description?: string | null;
+  og_image_url?: string | null;
+  og_site_name?: string | null;
   source_id?: number | null;
   tags?: string[]; // Tag slugs
   banner_image_id?: number | null;
@@ -182,6 +186,10 @@ export function createPost(input: CreatePostInput) {
     content,
     excerpt,
     url,
+    og_title,
+    og_description,
+    og_image_url,
+    og_site_name,
     source_id,
     tags: tagSlugs,
     banner_image_id,
@@ -220,6 +228,10 @@ export function createPost(input: CreatePostInput) {
       content,
       excerpt: finalExcerpt,
       url: url ?? null,
+      og_title: og_title ?? null,
+      og_description: og_description ?? null,
+      og_image_url: og_image_url ?? null,
+      og_site_name: og_site_name ?? null,
       source_id: source_id ?? null,
       banner_image_id: banner_image_id ?? null,
       created_at: published_at ?? now,
@@ -281,6 +293,10 @@ export interface UpdatePostInput {
   content?: string;
   excerpt?: string | null;
   url?: string | null;
+  og_title?: string | null;
+  og_description?: string | null;
+  og_image_url?: string | null;
+  og_site_name?: string | null;
   source_id?: number | null;
   tags?: string[]; // Tag slugs
   banner_image_id?: number | null;
@@ -296,7 +312,19 @@ export function updatePost(id: number, input: UpdatePostInput) {
     return null;
   }
 
-  const { title, content, excerpt, url, source_id, tags: tagSlugs, banner_image_id } = input;
+  const {
+    title,
+    content,
+    excerpt,
+    url,
+    og_title,
+    og_description,
+    og_image_url,
+    og_site_name,
+    source_id,
+    tags: tagSlugs,
+    banner_image_id,
+  } = input;
 
   // Validate banner_image_id if provided
   if (banner_image_id !== undefined && banner_image_id !== null) {
@@ -323,6 +351,10 @@ export function updatePost(id: number, input: UpdatePostInput) {
   if (content !== undefined) updates.content = content;
   if (excerpt !== undefined) updates.excerpt = excerpt;
   if (url !== undefined) updates.url = url;
+  if (og_title !== undefined) updates.og_title = og_title;
+  if (og_description !== undefined) updates.og_description = og_description;
+  if (og_image_url !== undefined) updates.og_image_url = og_image_url;
+  if (og_site_name !== undefined) updates.og_site_name = og_site_name;
   if (source_id !== undefined) updates.source_id = source_id;
   if (banner_image_id !== undefined) updates.banner_image_id = banner_image_id;
 


### PR DESCRIPTION
## Summary
- store Open Graph metadata for link posts and expose it through existing post flows
- render a rich preview card on link post pages using stored metadata
- lazily backfill preview metadata for older link posts during page render

## Testing
- make check
- bun test src/routes/__tests__/api.test.tsx src/routes/__tests__/pages.test.tsx src/services/__tests__/link-preview.test.ts
- visual verification in browser on `/posts/og-preview-test` against the local dev server

Task: #task-13cb27ed