### PR TITLE
Add source metadata and favicons

### DIFF
--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -183,6 +183,11 @@ export class ApiClient {
     name: string;
     url: string;
     feed_url?: string;
+    preview_title?: string | null;
+    preview_description?: string | null;
+    preview_image_url?: string | null;
+    preview_site_name?: string | null;
+    favicon_url?: string | null;
     authors?: Array<{ name: string }>;
   }): Promise<ApiResponse<Source>> {
     return this.request<Source>("POST", "/sources", data);
@@ -194,6 +199,11 @@ export class ApiClient {
       name?: string;
       url?: string;
       feed_url?: string | null;
+      preview_title?: string | null;
+      preview_description?: string | null;
+      preview_image_url?: string | null;
+      preview_site_name?: string | null;
+      favicon_url?: string | null;
       authors?: Array<{ name: string }>;
     }
   ): Promise<ApiResponse<Source>> {

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -69,6 +69,11 @@ export interface Source {
   name: string;
   url: string;
   feed_url: string | null;
+  preview_title: string | null;
+  preview_description: string | null;
+  preview_image_url: string | null;
+  preview_site_name: string | null;
+  favicon_url: string | null;
   authors: SourceAuthor[];
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ post_tags
   post_id, tag_id
 
 sources (link attribution)
-  id, name, url, feed_url
+  id, name, url, feed_url, preview_title, preview_description, preview_image_url, preview_site_name, favicon_url
 
 people (public attribution identities)
   id, name, url

--- a/drizzle/0008_nebulous_jamie_braddock.sql
+++ b/drizzle/0008_nebulous_jamie_braddock.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `sources` ADD `preview_title` text;--> statement-breakpoint
+ALTER TABLE `sources` ADD `preview_description` text;--> statement-breakpoint
+ALTER TABLE `sources` ADD `preview_image_url` text;--> statement-breakpoint
+ALTER TABLE `sources` ADD `preview_site_name` text;--> statement-breakpoint
+ALTER TABLE `sources` ADD `favicon_url` text;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,850 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "548bdb04-4465-4857-b33f-0a7d165c697b",
+  "prevId": "a19b9acf-6cd9-45dd-818b-bf408ae8ca33",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777148148270,
       "tag": "0007_certain_bishop",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1777154564761,
+      "tag": "0008_nebulous_jamie_braddock",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -47,6 +47,11 @@ export const sources = sqliteTable("sources", {
   name: text("name").notNull(),
   url: text("url").notNull(),
   feed_url: text("feed_url"),
+  preview_title: text("preview_title"),
+  preview_description: text("preview_description"),
+  preview_image_url: text("preview_image_url"),
+  preview_site_name: text("preview_site_name"),
+  favicon_url: text("favicon_url"),
 });
 
 export const people = sqliteTable("people", {

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -78,6 +78,29 @@ beforeEach(() => {
 
 const authHeader = { Authorization: "Bearer ek_test" };
 
+function mockSourcePreviewFetch(): void {
+  global.fetch = mock(
+    async () =>
+      new Response(
+        `
+          <html>
+            <head>
+              <title>Source Preview Title</title>
+              <meta name="description" content="Source preview description" />
+              <meta property="og:site_name" content="Source Site" />
+              <meta property="og:image" content="/source-preview.jpg" />
+              <link rel="icon" href="/favicon.ico" />
+            </head>
+          </html>
+        `,
+        {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }
+      )
+  ) as unknown as typeof fetch;
+}
+
 describe("API docs", () => {
   let api: typeof import("../api").api;
 
@@ -789,6 +812,10 @@ describe("POST /api/sources", () => {
     api = module.api;
   });
 
+  beforeEach(() => {
+    mockSourcePreviewFetch();
+  });
+
   it("creates source with multiple authors", async () => {
     const res = await api.request("/sources", {
       method: "POST",
@@ -832,6 +859,22 @@ describe("POST /api/sources", () => {
     expect(json.data.authors).toEqual([]);
   });
 
+  it("stores source preview metadata and favicon", async () => {
+    const res = await api.request("/sources", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Preview Source", url: "https://preview.example.com" }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.preview_title).toBe("Source Preview Title");
+    expect(json.data.preview_description).toBe("Source preview description");
+    expect(json.data.preview_image_url).toBe("https://preview.example.com/source-preview.jpg");
+    expect(json.data.preview_site_name).toBe("Source Site");
+    expect(json.data.favicon_url).toBe("https://preview.example.com/favicon.ico");
+  });
+
   it("reuses people for authors across sources", async () => {
     for (const [name, url] of [
       ["First Source", "https://first.example.com"],
@@ -868,6 +911,10 @@ describe("PUT /api/sources/:id", () => {
   beforeAll(async () => {
     const module = await import("../api");
     api = module.api;
+  });
+
+  beforeEach(() => {
+    mockSourcePreviewFetch();
   });
 
   it("updates source name", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -120,6 +120,8 @@ testDb
       name: "Test Blog",
       url: "https://example.com",
       feed_url: "https://example.com/feed.xml",
+      favicon_url: "https://example.com/favicon.ico",
+      preview_description: "A test source preview description.",
     },
     { id: 2, name: "Another Site", url: "https://another.example.com", feed_url: null },
     { id: 3, name: "Team Blog", url: "https://team.example.com", feed_url: null },
@@ -541,6 +543,23 @@ describe("pages routes", () => {
 
       expect(html).toContain("RSS");
       expect(html).toContain("https://example.com/feed.xml");
+    });
+
+    it("shows source favicons when present", async () => {
+      const app = getApp();
+      const res = await app.request("/sources");
+      const html = await res.text();
+
+      expect(html).toContain('src="https://example.com/favicon.ico"');
+      expect(html).toContain('class="h-full w-full object-cover"');
+    });
+
+    it("shows source preview descriptions when present", async () => {
+      const app = getApp();
+      const res = await app.request("/sources");
+      const html = await res.text();
+
+      expect(html).toContain("A test source preview description.");
     });
 
     it("shows source authors when present", async () => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -110,6 +110,11 @@ const SourceSummarySchema = z
     id: z.number().int().openapi({ example: 1 }),
     name: z.string().openapi({ example: "Hacker News" }),
     url: z.string().url().openapi({ example: "https://news.ycombinator.com" }),
+    preview_title: NullableStringSchema,
+    preview_description: NullableStringSchema,
+    preview_image_url: NullableStringSchema,
+    preview_site_name: NullableStringSchema,
+    favicon_url: NullableStringSchema,
     authors: z.array(SourceAuthorSchema),
   })
   .openapi("SourceSummary");
@@ -249,12 +254,21 @@ const SourceAuthorInputSchema = z.union([
   }),
 ]);
 
+const SourceMetadataBodySchema = {
+  preview_title: z.string().optional().nullable(),
+  preview_description: z.string().optional().nullable(),
+  preview_image_url: z.string().optional().nullable(),
+  preview_site_name: z.string().optional().nullable(),
+  favicon_url: z.string().optional().nullable(),
+};
+
 const CreateSourceBodySchema = z
   .object({
     name: z.string().openapi({ example: "Hacker News" }),
     url: z.string().openapi({ example: "https://news.ycombinator.com" }),
     feed_url: z.string().optional().nullable().openapi({ example: "https://hnrss.org/frontpage" }),
     authors: z.array(SourceAuthorInputSchema).optional().nullable(),
+    ...SourceMetadataBodySchema,
   })
   .openapi("CreateSourceBody");
 
@@ -264,8 +278,17 @@ const UpdateSourceBodySchema = z
     url: z.string().optional().nullable(),
     feed_url: z.string().optional().nullable(),
     authors: z.array(SourceAuthorInputSchema).optional().nullable(),
+    ...SourceMetadataBodySchema,
   })
   .openapi("UpdateSourceBody");
+
+function parseNullableString(input: unknown): string | null | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  return typeof input === "string" ? input.trim() || null : null;
+}
 
 function parseSourceAuthors(input: unknown): SourceAuthorInput[] | string | undefined {
   if (input === undefined) {
@@ -373,6 +396,27 @@ async function getLinkPreviewData(url: string | null | undefined): Promise<{
     og_description: preview.description,
     og_image_url: preview.imageUrl,
     og_site_name: preview.siteName,
+  };
+}
+
+async function getSourcePreviewData(url: string): Promise<{
+  preview_title: string | null;
+  preview_description: string | null;
+  preview_image_url: string | null;
+  preview_site_name: string | null;
+  favicon_url: string | null;
+} | null> {
+  const preview = await fetchLinkPreview(url);
+  if (!preview) {
+    return null;
+  }
+
+  return {
+    preview_title: preview.title,
+    preview_description: preview.description,
+    preview_image_url: preview.imageUrl,
+    preview_site_name: preview.siteName,
+    favicon_url: preview.faviconUrl,
   };
 }
 
@@ -1360,7 +1404,17 @@ registerProtectedRoute(
   }),
   async (c: Context) => {
     const body = await c.req.json();
-    const { name, url, feed_url, authors } = body;
+    const {
+      name,
+      url,
+      feed_url,
+      authors,
+      preview_title,
+      preview_description,
+      preview_image_url,
+      preview_site_name,
+      favicon_url,
+    } = body;
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
       return c.json({ error: "Name is required" }, 400);
@@ -1376,11 +1430,21 @@ registerProtectedRoute(
     }
 
     try {
+      const sourceUrl = url.trim();
+      const fetchedPreview = await getSourcePreviewData(sourceUrl);
       const source = createSource({
         name: name.trim(),
-        url: url.trim(),
+        url: sourceUrl,
         feed_url: feed_url?.trim() || null,
         authors: parsedAuthors,
+        preview_title: parseNullableString(preview_title) ?? fetchedPreview?.preview_title ?? null,
+        preview_description:
+          parseNullableString(preview_description) ?? fetchedPreview?.preview_description ?? null,
+        preview_image_url:
+          parseNullableString(preview_image_url) ?? fetchedPreview?.preview_image_url ?? null,
+        preview_site_name:
+          parseNullableString(preview_site_name) ?? fetchedPreview?.preview_site_name ?? null,
+        favicon_url: parseNullableString(favicon_url) ?? fetchedPreview?.favicon_url ?? null,
       });
 
       return c.json({ data: source }, 201);
@@ -1433,7 +1497,17 @@ registerProtectedRoute(
     }
 
     const body = await c.req.json();
-    const { name, url, feed_url, authors } = body;
+    const {
+      name,
+      url,
+      feed_url,
+      authors,
+      preview_title,
+      preview_description,
+      preview_image_url,
+      preview_site_name,
+      favicon_url,
+    } = body;
 
     if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
       return c.json({ error: "Name cannot be empty" }, 400);
@@ -1449,11 +1523,35 @@ registerProtectedRoute(
     }
 
     try {
+      const existingSource = getSource(id);
+      const sourceUrl = url?.trim() || existingSource?.url;
+      const fetchedPreview =
+        url !== undefined && sourceUrl ? await getSourcePreviewData(sourceUrl) : null;
       const source = updateSource(id, {
         name: name?.trim(),
         url: url?.trim(),
         feed_url: feed_url !== undefined ? feed_url?.trim() || null : undefined,
         authors: parsedAuthors,
+        preview_title:
+          preview_title !== undefined
+            ? parseNullableString(preview_title)
+            : (fetchedPreview?.preview_title ?? undefined),
+        preview_description:
+          preview_description !== undefined
+            ? parseNullableString(preview_description)
+            : (fetchedPreview?.preview_description ?? undefined),
+        preview_image_url:
+          preview_image_url !== undefined
+            ? parseNullableString(preview_image_url)
+            : (fetchedPreview?.preview_image_url ?? undefined),
+        preview_site_name:
+          preview_site_name !== undefined
+            ? parseNullableString(preview_site_name)
+            : (fetchedPreview?.preview_site_name ?? undefined),
+        favicon_url:
+          favicon_url !== undefined
+            ? parseNullableString(favicon_url)
+            : (fetchedPreview?.favicon_url ?? undefined),
       });
 
       if (!source) {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -141,9 +141,18 @@ function SourceCard({ source }: { source: SourceWithAuthors }) {
           target="_blank"
           rel="noopener noreferrer"
           aria-label={`${source.name} website`}
-          class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-teal-100 text-lg font-bold text-teal-700 dark:bg-teal-900/40 dark:text-teal-300"
+          class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-teal-100 text-lg font-bold text-teal-700 dark:bg-teal-900/40 dark:text-teal-300"
         >
-          {source.name.charAt(0).toUpperCase()}
+          {source.favicon_url ? (
+            <img
+              src={source.favicon_url}
+              alt=""
+              class="h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            source.name.charAt(0).toUpperCase()
+          )}
         </a>
         <div class="min-w-0 flex-1">
           <a
@@ -157,6 +166,12 @@ function SourceCard({ source }: { source: SourceWithAuthors }) {
           <p class="mt-1 truncate text-sm text-gray-500 dark:text-gray-400">{hostname}</p>
         </div>
       </div>
+
+      {source.preview_description ? (
+        <p class="mt-4 line-clamp-3 text-sm leading-6 text-gray-600 dark:text-gray-300">
+          {source.preview_description}
+        </p>
+      ) : null}
 
       {source.authors.length > 0 ? (
         <p class="mt-4 text-sm text-gray-600 dark:text-gray-300">

--- a/src/services/__tests__/link-preview.test.ts
+++ b/src/services/__tests__/link-preview.test.ts
@@ -38,6 +38,7 @@ describe("fetchLinkPreview", () => {
       description: "An example description",
       imageUrl: "https://example.com/images/card.jpg",
       siteName: "Example Site",
+      faviconUrl: "https://example.com/favicon.ico",
     });
   });
 
@@ -50,6 +51,7 @@ describe("fetchLinkPreview", () => {
             <head>
               <title>Fallback Title</title>
               <meta name="description" content="Fallback description" />
+              <link rel="icon" href="/custom.ico" />
             </head>
           </html>
         `,
@@ -69,6 +71,7 @@ describe("fetchLinkPreview", () => {
       description: "Fallback description",
       imageUrl: null,
       siteName: "example.com",
+      faviconUrl: "https://www.example.com/custom.ico",
     });
   });
 

--- a/src/services/link-preview.ts
+++ b/src/services/link-preview.ts
@@ -5,6 +5,7 @@ export interface LinkPreview {
   description: string | null;
   imageUrl: string | null;
   siteName: string | null;
+  faviconUrl: string | null;
 }
 
 function extractMetaContent(html: string, name: string): string | null {
@@ -32,6 +33,25 @@ function extractMetaContent(html: string, name: string): string | null {
 function extractTitleTag(html: string): string | null {
   const match = html.match(/<title[^>]*>([^<]+)<\/title>/i);
   return match?.[1] ? decodeHtmlEntities(match[1].trim()) : null;
+}
+
+function extractLinkHref(html: string, rel: string): string | null {
+  const linkTags = html.match(/<link\s+[^>]*>/gi) ?? [];
+  const relPattern = new RegExp(`\\b${escapeRegExp(rel)}\\b`, "i");
+
+  for (const tag of linkTags) {
+    const relMatch = tag.match(/\srel=["']([^"']+)["']/i);
+    if (!relMatch?.[1] || !relPattern.test(relMatch[1])) {
+      continue;
+    }
+
+    const hrefMatch = tag.match(/\shref=["']([^"']+)["']/i);
+    if (hrefMatch?.[1]) {
+      return decodeHtmlEntities(hrefMatch[1].trim());
+    }
+  }
+
+  return null;
 }
 
 function decodeHtmlEntities(value: string): string {
@@ -107,8 +127,15 @@ export async function fetchLinkPreview(url: string): Promise<LinkPreview | null>
       finalUrl
     );
     const siteName = extractMetaContent(html, "og:site_name") ?? getFallbackSiteName(finalUrl);
+    const faviconUrl = resolveUrl(
+      extractLinkHref(html, "icon") ??
+        extractLinkHref(html, "shortcut icon") ??
+        extractLinkHref(html, "apple-touch-icon") ??
+        "/favicon.ico",
+      finalUrl
+    );
 
-    if (!title && !description && !imageUrl && !siteName) {
+    if (!title && !description && !imageUrl && !siteName && !faviconUrl) {
       return null;
     }
 
@@ -117,6 +144,7 @@ export async function fetchLinkPreview(url: string): Promise<LinkPreview | null>
       description,
       imageUrl,
       siteName,
+      faviconUrl,
     };
   } catch (error) {
     logger.warn("link-preview", "Error fetching link preview", {

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -20,6 +20,11 @@ type SourceSummary = {
   id: number;
   name: string;
   url: string;
+  preview_title: string | null;
+  preview_description: string | null;
+  preview_image_url: string | null;
+  preview_site_name: string | null;
+  favicon_url: string | null;
   authors: Array<{
     id: number;
     name: string;
@@ -47,7 +52,17 @@ function getSourceSummary(sourceId: number): SourceSummary | null {
     .orderBy(asc(sourceAuthors.sort_order), asc(sourceAuthors.id))
     .all();
 
-  return { id: sourceRecord.id, name: sourceRecord.name, url: sourceRecord.url, authors };
+  return {
+    id: sourceRecord.id,
+    name: sourceRecord.name,
+    url: sourceRecord.url,
+    preview_title: sourceRecord.preview_title,
+    preview_description: sourceRecord.preview_description,
+    preview_image_url: sourceRecord.preview_image_url,
+    preview_site_name: sourceRecord.preview_site_name,
+    favicon_url: sourceRecord.favicon_url,
+    authors,
+  };
 }
 
 export interface ListPostsOptions {

--- a/src/services/sources.ts
+++ b/src/services/sources.ts
@@ -13,6 +13,11 @@ export interface Source {
   name: string;
   url: string;
   feed_url: string | null;
+  preview_title: string | null;
+  preview_description: string | null;
+  preview_image_url: string | null;
+  preview_site_name: string | null;
+  favicon_url: string | null;
   authors: SourceAuthor[];
 }
 
@@ -97,7 +102,15 @@ export function getSource(id: number): Source | null {
   return source ? attachAuthors(source) : null;
 }
 
-export interface CreateSourceInput {
+export interface SourceMetadataInput {
+  preview_title?: string | null;
+  preview_description?: string | null;
+  preview_image_url?: string | null;
+  preview_site_name?: string | null;
+  favicon_url?: string | null;
+}
+
+export interface CreateSourceInput extends SourceMetadataInput {
   name: string;
   url: string;
   feed_url?: string | null;
@@ -108,7 +121,17 @@ export interface CreateSourceInput {
  * Create a new source
  */
 export function createSource(input: CreateSourceInput): Source {
-  const { name, url, feed_url, authors } = input;
+  const {
+    name,
+    url,
+    feed_url,
+    authors,
+    preview_title,
+    preview_description,
+    preview_image_url,
+    preview_site_name,
+    favicon_url,
+  } = input;
 
   const source = db
     .insert(sources)
@@ -116,6 +139,11 @@ export function createSource(input: CreateSourceInput): Source {
       name,
       url,
       feed_url: feed_url ?? null,
+      preview_title: preview_title ?? null,
+      preview_description: preview_description ?? null,
+      preview_image_url: preview_image_url ?? null,
+      preview_site_name: preview_site_name ?? null,
+      favicon_url: favicon_url ?? null,
     })
     .returning()
     .get();
@@ -125,7 +153,7 @@ export function createSource(input: CreateSourceInput): Source {
   return attachAuthors(source);
 }
 
-export interface UpdateSourceInput {
+export interface UpdateSourceInput extends SourceMetadataInput {
   name?: string;
   url?: string;
   feed_url?: string | null;
@@ -145,6 +173,11 @@ export function updateSource(id: number, input: UpdateSourceInput): Source | nul
     name: string;
     url: string;
     feed_url: string | null;
+    preview_title: string | null;
+    preview_description: string | null;
+    preview_image_url: string | null;
+    preview_site_name: string | null;
+    favicon_url: string | null;
   }> = {};
 
   if (input.name !== undefined) {
@@ -155,6 +188,21 @@ export function updateSource(id: number, input: UpdateSourceInput): Source | nul
   }
   if (input.feed_url !== undefined) {
     updates.feed_url = input.feed_url;
+  }
+  if (input.preview_title !== undefined) {
+    updates.preview_title = input.preview_title;
+  }
+  if (input.preview_description !== undefined) {
+    updates.preview_description = input.preview_description;
+  }
+  if (input.preview_image_url !== undefined) {
+    updates.preview_image_url = input.preview_image_url;
+  }
+  if (input.preview_site_name !== undefined) {
+    updates.preview_site_name = input.preview_site_name;
+  }
+  if (input.favicon_url !== undefined) {
+    updates.favicon_url = input.favicon_url;
   }
 
   if (Object.keys(updates).length > 0) {


### PR DESCRIPTION
## Summary
- Add nullable source preview metadata fields and favicon URL storage
- Extract favicon URLs from link preview HTML and expose source metadata through API/CLI types
- Render source favicons and preview descriptions on Recommended Sites cards with initial fallback

## Verification
- make pre-pr
- npm run typecheck
- npm run lint
- bun test src/services/__tests__/link-preview.test.ts src/routes/__tests__/api.test.tsx src/routes/__tests__/pages.test.tsx
- Browser verification: http://localhost:5000/sources renders favicon and preview description (screenshot: /home/erik/.cache/tmp/screenshot-2026-04-25T22-04-48-736Z.png)
- Logs checked with make dev-tail grep; no errors/warnings

Task: #task-c7124aab