### PR TITLE
Fix link preview backfill updates

### DIFF
--- a/cli/src/commands/link/list.ts
+++ b/cli/src/commands/link/list.ts
@@ -2,6 +2,8 @@ import type { GlobalOptions, PostListItem } from "../../types";
 import { ApiClient } from "../../lib/api";
 import { loadConfig } from "../../lib/config";
 
+const ALL_LINKS_LIMIT = 2_147_483_647;
+
 interface ListOptions {
   limit?: number;
   tag?: string;
@@ -44,7 +46,7 @@ function showListHelp(): void {
 Usage: ec link list [options]
 
 Options:
-  --limit <n>       Maximum number of links (default: 50, max: 100)
+  --limit <n>       Maximum number of links (default: all)
   --tag <tag>       Filter by tag slug
   --status <status> Filter by status: draft, published, all (default: all)
   --json            Output as JSON
@@ -129,7 +131,7 @@ export async function list(args: string[], globalOptions: GlobalOptions): Promis
 
   const client = new ApiClient(apiUrl, apiKey);
   const result = await client.listPosts({
-    limit: options.limit,
+    limit: options.limit ?? ALL_LINKS_LIMIT,
     tag: options.tag,
     status: options.status || "all",
     type: "link",

--- a/scripts/backfill-link-previews.ts
+++ b/scripts/backfill-link-previews.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from "node:child_process";
+
+interface LinkListItem {
+  slug: string;
+}
+
+interface LinkPost {
+  slug: string;
+  url: string | null;
+  og_title?: string | null;
+  og_description?: string | null;
+  og_image_url?: string | null;
+  og_site_name?: string | null;
+}
+
+interface Options {
+  configPath?: string;
+  apiUrl?: string;
+  apiKey?: string;
+  dryRun: boolean;
+  limit?: number;
+}
+
+function usage(): string {
+  return `Usage: bun scripts/backfill-link-previews.ts [options]
+
+Backfill missing link preview metadata by re-saving each missing link URL through ec.
+
+Options:
+  --config PATH     CLI config file to use
+  --api-url URL     Override API URL
+  --api-key KEY     Override API key
+  --dry-run         Show links that would be updated without changing anything
+  --limit N         Process at most N missing links
+  --help, -h        Show this help
+
+Examples:
+  bun scripts/backfill-link-previews.ts --config cli/dev-config.yaml --dry-run
+  bun scripts/backfill-link-previews.ts --config cli/dev-config.yaml --limit 10
+`;
+}
+
+function parseArgs(args: string[]): Options {
+  const options: Options = { dryRun: false };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    const next = args[i + 1];
+
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--config" && next) {
+      options.configPath = next;
+      i += 1;
+    } else if (arg.startsWith("--config=")) {
+      options.configPath = arg.slice("--config=".length);
+    } else if (arg === "--api-url" && next) {
+      options.apiUrl = next;
+      i += 1;
+    } else if (arg.startsWith("--api-url=")) {
+      options.apiUrl = arg.slice("--api-url=".length);
+    } else if (arg === "--api-key" && next) {
+      options.apiKey = next;
+      i += 1;
+    } else if (arg.startsWith("--api-key=")) {
+      options.apiKey = arg.slice("--api-key=".length);
+    } else if (arg === "--limit" && next) {
+      options.limit = parseLimit(next);
+      i += 1;
+    } else if (arg.startsWith("--limit=")) {
+      options.limit = parseLimit(arg.slice("--limit=".length));
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function parseLimit(value: string): number {
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error("--limit must be an integer greater than 0");
+  }
+  return limit;
+}
+
+function cliArgs(options: Options): string[] {
+  const args = ["cli/src/index.ts"];
+  if (options.configPath) args.push("--config", options.configPath);
+  if (options.apiUrl) args.push("--api-url", options.apiUrl);
+  if (options.apiKey) args.push("--api-key", options.apiKey);
+  return args;
+}
+
+function runEcJson<T>(options: Options, args: string[]): T {
+  const result = spawnSync("bun", [...cliArgs(options), "--json", ...args], {
+    encoding: "utf-8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || result.stdout.trim() || `ec exited ${result.status}`);
+  }
+
+  return JSON.parse(result.stdout) as T;
+}
+
+function runEc(options: Options, args: string[]): void {
+  const result = spawnSync("bun", [...cliArgs(options), ...args], {
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || result.stdout.trim() || `ec exited ${result.status}`);
+  }
+}
+
+function hasPreview(link: LinkPost): boolean {
+  return Boolean(link.og_title || link.og_description || link.og_image_url || link.og_site_name);
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const links = runEcJson<LinkListItem[]>(options, ["link", "list"]);
+  let scanned = 0;
+  let missing = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const item of links) {
+    const link = runEcJson<LinkPost>(options, ["link", "show", item.slug]);
+    scanned += 1;
+
+    if (!link.url || hasPreview(link)) {
+      skipped += 1;
+      continue;
+    }
+
+    if (options.limit !== undefined && missing >= options.limit) {
+      skipped += 1;
+      continue;
+    }
+
+    missing += 1;
+    console.log(`${options.dryRun ? "would update" : "updating"}: ${link.slug} (${link.url})`);
+
+    if (!options.dryRun) {
+      runEc(options, ["link", "edit", link.slug, "--url", link.url]);
+      updated += 1;
+    }
+  }
+
+  console.log("\nBackfill complete");
+  console.log(`Scanned: ${scanned}`);
+  console.log(`Missing preview: ${missing}`);
+  console.log(`Updated: ${updated}`);
+  console.log(`Skipped: ${skipped}`);
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -8,6 +8,11 @@ import { eq } from "drizzle-orm";
 // Create test db immediately
 const testDb = createTestDb();
 const originalFetch = global.fetch;
+const mockFederatePost = mock(async () => true);
+const mockSendDeleteActivity = mock(async () => true);
+const mockSendDeleteActivityForUri = mock(async () => true);
+const mockSendUpdateActivity = mock(async () => true);
+const mockSendActorUpdateActivity = mock(async () => true);
 
 // Mock modules
 mock.module("@/db", () => ({
@@ -21,6 +26,14 @@ mock.module("@/federation/setup", () => ({
     sendActivity: mock(() => {}),
   },
   createFedifyFederation: mock(() => {}),
+}));
+
+mock.module("@/federation/publish", () => ({
+  federatePost: mockFederatePost,
+  sendDeleteActivity: mockSendDeleteActivity,
+  sendDeleteActivityForUri: mockSendDeleteActivityForUri,
+  sendUpdateActivity: mockSendUpdateActivity,
+  sendActorUpdateActivity: mockSendActorUpdateActivity,
 }));
 
 // Only mock the requireApiKey middleware to bypass auth in tests
@@ -54,6 +67,11 @@ beforeEach(() => {
   testDb.delete(posts).run();
   testDb.delete(sources).run();
   global.fetch = originalFetch;
+  mockFederatePost.mockClear();
+  mockSendDeleteActivity.mockClear();
+  mockSendDeleteActivityForUri.mockClear();
+  mockSendUpdateActivity.mockClear();
+  mockSendActorUpdateActivity.mockClear();
 });
 
 const authHeader = { Authorization: "Bearer ek_test" };
@@ -423,6 +441,73 @@ describe("PUT /api/posts/by-slug/:slug", () => {
     const json = await res.json();
     expect(json.data.title).toBe("Updated Title");
     expect(json.data.content).toBe("Updated content");
+  });
+
+  it("does not federate when only missing preview metadata changes", async () => {
+    const now = new Date("2026-01-01T00:00:00Z");
+    testDb
+      .insert(posts)
+      .values({
+        slug: "metadata-only-link",
+        type: "link",
+        title: "Metadata Only Link",
+        content: "Original content",
+        excerpt: "Original excerpt",
+        url: "https://example.com/metadata-only",
+        created_at: now,
+        updated_at: now,
+        published_at: now,
+      })
+      .run();
+
+    global.fetch = mock(async () => {
+      return new Response(
+        `<!doctype html><html><head>
+          <meta property="og:title" content="Fetched title" />
+          <meta property="og:description" content="Fetched description" />
+          <meta property="og:image" content="https://example.com/preview.jpg" />
+          <meta property="og:site_name" content="Example Site" />
+        </head></html>`,
+        { headers: { "content-type": "text/html" } }
+      );
+    }) as unknown as typeof fetch;
+
+    const res = await api.request("/posts/by-slug/metadata-only-link", {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ url: "https://example.com/metadata-only" }),
+    });
+
+    expect(res.status).toBe(200);
+    const post = testDb.select().from(posts).where(eq(posts.slug, "metadata-only-link")).get();
+    expect(post?.og_title).toBe("Fetched title");
+    expect(mockSendUpdateActivity).not.toHaveBeenCalled();
+  });
+
+  it("federates when published post content changes", async () => {
+    const now = new Date("2026-01-01T00:00:00Z");
+    const post = testDb
+      .insert(posts)
+      .values({
+        slug: "federated-content-change",
+        type: "article",
+        title: "Federated Content Change",
+        content: "Original content",
+        created_at: now,
+        updated_at: now,
+        published_at: now,
+      })
+      .returning()
+      .get();
+
+    const res = await api.request("/posts/by-slug/federated-content-change", {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "Updated content" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockSendUpdateActivity).toHaveBeenCalledWith(post.id);
   });
 
   it("returns 404 for non-existent slug", async () => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -303,6 +303,55 @@ async function getLinkPreviewData(url: string | null | undefined): Promise<{
   };
 }
 
+function hasFederatedPostChanges(
+  existingPost: {
+    title: string | null;
+    content: string;
+    excerpt: string | null;
+    url: string | null;
+    source_id: number | null;
+    banner_image_id: number | null;
+  },
+  input: {
+    title?: string | null;
+    content?: string;
+    excerpt?: string | null;
+    url?: string | null;
+    source_id?: number | null;
+    tags?: string[];
+    banner_image_id?: number | null;
+  }
+): boolean {
+  if (input.title !== undefined && (input.title?.trim() || null) !== existingPost.title) {
+    return true;
+  }
+
+  if (input.content !== undefined && input.content.trim() !== existingPost.content) {
+    return true;
+  }
+
+  if (input.excerpt !== undefined && (input.excerpt?.trim() || null) !== existingPost.excerpt) {
+    return true;
+  }
+
+  if (input.url !== undefined && (input.url?.trim() || null) !== existingPost.url) {
+    return true;
+  }
+
+  if (input.source_id !== undefined && input.source_id !== existingPost.source_id) {
+    return true;
+  }
+
+  if (
+    input.banner_image_id !== undefined &&
+    input.banner_image_id !== existingPost.banner_image_id
+  ) {
+    return true;
+  }
+
+  return input.tags !== undefined;
+}
+
 registerProtectedRoute(
   protectedRoute({
     method: "get",
@@ -374,8 +423,8 @@ registerProtectedRoute(
       return c.json({ error: "Invalid type. Must be article, link, or note" }, 400);
     }
 
-    if (limit !== undefined && (isNaN(limit) || limit < 1 || limit > 100)) {
-      return c.json({ error: "Invalid limit. Must be between 1 and 100" }, 400);
+    if (limit !== undefined && (isNaN(limit) || limit < 1)) {
+      return c.json({ error: "Invalid limit. Must be 1 or greater" }, 400);
     }
 
     if (status && !["draft", "published", "all"].includes(status)) {
@@ -634,9 +683,22 @@ registerProtectedRoute(
 
     try {
       const existingPost = getPost(id);
-      const nextUrl = url !== undefined ? url?.trim() || null : existingPost?.url;
+      if (!existingPost) {
+        return c.json({ error: "Post not found" }, 404);
+      }
+
+      const shouldFederateUpdate = hasFederatedPostChanges(existingPost, {
+        title,
+        content,
+        excerpt,
+        url,
+        source_id,
+        tags,
+        banner_image_id,
+      });
+      const nextUrl = url !== undefined ? url?.trim() || null : existingPost.url;
       const linkPreview =
-        existingPost?.type === "link" && (url !== undefined || !hasStoredLinkPreview(existingPost))
+        existingPost.type === "link" && (url !== undefined || !hasStoredLinkPreview(existingPost))
           ? await getLinkPreviewData(nextUrl)
           : null;
       const post = updatePost(id, {
@@ -673,7 +735,7 @@ registerProtectedRoute(
         return c.json({ error: "Post not found" }, 404);
       }
 
-      if (post.published_at) {
+      if (post.published_at && shouldFederateUpdate) {
         await sendUpdateActivity(post.id);
       }
 
@@ -935,6 +997,15 @@ registerProtectedRoute(
     }
 
     try {
+      const shouldFederateUpdate = hasFederatedPostChanges(existingPost, {
+        title,
+        content,
+        excerpt,
+        url,
+        source_id,
+        tags,
+        banner_image_id,
+      });
       const nextUrl = url !== undefined ? url?.trim() || null : existingPost.url;
       const linkPreview =
         existingPost.type === "link" && (url !== undefined || !hasStoredLinkPreview(existingPost))
@@ -970,7 +1041,7 @@ registerProtectedRoute(
         return c.json({ error: "Post not found" }, 404);
       }
 
-      if (post.published_at) {
+      if (post.published_at && shouldFederateUpdate) {
         await sendUpdateActivity(post.id);
       }
 


### PR DESCRIPTION
## Summary
- make `ec link list` request all links by default
- allow the posts API to list more than 100 records when an explicit limit is provided
- avoid sending ActivityPub Update activities when an edit only fills missing link preview metadata

## Validation
- make check
- npm run typecheck

Task: task-506467e3