### PR TITLE
Add optional author field to sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@
 
 The preflight ensures you understand the task, check dependencies, and follow project guidelines.
 
+After preflight passes and the implementation plan is approved, set the task status to `inprogress` before making code changes.
+
 ## Required Reading
 
 Before working, read and follow:
@@ -201,6 +203,7 @@ CLI integration tests are in `integration-tests/cli-*/`. These tests assume `EC_
 ## Task Lifecycle
 
 - **Starting**: ALWAYS run `task-start-preflight` skill first
+- **Before work begins**: After preflight passes and the user approves the plan, move the task to `inprogress` before making code changes
 - **Closing**: Run `task-close-preflight` skill
 
 ## PR Workflow

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ec link create --url "..." --slug my-link --content "Commentary"
 ec note create --slug thought --content "A quick note"
 
 ec source list                  # List sources (blogroll)
-ec source create --name "HN" --url "https://news.ycombinator.com"
+ec source create --name "HN" --url "https://news.ycombinator.com" --author "Paul Graham"
 
 ec tag list                     # List tags with counts
 

--- a/cli/src/commands/source/create.ts
+++ b/cli/src/commands/source/create.ts
@@ -6,6 +6,7 @@ interface CreateOptions {
   name?: string;
   url?: string;
   feedUrl?: string;
+  author?: string;
 }
 
 function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolean } {
@@ -30,6 +31,10 @@ function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolea
       options.feedUrl = args[++i];
     } else if (arg.startsWith("--feed-url=")) {
       options.feedUrl = arg.split("=").slice(1).join("=");
+    } else if (arg === "--author" && args[i + 1]) {
+      options.author = args[++i];
+    } else if (arg.startsWith("--author=")) {
+      options.author = arg.split("=").slice(1).join("=");
     }
 
     i++;
@@ -49,12 +54,13 @@ Required:
 
 Options:
   --feed-url <url>    RSS/Atom feed URL (optional)
+  --author <name>     Source author name (optional)
   --json              Output as JSON
   --help, -h          Show this help message
 
 Examples:
   ec source create --name "Hacker News" --url "https://news.ycombinator.com"
-  ec source create --name "Hacker News" --url "https://news.ycombinator.com" --feed-url "https://news.ycombinator.com/rss"
+  ec source create --name "One Useful Thing" --url "https://www.oneusefulthing.org/" --author "Ethan Mollick" --feed-url "https://www.oneusefulthing.org/feed"
 `);
 }
 
@@ -92,6 +98,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     name: options.name,
     url: options.url,
     feed_url: options.feedUrl,
