### PR TITLE
Support multiple authors for sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ec link create --url "..." --slug my-link --content "Commentary"
 ec note create --slug thought --content "A quick note"
 
 ec source list                  # List sources (blogroll)
-ec source create --name "HN" --url "https://news.ycombinator.com" --author "Paul Graham"
+ec source create --name "HN" --url "https://news.ycombinator.com" --author "Paul Graham" --author "Jessica Livingston"
 
 ec tag list                     # List tags with counts
 

--- a/cli/src/commands/source/create.ts
+++ b/cli/src/commands/source/create.ts
@@ -6,11 +6,11 @@ interface CreateOptions {
   name?: string;
   url?: string;
   feedUrl?: string;
-  author?: string;
+  authors: string[];
 }
 
 function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolean } {
-  const options: CreateOptions = {};
+  const options: CreateOptions = { authors: [] };
   let help = false;
 
   let i = 0;
@@ -32,9 +32,9 @@ function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolea
     } else if (arg.startsWith("--feed-url=")) {
       options.feedUrl = arg.split("=").slice(1).join("=");
     } else if (arg === "--author" && args[i + 1]) {
-      options.author = args[++i];
+      options.authors.push(args[++i]);
     } else if (arg.startsWith("--author=")) {
-      options.author = arg.split("=").slice(1).join("=");
+      options.authors.push(arg.split("=").slice(1).join("="));
     }
 
     i++;
@@ -54,13 +54,14 @@ Required:
 
 Options:
   --feed-url <url>    RSS/Atom feed URL (optional)
-  --author <name>     Source author name (optional)
+  --author <name>     Source author name (can be repeated)
   --json              Output as JSON
   --help, -h          Show this help message
 
 Examples:
   ec source create --name "Hacker News" --url "https://news.ycombinator.com"
   ec source create --name "One Useful Thing" --url "https://www.oneusefulthing.org/" --author "Ethan Mollick" --feed-url "https://www.oneusefulthing.org/feed"
+  ec source create --name "Team Blog" --url "https://example.com" --author "Alice" --author "Bob"
 `);
 }
 
@@ -98,7 +99,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     name: options.name,
     url: options.url,
     feed_url: options.feedUrl,
-    author: options.author,
+    authors: options.authors.map((name) => ({ name })),
   });
 
   if (result.error) {

--- a/cli/src/commands/source/edit.ts
+++ b/cli/src/commands/source/edit.ts
@@ -6,7 +6,7 @@ interface EditOptions {
   name?: string;
   url?: string;
   feedUrl?: string | null;
-  author?: string | null;
+  authors?: string[];
 }
 
 function parseEditArgs(args: string[]): { id: number | null; options: EditOptions; help: boolean } {
@@ -35,11 +35,11 @@ function parseEditArgs(args: string[]): { id: number | null; options: EditOption
     } else if (arg === "--no-feed-url") {
       options.feedUrl = null;
     } else if (arg === "--author" && args[i + 1]) {
-      options.author = args[++i];
+      options.authors = [...(options.authors ?? []), args[++i]];
     } else if (arg.startsWith("--author=")) {
-      options.author = arg.split("=").slice(1).join("=");
-    } else if (arg === "--no-author") {
-      options.author = null;
+      options.authors = [...(options.authors ?? []), arg.split("=").slice(1).join("=")];
+    } else if (arg === "--no-authors") {
+      options.authors = [];
     } else if (!arg.startsWith("-") && id === null) {
       const parsed = parseInt(arg, 10);
       if (!isNaN(parsed)) {
@@ -66,8 +66,8 @@ Options:
   --url <url>         Update source URL
   --feed-url <url>    Update RSS/Atom feed URL
   --no-feed-url       Remove feed URL
-  --author <name>     Update source author name
-  --no-author         Remove source author name
+  --author <name>     Replace source authors (can be repeated)
+  --no-authors        Remove all source authors
   --json              Output as JSON
   --help, -h          Show this help message
 
@@ -76,8 +76,9 @@ Examples:
   ec source edit 1 --url "https://hn.algolia.com"
   ec source edit 1 --feed-url "https://hnrss.org/frontpage"
   ec source edit 1 --author "Paul Graham"
+  ec source edit 1 --author "Alice" --author "Bob"
   ec source edit 1 --no-feed-url
-  ec source edit 1 --no-author
+  ec source edit 1 --no-authors
 `);
 }
 
@@ -100,12 +101,12 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     options.name !== undefined ||
     options.url !== undefined ||
     options.feedUrl !== undefined ||
-    options.author !== undefined;
+    options.authors !== undefined;
 
   if (!hasUpdates) {
     console.error("❌ No update options provided.");
     console.error(
-      "Specify at least one of: --name, --url, --feed-url, --no-feed-url, --author, --no-author"
+      "Specify at least one of: --name, --url, --feed-url, --no-feed-url, --author, --no-authors"
     );
     process.exit(1);
   }
@@ -124,7 +125,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     name: options.name,
     url: options.url,
     feed_url: options.feedUrl,