+    author: options.author,
   });
 
   if (result.error) {

--- a/cli/src/commands/source/edit.ts
+++ b/cli/src/commands/source/edit.ts
@@ -6,6 +6,7 @@ interface EditOptions {
   name?: string;
   url?: string;
   feedUrl?: string | null;
+  author?: string | null;
 }
 
 function parseEditArgs(args: string[]): { id: number | null; options: EditOptions; help: boolean } {
@@ -33,6 +34,12 @@ function parseEditArgs(args: string[]): { id: number | null; options: EditOption
       options.feedUrl = arg.split("=").slice(1).join("=");
     } else if (arg === "--no-feed-url") {
       options.feedUrl = null;
+    } else if (arg === "--author" && args[i + 1]) {
+      options.author = args[++i];
+    } else if (arg.startsWith("--author=")) {
+      options.author = arg.split("=").slice(1).join("=");
+    } else if (arg === "--no-author") {
+      options.author = null;
     } else if (!arg.startsWith("-") && id === null) {
       const parsed = parseInt(arg, 10);
       if (!isNaN(parsed)) {
@@ -59,6 +66,8 @@ Options:
   --url <url>         Update source URL
   --feed-url <url>    Update RSS/Atom feed URL
   --no-feed-url       Remove feed URL
+  --author <name>     Update source author name
+  --no-author         Remove source author name
   --json              Output as JSON
   --help, -h          Show this help message
 
@@ -66,7 +75,9 @@ Examples:
   ec source edit 1 --name "HN"
   ec source edit 1 --url "https://hn.algolia.com"
   ec source edit 1 --feed-url "https://hnrss.org/frontpage"
+  ec source edit 1 --author "Paul Graham"
   ec source edit 1 --no-feed-url
+  ec source edit 1 --no-author
 `);
 }
 
@@ -86,11 +97,16 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
 
   // Check if any update options were provided
   const hasUpdates =
-    options.name !== undefined || options.url !== undefined || options.feedUrl !== undefined;
+    options.name !== undefined ||
+    options.url !== undefined ||
+    options.feedUrl !== undefined ||
+    options.author !== undefined;
 
   if (!hasUpdates) {
     console.error("❌ No update options provided.");
-    console.error("Specify at least one of: --name, --url, --feed-url, --no-feed-url");
+    console.error(
+      "Specify at least one of: --name, --url, --feed-url, --no-feed-url, --author, --no-author"
+    );
     process.exit(1);
   }
 
@@ -108,6 +124,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     name: options.name,
     url: options.url,
     feed_url: options.feedUrl,
+    author: options.author,
   });
 
   if (result.error) {

--- a/cli/src/commands/source/index.ts
+++ b/cli/src/commands/source/index.ts
@@ -23,7 +23,7 @@ Options:
 Examples:
   ec source list
   ec source show 1
-  ec source create --name "Hacker News" --url "https://news.ycombinator.com"
+  ec source create --name "Hacker News" --url "https://news.ycombinator.com" --author "Paul Graham"
   ec source edit 1 --name "HN"
   ec source delete 1
 `);

--- a/cli/src/commands/source/list.ts
+++ b/cli/src/commands/source/list.ts
@@ -38,12 +38,16 @@ function formatTable(sources: Source[]): void {
   // Calculate column widths
   const idWidth = Math.max(2, ...sources.map((s) => String(s.id).length));
   const nameWidth = Math.min(30, Math.max(4, ...sources.map((s) => s.name.length)));
+  const authorWidth = Math.min(25, Math.max(6, ...sources.map((s) => (s.author ?? "-").length)));
   const urlWidth = Math.min(50, Math.max(3, ...sources.map((s) => s.url.length)));
 
   // Header
-  const header = ["ID".padEnd(idWidth), "NAME".padEnd(nameWidth), "URL".padEnd(urlWidth)].join(
-    "  "
-  );
+  const header = [
+    "ID".padEnd(idWidth),
+    "NAME".padEnd(nameWidth),
+    "AUTHOR".padEnd(authorWidth),
+    "URL".padEnd(urlWidth),
+  ].join("  ");
 
   console.log(header);
 
@@ -52,6 +56,7 @@ function formatTable(sources: Source[]): void {
     const row = [
       String(source.id).padEnd(idWidth),
       truncate(source.name, nameWidth).padEnd(nameWidth),
+      truncate(source.author ?? "-", authorWidth).padEnd(authorWidth),
       truncate(source.url, urlWidth).padEnd(urlWidth),
     ].join("  ");
 

--- a/cli/src/commands/source/show.ts
+++ b/cli/src/commands/source/show.ts
@@ -42,6 +42,7 @@ function formatSource(source: Source): void {
   console.log(`ID:        ${source.id}`);
   console.log(`Name:      ${source.name}`);
   console.log(`URL:       ${source.url}`);
+  console.log(`Author:    ${source.author || "-"}`);
   console.log(`Feed URL:  ${source.feed_url || "-"}`);
 }
 

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -183,6 +183,7 @@ export class ApiClient {
     name: string;
     url: string;
     feed_url?: string;
+    author?: string;
   }): Promise<ApiResponse<Source>> {
     return this.request<Source>("POST", "/sources", data);
   }
@@ -193,6 +194,7 @@ export class ApiClient {
       name?: string;
       url?: string;
       feed_url?: string | null;
+      author?: string | null;
     }
   ): Promise<ApiResponse<Source>> {
     return this.request<Source>("PUT", `/sources/${id}`, data);

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -62,6 +62,7 @@ export interface Source {
   name: string;
   url: string;
   feed_url: string | null;
+  author: string | null;
 }
 
 export interface TagWithCount {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ post_tags
   post_id, tag_id
 
 sources (link attribution)
-  id, name, url, feed_url
+  id, name, url, feed_url, author
 
 followers
   id, actor_uri, inbox_uri, shared_inbox_uri, followed_at

--- a/docs/CLI_DESIGN.md
+++ b/docs/CLI_DESIGN.md
@@ -89,8 +89,8 @@ Sources provide attribution for links (e.g., "via Hacker News").
 ```bash
 ec source list
 ec source show <id>
-ec source create --name "..." --url "..." [--feed-url "..."]
-ec source edit <id> [--name "..."] [--url "..."] [--feed-url "..."]
+ec source create --name "..." --url "..." [--feed-url "..."] [--author "..."]
+ec source edit <id> [--name "..."] [--url "..."] [--feed-url "..."] [--author "..."] [--no-author]
 ec source delete <id>
 ```
 

--- a/drizzle/0006_magenta_hemingway.sql
+++ b/drizzle/0006_magenta_hemingway.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sources` ADD `author` text;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,733 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "514b5783-feae-41da-97b0-a467bb3faff9",
+  "prevId": "0f01da3c-532a-40d9-b9ca-798bc0ab9b17",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776905887006,
       "tag": "0005_unusual_hellcat",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1777145488638,
+      "tag": "0006_magenta_hemingway",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -47,6 +47,7 @@ export const sources = sqliteTable("sources", {
   name: text("name").notNull(),
   url: text("url").notNull(),
   feed_url: text("feed_url"),
+  author: text("author"),
 });
 
 // ActivityPub followers

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -779,6 +779,47 @@ describe("GET /api/posts - status filter", () => {
   });
 });
 
+describe("POST /api/sources", () => {
+  let api: typeof import("../api").api;
+
+  beforeAll(async () => {
+    const module = await import("../api");
+    api = module.api;
+  });
+
+  it("creates source with optional author", async () => {
+    const res = await api.request("/sources", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "One Useful Thing",
+        url: "https://www.oneusefulthing.org/",
+        feed_url: "https://www.oneusefulthing.org/feed",
+        author: "Ethan Mollick",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.author).toBe("Ethan Mollick");
+
+    const source = testDb.select().from(sources).where(eq(sources.id, json.data.id)).get();
+    expect(source?.author).toBe("Ethan Mollick");
+  });
+
+  it("creates source without author", async () => {
+    const res = await api.request("/sources", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "No Author", url: "https://example.com" }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.author).toBeNull();
+  });
+});
+
 describe("PUT /api/sources/:id", () => {
   let api: typeof import("../api").api;
 
@@ -840,6 +881,42 @@ describe("PUT /api/sources/:id", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.feed_url).toBeNull();
+  });
+
+  it("updates author", async () => {
+    const source = testDb
+      .insert(sources)
+      .values({ name: "Test", url: "https://example.com" })
+      .returning()
+      .get();
+
+    const res = await api.request(`/sources/${source.id}`, {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ author: "Updated Author" }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.author).toBe("Updated Author");
+  });
+
+  it("updates author to null", async () => {
+    const source = testDb
+      .insert(sources)
+      .values({ name: "Test", url: "https://example.com", author: "Original Author" })
+      .returning()
+      .get();
+
+    const res = await api.request(`/sources/${source.id}`, {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ author: null }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.author).toBeNull();
   });
 
   it("returns 404 for non-existent source", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -120,6 +120,7 @@ testDb
       name: "Test Blog",
       url: "https://example.com",
       feed_url: "https://example.com/feed.xml",
+      author: "Test Author",
     },
     { id: 2, name: "Another Site", url: "https://another.example.com", feed_url: null },
   ])
@@ -517,6 +518,14 @@ describe("pages routes", () => {
 
       expect(html).toContain("RSS");
       expect(html).toContain("https://example.com/feed.xml");
+    });
+
+    it("shows source authors when present", async () => {
+      const app = getApp();
+      const res = await app.request("/sources");
+      const html = await res.text();
+
+      expect(html).toContain("by Test Author");
     });
 
     it("includes dark mode classes", async () => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -100,6 +100,7 @@ const SourceSummarySchema = z
     id: z.number().int().openapi({ example: 1 }),
     name: z.string().openapi({ example: "Hacker News" }),
     url: z.string().url().openapi({ example: "https://news.ycombinator.com" }),
+    author: NullableStringSchema.openapi({ example: "Paul Graham" }),
   })
   .openapi("SourceSummary");
 
@@ -235,6 +236,7 @@ const CreateSourceBodySchema = z
     name: z.string().openapi({ example: "Hacker News" }),
     url: z.string().openapi({ example: "https://news.ycombinator.com" }),
     feed_url: z.string().optional().nullable().openapi({ example: "https://hnrss.org/frontpage" }),
+    author: z.string().optional().nullable().openapi({ example: "Paul Graham" }),
   })
   .openapi("CreateSourceBody");
 
@@ -243,6 +245,7 @@ const UpdateSourceBodySchema = z
     name: z.string().optional().nullable(),
     url: z.string().optional().nullable(),
     feed_url: z.string().optional().nullable(),
+    author: z.string().optional().nullable(),
   })
   .openapi("UpdateSourceBody");
 
@@ -1287,7 +1290,7 @@ registerProtectedRoute(
   }),
   async (c: Context) => {
     const body = await c.req.json();
-    const { name, url, feed_url } = body;
+    const { name, url, feed_url, author } = body;
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
       return c.json({ error: "Name is required" }, 400);
@@ -1297,11 +1300,16 @@ registerProtectedRoute(
       return c.json({ error: "URL is required" }, 400);
     }
 
+    if (author !== undefined && author !== null && typeof author !== "string") {
+      return c.json({ error: "Author must be a string" }, 400);
+    }
+
     try {
       const source = createSource({
         name: name.trim(),
         url: url.trim(),
         feed_url: feed_url?.trim() || null,
+        author: author?.trim() || null,
       });
 
       return c.json({ data: source }, 201);
@@ -1354,7 +1362,7 @@ registerProtectedRoute(
     }
 
     const body = await c.req.json();
-    const { name, url, feed_url } = body;
+    const { name, url, feed_url, author } = body;
 
     if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
       return c.json({ error: "Name cannot be empty" }, 400);
@@ -1364,11 +1372,16 @@ registerProtectedRoute(
       return c.json({ error: "URL cannot be empty" }, 400);
     }
 
+    if (author !== undefined && author !== null && typeof author !== "string") {
+      return c.json({ error: "Author must be a string" }, 400);
+    }
+
     try {
       const source = updateSource(id, {
         name: name?.trim(),
         url: url?.trim(),
         feed_url: feed_url !== undefined ? feed_url?.trim() || null : undefined,
+        author: author !== undefined ? author?.trim() || null : undefined,
       });
 
       if (!source) {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1437,19 +1437,30 @@ export function createPagesRoutes(db: Database): Hono {
                 >
                   {source.name}
                 </a>
+                {source.author ? (
+                  <>
+                    {" "}
+                    <span class="ml-2 text-sm text-gray-500 dark:text-gray-400">
+                      by {source.author}
+                    </span>
+                  </>
+                ) : null}
                 {source.feed_url ? (
-                  <span class="ml-2 text-sm text-gray-400 dark:text-gray-500">
-                    (
-                    <a
-                      href={source.feed_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="hover:text-gray-600 dark:hover:text-gray-300"
-                    >
-                      RSS
-                    </a>
-                    )
-                  </span>
+                  <>
+                    {" "}
+                    <span class="ml-2 text-sm text-gray-400 dark:text-gray-500">
+                      (
+                      <a
+                        href={source.feed_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="hover:text-gray-600 dark:hover:text-gray-300"
+                      >
+                        RSS
+                      </a>
+                      )
+                    </span>
+                  </>
                 ) : null}
               </li>
             ))}

--- a/src/services/sources.ts
+++ b/src/services/sources.ts
@@ -6,6 +6,7 @@ export interface Source {
   name: string;
   url: string;
   feed_url: string | null;
+  author: string | null;
 }
 
 /**
@@ -26,13 +27,14 @@ export interface CreateSourceInput {
   name: string;
   url: string;
   feed_url?: string | null;
+  author?: string | null;
 }
 
 /**
  * Create a new source
  */
 export function createSource(input: CreateSourceInput): Source {
-  const { name, url, feed_url } = input;
+  const { name, url, feed_url, author } = input;
 
   const source = db
     .insert(sources)
@@ -40,6 +42,7 @@ export function createSource(input: CreateSourceInput): Source {
       name,
       url,
       feed_url: feed_url ?? null,
+      author: author ?? null,
     })
     .returning()
     .get();
@@ -51,6 +54,7 @@ export interface UpdateSourceInput {
   name?: string;
   url?: string;
   feed_url?: string | null;
+  author?: string | null;
 }
 
 /**
@@ -62,7 +66,12 @@ export function updateSource(id: number, input: UpdateSourceInput): Source | nul
     return null;
   }
 
-  const updates: Partial<{ name: string; url: string; feed_url: string | null }> = {};
+  const updates: Partial<{
+    name: string;
+    url: string;
+    feed_url: string | null;
+    author: string | null;
+  }> = {};
 
   if (input.name !== undefined) {
     updates.name = input.name;
@@ -72,6 +81,9 @@ export function updateSource(id: number, input: UpdateSourceInput): Source | nul
   }
   if (input.feed_url !== undefined) {
     updates.feed_url = input.feed_url;
+  }
+  if (input.author !== undefined) {
+    updates.author = input.author;
   }
 
   if (Object.keys(updates).length === 0) {


### PR DESCRIPTION
## Summary
- Add nullable source author column and migration
- Thread author through source create/update API, service, and CLI flows
- Display source authors on the public sources page when present

## Verification
- make pre-pr
- make check
- npm run typecheck
- Visual verification: http://localhost:5000/sources shows "One Useful Thing by Ethan Mollick (RSS)" (screenshot: /home/erik/.cache/tmp/screenshot-2026-04-25T19-34-29-290Z.png)

Task: #task-b0597abb