-    author: options.author,
+    authors: options.authors?.map((name) => ({ name })),
   });
 
   if (result.error) {

--- a/cli/src/commands/source/index.ts
+++ b/cli/src/commands/source/index.ts
@@ -23,7 +23,7 @@ Options:
 Examples:
   ec source list
   ec source show 1
-  ec source create --name "Hacker News" --url "https://news.ycombinator.com" --author "Paul Graham"
+  ec source create --name "Hacker News" --url "https://news.ycombinator.com" --author "Paul Graham" --author "Jessica Livingston"
   ec source edit 1 --name "HN"
   ec source delete 1
 `);

--- a/cli/src/commands/source/list.ts
+++ b/cli/src/commands/source/list.ts
@@ -38,14 +38,14 @@ function formatTable(sources: Source[]): void {
   // Calculate column widths
   const idWidth = Math.max(2, ...sources.map((s) => String(s.id).length));
   const nameWidth = Math.min(30, Math.max(4, ...sources.map((s) => s.name.length)));
-  const authorWidth = Math.min(25, Math.max(6, ...sources.map((s) => (s.author ?? "-").length)));
+  const authorWidth = Math.min(25, Math.max(7, ...sources.map((s) => formatAuthors(s).length)));
   const urlWidth = Math.min(50, Math.max(3, ...sources.map((s) => s.url.length)));
 
   // Header
   const header = [
     "ID".padEnd(idWidth),
     "NAME".padEnd(nameWidth),
-    "AUTHOR".padEnd(authorWidth),
+    "AUTHORS".padEnd(authorWidth),
     "URL".padEnd(urlWidth),
   ].join("  ");
 
@@ -56,7 +56,7 @@ function formatTable(sources: Source[]): void {
     const row = [
       String(source.id).padEnd(idWidth),
       truncate(source.name, nameWidth).padEnd(nameWidth),
-      truncate(source.author ?? "-", authorWidth).padEnd(authorWidth),
+      truncate(formatAuthors(source), authorWidth).padEnd(authorWidth),
       truncate(source.url, urlWidth).padEnd(urlWidth),
     ].join("  ");
 
@@ -64,6 +64,11 @@ function formatTable(sources: Source[]): void {
   }
 
   console.log(`\nTotal: ${sources.length} sources`);
+}
+
+function formatAuthors(source: Source): string {
+  if (source.authors.length === 0) return "-";
+  return source.authors.map((author) => author.name).join(", ");
 }
 
 function truncate(str: string, maxLen: number): string {

--- a/cli/src/commands/source/show.ts
+++ b/cli/src/commands/source/show.ts
@@ -38,11 +38,16 @@ Examples:
 `);
 }
 
+function formatAuthors(source: Source): string {
+  if (source.authors.length === 0) return "-";
+  return source.authors.map((author) => author.name).join(", ");
+}
+
 function formatSource(source: Source): void {
   console.log(`ID:        ${source.id}`);
   console.log(`Name:      ${source.name}`);
   console.log(`URL:       ${source.url}`);
-  console.log(`Author:    ${source.author || "-"}`);
+  console.log(`Authors:   ${formatAuthors(source)}`);
   console.log(`Feed URL:  ${source.feed_url || "-"}`);
 }
 

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -183,7 +183,7 @@ export class ApiClient {
     name: string;
     url: string;
     feed_url?: string;
-    author?: string;
+    authors?: Array<{ name: string }>;
   }): Promise<ApiResponse<Source>> {
     return this.request<Source>("POST", "/sources", data);
   }
@@ -194,7 +194,7 @@ export class ApiClient {
       name?: string;
       url?: string;
       feed_url?: string | null;
-      author?: string | null;
+      authors?: Array<{ name: string }>;
     }
   ): Promise<ApiResponse<Source>> {
     return this.request<Source>("PUT", `/sources/${id}`, data);

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -57,12 +57,19 @@ export interface Media {
   url: string;
 }
 
+export interface SourceAuthor {
+  id: number;
+  name: string;
+  url: string | null;
+  sort_order: number;
+}
+
 export interface Source {
   id: number;
   name: string;
   url: string;
   feed_url: string | null;
-  author: string | null;
+  authors: SourceAuthor[];
 }
 
 export interface TagWithCount {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,13 @@ post_tags
   post_id, tag_id
 
 sources (link attribution)
-  id, name, url, feed_url, author
+  id, name, url, feed_url
+
+people (public attribution identities)
+  id, name, url
+
+source_authors (source bylines)
+  id, source_id, person_id, sort_order
 
 followers
   id, actor_uri, inbox_uri, shared_inbox_uri, followed_at

--- a/docs/CLI_DESIGN.md
+++ b/docs/CLI_DESIGN.md
@@ -89,8 +89,8 @@ Sources provide attribution for links (e.g., "via Hacker News").
 ```bash
 ec source list
 ec source show <id>
-ec source create --name "..." --url "..." [--feed-url "..."] [--author "..."]
-ec source edit <id> [--name "..."] [--url "..."] [--feed-url "..."] [--author "..."] [--no-author]
+ec source create --name "..." --url "..." [--feed-url "..."] [--author "..."]...
+ec source edit <id> [--name "..."] [--url "..."] [--feed-url "..."] [--author "..."]... [--no-authors]
 ec source delete <id>
 ```
 

--- a/drizzle/0007_certain_bishop.sql
+++ b/drizzle/0007_certain_bishop.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `people` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`url` text
+);
+--> statement-breakpoint
+CREATE TABLE `source_authors` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`source_id` integer NOT NULL,
+	`person_id` integer NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`source_id`) REFERENCES `sources`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`person_id`) REFERENCES `people`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+ALTER TABLE `sources` DROP COLUMN `author`;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,815 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a19b9acf-6cd9-45dd-818b-bf408ae8ca33",
+  "prevId": "514b5783-feae-41da-97b0-a467bb3faff9",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777145488638,
       "tag": "0006_magenta_hemingway",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1777148148270,
+      "tag": "0007_certain_bishop",
+      "breakpoints": true
     }
   ]
 }

--- a/integration-tests/cli-source/create.md
+++ b/integration-tests/cli-source/create.md
@@ -19,13 +19,21 @@ bun src/index.ts --config dev-config.yaml source create --name "Hacker News" --u
 
 **Expected:** Success message with source ID.
 
+## Create with Multiple Authors
+
+```bash
+bun src/index.ts --config dev-config.yaml source create --name "Team Blog" --url "https://team.example.com" --author "Alice" --author "Bob"
+```
+
+**Expected:** Success message with source ID.
+
 ## Create with JSON Output
 
 ```bash
-bun src/index.ts --config dev-config.yaml source create --name "JSON Test" --url "https://json.example.com" --json
+bun src/index.ts --config dev-config.yaml source create --name "JSON Test" --url "https://json.example.com" --author "Alice" --json
 ```
 
-**Expected:** JSON object with id, name, url, feed_url fields.
+**Expected:** JSON object with id, name, url, feed_url, and authors fields.
 
 ## Error: Missing Name
 

--- a/integration-tests/cli-source/edit.md
+++ b/integration-tests/cli-source/edit.md
@@ -49,6 +49,34 @@ bun src/index.ts --config dev-config.yaml source show <id>
 
 **Expected:** Feed URL shows the new value.
 
+## Replace Authors
+
+```bash
+bun src/index.ts --config dev-config.yaml source edit <id> --author "Alice" --author "Bob"
+```
+
+**Expected:** Success message.
+
+```bash
+bun src/index.ts --config dev-config.yaml source show <id>
+```
+
+**Expected:** Authors show "Alice, Bob".
+
+## Clear Authors
+
+```bash
+bun src/index.ts --config dev-config.yaml source edit <id> --no-authors
+```
+
+**Expected:** Success message.
+
+```bash
+bun src/index.ts --config dev-config.yaml source show <id>
+```
+
+**Expected:** Authors show "-".
+
 ## Remove Feed URL
 
 ```bash

--- a/integration-tests/cli-source/list.md
+++ b/integration-tests/cli-source/list.md
@@ -18,7 +18,7 @@ bun src/index.ts --config dev-config.yaml source create --name "Source Two" --ur
 bun src/index.ts --config dev-config.yaml source list
 ```
 
-**Expected:** Table with ID, NAME, URL columns showing both sources.
+**Expected:** Table with ID, NAME, AUTHORS, URL columns showing both sources.
 
 ## List as JSON
 
@@ -26,7 +26,7 @@ bun src/index.ts --config dev-config.yaml source list
 bun src/index.ts --config dev-config.yaml source list --json
 ```
 
-**Expected:** JSON array of source objects with id, name, url, feed_url fields.
+**Expected:** JSON array of source objects with id, name, url, feed_url, and authors fields.
 
 ## Empty List
 

--- a/integration-tests/cli-source/show.md
+++ b/integration-tests/cli-source/show.md
@@ -24,6 +24,7 @@ bun src/index.ts --config dev-config.yaml source show <id>
 - ID: <id>
 - Name: Show Test
 - URL: https://show.example.com
+- Authors: -
 - Feed URL: https://show.example.com/rss
 
 ## Show as JSON

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -47,7 +47,23 @@ export const sources = sqliteTable("sources", {
   name: text("name").notNull(),
   url: text("url").notNull(),
   feed_url: text("feed_url"),
-  author: text("author"),
+});
+
+export const people = sqliteTable("people", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  url: text("url"),
+});
+
+export const sourceAuthors = sqliteTable("source_authors", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  source_id: integer("source_id")
+    .notNull()
+    .references(() => sources.id, { onDelete: "cascade" }),
+  person_id: integer("person_id")
+    .notNull()
+    .references(() => people.id, { onDelete: "cascade" }),
+  sort_order: integer("sort_order").notNull().default(0),
 });
 
 // ActivityPub followers

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeAll, beforeEach } from "bun:test";
 import { mock } from "bun:test";
 import { createTestDb } from "../../db/test-utils";
-import { posts, sources, tags, postTags } from "../../db/schema";
+import { posts, sources, sourceAuthors, people, tags, postTags } from "../../db/schema";
 import { eq } from "drizzle-orm";
 
 // Create test db immediately
@@ -65,6 +65,8 @@ beforeEach(() => {
   testDb.delete(postTags).run();
   testDb.delete(tags).run();
   testDb.delete(posts).run();
+  testDb.delete(sourceAuthors).run();
+  testDb.delete(people).run();
   testDb.delete(sources).run();
   global.fetch = originalFetch;
   mockFederatePost.mockClear();
@@ -787,36 +789,76 @@ describe("POST /api/sources", () => {
     api = module.api;
   });
 
-  it("creates source with optional author", async () => {
+  it("creates source with multiple authors", async () => {
     const res = await api.request("/sources", {
       method: "POST",
       headers: { ...authHeader, "Content-Type": "application/json" },
       body: JSON.stringify({
-        name: "One Useful Thing",
-        url: "https://www.oneusefulthing.org/",
-        feed_url: "https://www.oneusefulthing.org/feed",
-        author: "Ethan Mollick",
+        name: "Team Blog",
+        url: "https://team.example.com/",
+        feed_url: "https://team.example.com/feed",
+        authors: ["Alice", { name: "Bob", url: "https://bob.example.com" }],
       }),
     });
 
     expect(res.status).toBe(201);
     const json = await res.json();
-    expect(json.data.author).toBe("Ethan Mollick");
+    expect(json.data.authors.map((author: { name: string }) => author.name)).toEqual([
+      "Alice",
+      "Bob",
+    ]);
+    expect(json.data.authors[1].url).toBe("https://bob.example.com");
 
-    const source = testDb.select().from(sources).where(eq(sources.id, json.data.id)).get();
-    expect(source?.author).toBe("Ethan Mollick");
+    const persistedAuthors = testDb
+      .select()
+      .from(sourceAuthors)
+      .where(eq(sourceAuthors.source_id, json.data.id))
+      .all();
+    expect(persistedAuthors).toHaveLength(2);
+
+    const persistedPeople = testDb.select().from(people).all();
+    expect(persistedPeople.map((person) => person.name)).toEqual(["Alice", "Bob"]);
   });
 
-  it("creates source without author", async () => {
+  it("creates source without authors", async () => {
     const res = await api.request("/sources", {
       method: "POST",
       headers: { ...authHeader, "Content-Type": "application/json" },
-      body: JSON.stringify({ name: "No Author", url: "https://example.com" }),
+      body: JSON.stringify({ name: "No Authors", url: "https://example.com" }),
     });
 
     expect(res.status).toBe(201);
     const json = await res.json();
-    expect(json.data.author).toBeNull();
+    expect(json.data.authors).toEqual([]);
+  });
+
+  it("reuses people for authors across sources", async () => {
+    for (const [name, url] of [
+      ["First Source", "https://first.example.com"],
+      ["Second Source", "https://second.example.com"],
+    ]) {
+      const res = await api.request("/sources", {
+        method: "POST",
+        headers: { ...authHeader, "Content-Type": "application/json" },
+        body: JSON.stringify({ name, url, authors: ["Shared Author"] }),
+      });
+      expect(res.status).toBe(201);
+    }
+
+    const sharedPeople = testDb.select().from(people).where(eq(people.name, "Shared Author")).all();
+    expect(sharedPeople).toHaveLength(1);
+  });
+
+  it("rejects malformed authors", async () => {
+    const res = await api.request("/sources", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Bad", url: "https://example.com", authors: "Alice" }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(JSON.stringify(json.error)).toContain("expected array");
   });
 });
 
@@ -883,40 +925,55 @@ describe("PUT /api/sources/:id", () => {
     expect(json.data.feed_url).toBeNull();
   });
 
-  it("updates author", async () => {
+  it("replaces authors", async () => {
     const source = testDb
       .insert(sources)
       .values({ name: "Test", url: "https://example.com" })
       .returning()
       .get();
 
+    const originalPerson = testDb.insert(people).values({ name: "Original" }).returning().get();
+    testDb
+      .insert(sourceAuthors)
+      .values({ source_id: source.id, person_id: originalPerson.id })
+      .run();
+
     const res = await api.request(`/sources/${source.id}`, {
       method: "PUT",
       headers: { ...authHeader, "Content-Type": "application/json" },
-      body: JSON.stringify({ author: "Updated Author" }),
+      body: JSON.stringify({ authors: ["Alice", "Bob"] }),
     });
 
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.data.author).toBe("Updated Author");
+    expect(json.data.authors.map((author: { name: string }) => author.name)).toEqual([
+      "Alice",
+      "Bob",
+    ]);
   });
 
-  it("updates author to null", async () => {
+  it("clears authors", async () => {
     const source = testDb
       .insert(sources)
-      .values({ name: "Test", url: "https://example.com", author: "Original Author" })
+      .values({ name: "Test", url: "https://example.com" })
       .returning()
       .get();
 
+    const originalPerson = testDb.insert(people).values({ name: "Original" }).returning().get();
+    testDb
+      .insert(sourceAuthors)
+      .values({ source_id: source.id, person_id: originalPerson.id })
+      .run();
+
     const res = await api.request(`/sources/${source.id}`, {
       method: "PUT",
       headers: { ...authHeader, "Content-Type": "application/json" },
-      body: JSON.stringify({ author: null }),
+      body: JSON.stringify({ authors: [] }),
     });
 
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.data.author).toBeNull();
+    expect(json.data.authors).toEqual([]);
   });
 
   it("returns 404 for non-existent source", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -9,7 +9,7 @@ afterEach(() => {
   global.fetch = originalFetch;
 });
 import { createTestDb } from "../../db/test-utils";
-import { posts, tags, postTags, sources, media } from "../../db/schema";
+import { posts, tags, postTags, sources, sourceAuthors, people, media } from "../../db/schema";
 
 // Create test db immediately
 const testDb = createTestDb();
@@ -120,9 +120,32 @@ testDb
       name: "Test Blog",
       url: "https://example.com",
       feed_url: "https://example.com/feed.xml",
-      author: "Test Author",
     },
     { id: 2, name: "Another Site", url: "https://another.example.com", feed_url: null },
+    { id: 3, name: "Team Blog", url: "https://team.example.com", feed_url: null },
+    { id: 4, name: "Group Blog", url: "https://group.example.com", feed_url: null },
+  ])
+  .run();
+
+testDb
+  .insert(people)
+  .values([
+    { id: 1, name: "Test Author" },
+    { id: 2, name: "Alice" },
+    { id: 3, name: "Bob" },
+    { id: 4, name: "Carol" },
+  ])
+  .run();
+
+testDb
+  .insert(sourceAuthors)
+  .values([
+    { source_id: 1, person_id: 1, sort_order: 0 },
+    { source_id: 3, person_id: 2, sort_order: 0 },
+    { source_id: 3, person_id: 3, sort_order: 1 },
+    { source_id: 4, person_id: 2, sort_order: 0 },
+    { source_id: 4, person_id: 3, sort_order: 1 },
+    { source_id: 4, person_id: 4, sort_order: 2 },
   ])
   .run();
 
@@ -526,6 +549,22 @@ describe("pages routes", () => {
       const html = await res.text();
 
       expect(html).toContain("by Test Author");
+    });
+
+    it("formats two source authors naturally", async () => {
+      const app = getApp();
+      const res = await app.request("/sources");
+      const html = await res.text();
+
+      expect(html).toContain("by Alice and Bob");
+    });
+
+    it("formats three or more source authors naturally", async () => {
+      const app = getApp();
+      const res = await app.request("/sources");
+      const html = await res.text();
+
+      expect(html).toContain("by Alice, Bob, and Carol");
     });
 
     it("includes dark mode classes", async () => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -24,6 +24,7 @@ import {
   createSource,
   updateSource,
   deleteSource,
+  type SourceAuthorInput,
 } from "@/services/sources";
 import { listTags } from "@/services/tags";
 import { fetchLinkPreview } from "@/services/link-preview";
@@ -95,12 +96,21 @@ const ApiPingSchema = z
   })
   .openapi("ApiPing");
 
+const SourceAuthorSchema = z
+  .object({
+    id: z.number().int().openapi({ example: 1 }),
+    name: z.string().openapi({ example: "Paul Graham" }),
+    url: NullableStringSchema.openapi({ example: "https://paulgraham.com" }),
+    sort_order: z.number().int().openapi({ example: 0 }),
+  })
+  .openapi("SourceAuthor");
+
 const SourceSummarySchema = z
   .object({
     id: z.number().int().openapi({ example: 1 }),
     name: z.string().openapi({ example: "Hacker News" }),
     url: z.string().url().openapi({ example: "https://news.ycombinator.com" }),
-    author: NullableStringSchema.openapi({ example: "Paul Graham" }),
+    authors: z.array(SourceAuthorSchema),
   })
   .openapi("SourceSummary");
 
@@ -231,12 +241,20 @@ const UpdatePostBodySchema = z
   })
   .openapi("UpdatePostBody");
 
+const SourceAuthorInputSchema = z.union([
+  z.string().openapi({ example: "Paul Graham" }),
+  z.object({
+    name: z.string().openapi({ example: "Paul Graham" }),
+    url: z.string().optional().nullable().openapi({ example: "https://paulgraham.com" }),
+  }),
+]);
+
 const CreateSourceBodySchema = z
   .object({
     name: z.string().openapi({ example: "Hacker News" }),
     url: z.string().openapi({ example: "https://news.ycombinator.com" }),
     feed_url: z.string().optional().nullable().openapi({ example: "https://hnrss.org/frontpage" }),
-    author: z.string().optional().nullable().openapi({ example: "Paul Graham" }),
+    authors: z.array(SourceAuthorInputSchema).optional().nullable(),
   })
   .openapi("CreateSourceBody");
 
@@ -245,9 +263,61 @@ const UpdateSourceBodySchema = z
     name: z.string().optional().nullable(),
     url: z.string().optional().nullable(),
     feed_url: z.string().optional().nullable(),
-    author: z.string().optional().nullable(),
+    authors: z.array(SourceAuthorInputSchema).optional().nullable(),
   })
   .openapi("UpdateSourceBody");
+
+function parseSourceAuthors(input: unknown): SourceAuthorInput[] | string | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  if (input === null) {
+    return [];
+  }
+
+  if (!Array.isArray(input)) {
+    return "Authors must be an array";
+  }
+
+  const authors: SourceAuthorInput[] = [];
+
+  for (const [index, author] of input.entries()) {
+    if (typeof author === "string") {
+      const name = author.trim();
+      if (!name) {
+        return `Author at index ${index} must have a name`;
+      }
+      authors.push({ name });
+      continue;
+    }
+
+    if (!author || typeof author !== "object" || Array.isArray(author)) {
+      return `Author at index ${index} must be a string or object`;
+    }
+
+    const authorRecord = author as { name?: unknown; url?: unknown };
+    if (typeof authorRecord.name !== "string" || authorRecord.name.trim().length === 0) {
+      return `Author at index ${index} must have a name`;
+    }
+
+    if (
+      authorRecord.url !== undefined &&
+      authorRecord.url !== null &&
+      typeof authorRecord.url !== "string"
+    ) {
+      return `Author URL at index ${index} must be a string`;
+    }
+
+    const authorUrl = typeof authorRecord.url === "string" ? authorRecord.url.trim() || null : null;
+    authors.push({
+      name: authorRecord.name.trim(),
+      url: authorUrl,
+    });
+  }
+
+  return authors;
+}
 
 const DeleteUriBodySchema = z
   .object({
@@ -1290,7 +1360,7 @@ registerProtectedRoute(
   }),
   async (c: Context) => {
     const body = await c.req.json();
-    const { name, url, feed_url, author } = body;
+    const { name, url, feed_url, authors } = body;
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
       return c.json({ error: "Name is required" }, 400);
@@ -1300,8 +1370,9 @@ registerProtectedRoute(
       return c.json({ error: "URL is required" }, 400);
     }
 
-    if (author !== undefined && author !== null && typeof author !== "string") {
-      return c.json({ error: "Author must be a string" }, 400);
+    const parsedAuthors = parseSourceAuthors(authors);
+    if (typeof parsedAuthors === "string") {
+      return c.json({ error: parsedAuthors }, 400);
     }
 
     try {
@@ -1309,7 +1380,7 @@ registerProtectedRoute(
         name: name.trim(),
         url: url.trim(),
         feed_url: feed_url?.trim() || null,
-        author: author?.trim() || null,
+        authors: parsedAuthors,
       });
 
       return c.json({ data: source }, 201);
@@ -1362,7 +1433,7 @@ registerProtectedRoute(
     }
 
     const body = await c.req.json();
-    const { name, url, feed_url, author } = body;
+    const { name, url, feed_url, authors } = body;
 
     if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
       return c.json({ error: "Name cannot be empty" }, 400);
@@ -1372,8 +1443,9 @@ registerProtectedRoute(
       return c.json({ error: "URL cannot be empty" }, 400);
     }
 
-    if (author !== undefined && author !== null && typeof author !== "string") {
-      return c.json({ error: "Author must be a string" }, 400);
+    const parsedAuthors = parseSourceAuthors(authors);
+    if (typeof parsedAuthors === "string") {
+      return c.json({ error: parsedAuthors }, 400);
     }
 
     try {
@@ -1381,7 +1453,7 @@ registerProtectedRoute(
         name: name?.trim(),
         url: url?.trim(),
         feed_url: feed_url !== undefined ? feed_url?.trim() || null : undefined,
-        author: author !== undefined ? author?.trim() || null : undefined,
+        authors: parsedAuthors,
       });
 
       if (!source) {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1,7 +1,17 @@
 import { Hono } from "hono";
 import { raw } from "hono/html";
-import { desc, eq, isNotNull, and } from "drizzle-orm";
-import { db as defaultDb, posts, tags, postTags, sources, media, followers } from "../db";
+import { asc, desc, eq, isNotNull, and } from "drizzle-orm";
+import {
+  db as defaultDb,
+  posts,
+  tags,
+  postTags,
+  sources,
+  sourceAuthors,
+  people,
+  media,
+  followers,
+} from "../db";
 import { Layout } from "../templates/layout";
 import { NotFound } from "../templates/not-found";
 import { truncate } from "../utils/text";
@@ -19,6 +29,13 @@ type Database = typeof defaultDb;
 // Post type for the card component (with optional source)
 type Post = typeof posts.$inferSelect;
 type Source = typeof sources.$inferSelect;
+type SourceAuthor = {
+  id: number;
+  name: string;
+  url: string | null;
+  sort_order: number;
+};
+type SourceWithAuthors = Source & { authors: SourceAuthor[] };
 type Tag = { id: number; name: string; slug: string };
 type PostWithSource = Post & { source?: Source | null };
 
@@ -93,6 +110,24 @@ function normalizeFediverseServer(input: string): string | null {
   } catch {
     return null;
   }
+}
+
+function formatAuthorByline(authors: SourceAuthor[]): string | null {
+  const names = authors.map((author) => author.name);
+
+  if (names.length === 0) {
+    return null;
+  }
+
+  if (names.length === 1) {
+    return names[0];
+  }
+
+  if (names.length === 2) {
+    return `${names[0]} and ${names[1]}`;
+  }
+
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
 }
 
 function buildRemoteFollowUrl(serverOrigin: string): string {
@@ -1412,7 +1447,36 @@ export function createPagesRoutes(db: Database): Hono {
 
   // Sources / Blogroll page
   pages.get("/sources", (c) => {
-    const allSources = db.select().from(sources).orderBy(sources.name).all();
+    const allSourceRows = db.select().from(sources).orderBy(sources.name).all();
+    const allSourceAuthors = db
+      .select({
+        sourceId: sourceAuthors.source_id,
+        id: people.id,
+        name: people.name,
+        url: people.url,
+        sort_order: sourceAuthors.sort_order,
+      })
+      .from(sourceAuthors)
+      .innerJoin(people, eq(sourceAuthors.person_id, people.id))
+      .orderBy(asc(sourceAuthors.source_id), asc(sourceAuthors.sort_order), asc(sourceAuthors.id))
+      .all();
+
+    const authorsBySourceId = new Map<number, SourceAuthor[]>();
+    for (const author of allSourceAuthors) {
+      const existing = authorsBySourceId.get(author.sourceId) ?? [];
+      existing.push({
+        id: author.id,
+        name: author.name,
+        url: author.url,
+        sort_order: author.sort_order,
+      });
+      authorsBySourceId.set(author.sourceId, existing);
+    }
+
+    const allSources: SourceWithAuthors[] = allSourceRows.map((source) => ({
+      ...source,
+      authors: authorsBySourceId.get(source.id) ?? [],
+    }));
 
     return c.html(
       <Layout title="Sources | erikcraddock.me">
@@ -1437,11 +1501,11 @@ export function createPagesRoutes(db: Database): Hono {
                 >
                   {source.name}
                 </a>
-                {source.author ? (
+                {formatAuthorByline(source.authors) ? (
                   <>
                     {" "}
                     <span class="ml-2 text-sm text-gray-500 dark:text-gray-400">
-                      by {source.author}
+                      by {formatAuthorByline(source.authors)}
                     </span>
                   </>
                 ) : null}

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -1,5 +1,5 @@
-import { eq, desc, and, isNotNull, isNull } from "drizzle-orm";
-import { db, posts, tags, postTags, media, sources } from "@/db";
+import { asc, eq, desc, and, isNotNull, isNull } from "drizzle-orm";
+import { db, posts, tags, postTags, media, sources, sourceAuthors, people } from "@/db";
 import { mediaUrl } from "./media";
 
 export type PostType = "article" | "link" | "note";
@@ -15,6 +15,40 @@ export interface PostListItem {
 }
 
 export type PostStatus = "draft" | "published" | "all";
+
+type SourceSummary = {
+  id: number;
+  name: string;
+  url: string;
+  authors: Array<{
+    id: number;
+    name: string;
+    url: string | null;
+    sort_order: number;
+  }>;
+};
+
+function getSourceSummary(sourceId: number): SourceSummary | null {
+  const sourceRecord = db.select().from(sources).where(eq(sources.id, sourceId)).get();
+  if (!sourceRecord) {
+    return null;
+  }
+
+  const authors = db
+    .select({
+      id: people.id,
+      name: people.name,
+      url: people.url,
+      sort_order: sourceAuthors.sort_order,
+    })
+    .from(sourceAuthors)
+    .innerJoin(people, eq(sourceAuthors.person_id, people.id))
+    .where(eq(sourceAuthors.source_id, sourceRecord.id))
+    .orderBy(asc(sourceAuthors.sort_order), asc(sourceAuthors.id))
+    .all();
+
+  return { id: sourceRecord.id, name: sourceRecord.name, url: sourceRecord.url, authors };
+}
 
 export interface ListPostsOptions {
   type?: PostType;
@@ -269,13 +303,7 @@ export function createPost(input: CreatePostInput) {
   }
 
   // Get source info if source_id is set
-  let source: { id: number; name: string; url: string } | null = null;
-  if (post.source_id) {
-    const sourceRecord = db.select().from(sources).where(eq(sources.id, post.source_id)).get();
-    if (sourceRecord) {
-      source = { id: sourceRecord.id, name: sourceRecord.name, url: sourceRecord.url };
-    }
-  }
+  const source = post.source_id ? getSourceSummary(post.source_id) : null;
 
   return {
     ...post,
@@ -471,13 +499,7 @@ export function getPost(id: number) {
   }
 
   // Get source info if source_id is set
-  let source: { id: number; name: string; url: string } | null = null;
-  if (post.source_id) {
-    const sourceRecord = db.select().from(sources).where(eq(sources.id, post.source_id)).get();
-    if (sourceRecord) {
-      source = { id: sourceRecord.id, name: sourceRecord.name, url: sourceRecord.url };
-    }
-  }
+  const source = post.source_id ? getSourceSummary(post.source_id) : null;
 
   return {
     ...post,
@@ -517,13 +539,7 @@ export function getPostBySlug(slug: string) {
   }
 
   // Get source info if source_id is set
-  let source: { id: number; name: string; url: string } | null = null;
-  if (post.source_id) {
-    const sourceRecord = db.select().from(sources).where(eq(sources.id, post.source_id)).get();
-    if (sourceRecord) {
-      source = { id: sourceRecord.id, name: sourceRecord.name, url: sourceRecord.url };
-    }
-  }
+  const source = post.source_id ? getSourceSummary(post.source_id) : null;
 
   return {
     ...post,

--- a/src/services/sources.ts
+++ b/src/services/sources.ts
@@ -1,40 +1,114 @@
-import { eq } from "drizzle-orm";
-import { db, sources } from "@/db";
+import { asc, eq } from "drizzle-orm";
+import { db, people, sourceAuthors, sources } from "@/db";
+
+export interface SourceAuthor {
+  id: number;
+  name: string;
+  url: string | null;
+  sort_order: number;
+}
 
 export interface Source {
   id: number;
   name: string;
   url: string;
   feed_url: string | null;
-  author: string | null;
+  authors: SourceAuthor[];
+}
+
+export interface SourceAuthorInput {
+  name: string;
+  url?: string | null;
+}
+
+type SourceRecord = typeof sources.$inferSelect;
+
+function listAuthorsForSource(sourceId: number): SourceAuthor[] {
+  return db
+    .select({
+      id: people.id,
+      name: people.name,
+      url: people.url,
+      sort_order: sourceAuthors.sort_order,
+    })
+    .from(sourceAuthors)
+    .innerJoin(people, eq(sourceAuthors.person_id, people.id))
+    .where(eq(sourceAuthors.source_id, sourceId))
+    .orderBy(asc(sourceAuthors.sort_order), asc(sourceAuthors.id))
+    .all();
+}
+
+function attachAuthors(source: SourceRecord): Source {
+  return { ...source, authors: listAuthorsForSource(source.id) };
+}
+
+function getOrCreatePerson(author: SourceAuthorInput): number {
+  const existing = db.select().from(people).where(eq(people.name, author.name)).get();
+  if (existing) {
+    if (author.url && !existing.url) {
+      db.update(people).set({ url: author.url }).where(eq(people.id, existing.id)).run();
+    }
+    return existing.id;
+  }
+
+  const person = db
+    .insert(people)
+    .values({ name: author.name, url: author.url ?? null })
+    .returning()
+    .get();
+
+  return person.id;
+}
+
+function replaceSourceAuthors(sourceId: number, authors: SourceAuthorInput[]): void {
+  db.delete(sourceAuthors).where(eq(sourceAuthors.source_id, sourceId)).run();
+
+  if (authors.length === 0) {
+    return;
+  }
+
+  db.insert(sourceAuthors)
+    .values(
+      authors.map((author, index) => ({
+        source_id: sourceId,
+        person_id: getOrCreatePerson(author),
+        sort_order: index,
+      }))
+    )
+    .run();
 }
 
 /**
  * List all sources
  */
 export function listSources(): Source[] {
-  return db.select().from(sources).all();
+  return db
+    .select()
+    .from(sources)
+    .all()
+    .map((source) => attachAuthors(source));
 }
 
 /**
  * Get a single source by ID
  */
 export function getSource(id: number): Source | null {
-  return db.select().from(sources).where(eq(sources.id, id)).get() ?? null;
+  const source = db.select().from(sources).where(eq(sources.id, id)).get();
+  return source ? attachAuthors(source) : null;
 }
 
 export interface CreateSourceInput {
   name: string;
   url: string;
   feed_url?: string | null;
-  author?: string | null;
+  authors?: SourceAuthorInput[];
 }
 
 /**
  * Create a new source
  */
 export function createSource(input: CreateSourceInput): Source {
-  const { name, url, feed_url, author } = input;
+  const { name, url, feed_url, authors } = input;
 
   const source = db
     .insert(sources)
@@ -42,19 +116,20 @@ export function createSource(input: CreateSourceInput): Source {
       name,
       url,
       feed_url: feed_url ?? null,
-      author: author ?? null,
     })
     .returning()
     .get();
 
-  return source;
+  replaceSourceAuthors(source.id, authors ?? []);
+
+  return attachAuthors(source);
 }
 
 export interface UpdateSourceInput {
   name?: string;
   url?: string;
   feed_url?: string | null;
-  author?: string | null;
+  authors?: SourceAuthorInput[];
 }
 
 /**
@@ -70,7 +145,6 @@ export function updateSource(id: number, input: UpdateSourceInput): Source | nul
     name: string;
     url: string;
     feed_url: string | null;
-    author: string | null;
   }> = {};
 
   if (input.name !== undefined) {
@@ -82,17 +156,16 @@ export function updateSource(id: number, input: UpdateSourceInput): Source | nul
   if (input.feed_url !== undefined) {
     updates.feed_url = input.feed_url;
   }
-  if (input.author !== undefined) {
-    updates.author = input.author;
+
+  if (Object.keys(updates).length > 0) {
+    db.update(sources).set(updates).where(eq(sources.id, id)).returning().get();
   }
 
-  if (Object.keys(updates).length === 0) {
-    return existing;
+  if (input.authors !== undefined) {
+    replaceSourceAuthors(id, input.authors);
   }
 
-  const source = db.update(sources).set(updates).where(eq(sources.id, id)).returning().get();
-
-  return source ?? null;
+  return getSource(id);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace singular source author model with reusable people plus source_authors join table
- Expose plural authors in source API/service/CLI responses and update create/edit flows
- Reuse the same person record when an author writes for multiple sources
- Render multiple source bylines on /sources with natural formatting

## Verification
- make pre-pr
- npm run typecheck
- npm run lint
- bun test src/routes/__tests__/api.test.tsx src/routes/__tests__/pages.test.tsx
- Browser verification: http://localhost:5000/sources shows "Multi Author Test by Alice, Bob, and Carol" (screenshot: /home/erik/.cache/tmp/screenshot-2026-04-25T20-06-18-538Z.png)
- CLI verification: source create/list/show with repeated --author flags
- Logs checked with make dev-tail grep; no errors/warnings

Task: #task-9f6c9f53