### PR TITLE
feat: add link author attribution

### DIFF
--- a/cli/src/commands/link/create.ts
+++ b/cli/src/commands/link/create.ts
@@ -15,6 +15,7 @@ interface CreateOptions {
   excerpt?: string;
   tags?: string[];
   source?: string;
+  author?: string;
 }
 
 function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolean } {
@@ -64,6 +65,10 @@ function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolea
       options.source = args[++i];
     } else if (arg.startsWith("--source=")) {
       options.source = arg.split("=").slice(1).join("=");
+    } else if (arg === "--author" && args[i + 1]) {
+      options.author = args[++i];
+    } else if (arg.startsWith("--author=")) {
+      options.author = arg.split("=").slice(1).join("=");
     }
 
     i++;
@@ -87,6 +92,7 @@ Options:
   --excerpt <text>    Short excerpt/summary
   --tags <tags>       Comma-separated list of tags
   --source <id>       Source ID (e.g., Hacker News, Reddit)
+  --author <id>       Author person ID
   --json              Output as JSON
   --help, -h          Show this help message
 
@@ -128,6 +134,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
   let excerpt = options.excerpt;
   let tags = options.tags;
   let source = options.source;
+  let author = options.author;
   let banner: string | undefined;
   let bannerImageId: number | undefined;
   let publishedAt: string | undefined; // For imports - original publish date from frontmatter
@@ -151,6 +158,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     slug = options.slug ?? frontmatter.slug;
     excerpt = options.excerpt ?? frontmatter.excerpt;
     source = options.source ?? frontmatter.source;
+    author = options.author ?? frontmatter.author;
     banner = frontmatter.banner;
     publishedAt = frontmatter.date; // For imports - set original publish date
 
@@ -215,6 +223,13 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     process.exit(1);
   }
 
+  // Parse author ID if provided
+  const authorId = author ? parseInt(author, 10) : undefined;
+  if (author && (isNaN(authorId!) || authorId! <= 0)) {
+    console.error("❌ Invalid author ID. Must be a positive integer.");
+    process.exit(1);
+  }
+
   const result = await client.createPost({
     type: "link",
     slug,
@@ -224,6 +239,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     excerpt,
     tags,
     source_id: sourceId,
+    author_id: authorId,
     banner_image_id: bannerImageId,
     published_at: publishedAt,
   });

--- a/cli/src/commands/link/edit.ts
+++ b/cli/src/commands/link/edit.ts
@@ -14,6 +14,7 @@ interface EditOptions {
   excerpt?: string;
   tags?: string[];
   source?: string;
+  author?: string | null;
 }
 
 function parseEditArgs(args: string[]): { slug?: string; options: EditOptions; help: boolean } {
@@ -60,6 +61,12 @@ function parseEditArgs(args: string[]): { slug?: string; options: EditOptions; h
       options.source = args[++i];
     } else if (arg.startsWith("--source=")) {
       options.source = arg.split("=").slice(1).join("=");
+    } else if (arg === "--author" && args[i + 1]) {
+      options.author = args[++i];
+    } else if (arg.startsWith("--author=")) {
+      options.author = arg.split("=").slice(1).join("=");
+    } else if (arg === "--no-author") {
+      options.author = null;
     } else if (!arg.startsWith("-") && !slug) {
       slug = arg;
     }
@@ -87,6 +94,8 @@ Options:
   --excerpt <text>    Update excerpt
   --tags <tags>       Replace tags (comma-separated)
   --source <id>       Update source ID
+  --author <id>       Update author person ID
+  --no-author         Clear author
   --json              Output as JSON
   --help, -h          Show this help message
 
@@ -134,6 +143,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
   let excerpt = options.excerpt;
   let tags = options.tags;
   let source = options.source;
+  let author = options.author;
 
   if (options.file) {
     // File-based editing
@@ -154,6 +164,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     excerpt = options.excerpt ?? frontmatter.excerpt;
     tags = options.tags ?? frontmatter.tags;
     source = options.source ?? frontmatter.source;
+    author = options.author ?? frontmatter.author;
 
     // Process images
     const banner = frontmatter.banner;
@@ -176,9 +187,11 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
   }
 
   // Check if any update options provided
-  if (!url && !title && !content && !excerpt && !tags && !source) {
+  if (!url && !title && !content && !excerpt && !tags && !source && author === undefined) {
     console.error("❌ No update options provided.");
-    console.error("Use --file, --url, --title, --content, --excerpt, --tags, or --source.");
+    console.error(
+      "Use --file, --url, --title, --content, --excerpt, --tags, --source, --author, or --no-author."
+    );
     process.exit(1);
   }
 
@@ -192,6 +205,17 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     }
   }
 
+  let authorId: number | null | undefined;
+  if (author !== undefined && author !== null) {
+    authorId = parseInt(author, 10);
+    if (isNaN(authorId) || authorId <= 0) {
+      console.error("❌ Invalid author ID. Must be a positive integer.");
+      process.exit(1);
+    }
+  } else if (author === null) {
+    authorId = null;
+  }
+
   const updateData: {
     url?: string;
     title?: string;
@@ -199,6 +223,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     excerpt?: string;
     tags?: string[];
     source_id?: number;
+    author_id?: number | null;
   } = {};
 
   if (url !== undefined) updateData.url = url;
@@ -207,6 +232,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
   if (excerpt !== undefined) updateData.excerpt = excerpt;
   if (tags !== undefined) updateData.tags = tags;
   if (sourceId !== undefined) updateData.source_id = sourceId;
+  if (authorId !== undefined) updateData.author_id = authorId;
 
   const result = await client.updatePost(slug, updateData);
 

--- a/cli/src/commands/link/list.ts
+++ b/cli/src/commands/link/list.ts
@@ -82,6 +82,14 @@ function formatTable(posts: PostListItem[]): void {
   const slugWidth = Math.max(4, ...posts.map((p) => p.slug.length));
   const titleWidth = Math.min(40, Math.max(5, ...posts.map((p) => (p.title || "-").length)));
   const statusWidth = 9; // "published" is 9 chars
+  const authorWidth = Math.min(
+    24,
+    Math.max(6, ...posts.map((p) => (p.author?.name || "-").length))
+  );
+  const sourceWidth = Math.min(
+    24,
+    Math.max(6, ...posts.map((p) => (p.source?.name || "-").length))
+  );
   const dateWidth = 10; // YYYY-MM-DD
 
   // Header
@@ -89,6 +97,8 @@ function formatTable(posts: PostListItem[]): void {
     "SLUG".padEnd(Math.min(slugWidth, 30)),
     "TITLE".padEnd(titleWidth),
     "STATUS".padEnd(statusWidth),
+    "AUTHOR".padEnd(authorWidth),
+    "SOURCE".padEnd(sourceWidth),
     "DATE".padEnd(dateWidth),
   ].join("  ");
 
@@ -103,6 +113,8 @@ function formatTable(posts: PostListItem[]): void {
       truncate(post.slug, 30).padEnd(Math.min(slugWidth, 30)),
       truncate(post.title, titleWidth).padEnd(titleWidth),
       status.padEnd(statusWidth),
+      truncate(post.author?.name ?? null, authorWidth).padEnd(authorWidth),
+      truncate(post.source?.name ?? null, sourceWidth).padEnd(sourceWidth),
       date.padEnd(dateWidth),
     ].join("  ");
 

--- a/cli/src/commands/link/show.ts
+++ b/cli/src/commands/link/show.ts
@@ -35,6 +35,12 @@ function formatLink(post: Post): void {
   }
   console.log(`Slug:      ${post.slug}`);
   console.log(`Status:    ${status}`);
+  if (post.author) {
+    console.log(`Author:    ${post.author.name}`);
+  }
+  if (post.source) {
+    console.log(`Source:    ${post.source.name}`);
+  }
   console.log(`Created:   ${formatDate(post.created_at)}`);
   console.log(`Updated:   ${formatDate(post.updated_at)}`);
   if (post.published_at) {

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -84,6 +84,7 @@ export class ApiClient {
     excerpt?: string;
     url?: string;
     source_id?: number;
+    author_id?: number;
     tags?: string[];
     banner_image_id?: number;
     published_at?: string; // ISO date string for imports
@@ -99,6 +100,7 @@ export class ApiClient {
       excerpt?: string;
       url?: string;
       source_id?: number;
+      author_id?: number | null;
       tags?: string[];
       banner_image_id?: number;
     }

--- a/cli/src/lib/markdown.ts
+++ b/cli/src/lib/markdown.ts
@@ -13,6 +13,7 @@ export interface PostFrontmatter {
   type?: string;
   url?: string;
   source?: string;
+  author?: string;
   date?: string; // For imports - original publish date
 }
 
@@ -163,6 +164,9 @@ export function generateMarkdown(frontmatter: PostFrontmatter, content: string):
   }
   if (frontmatter.source) {
     lines.push(`source: ${frontmatter.source}`);
+  }
+  if (frontmatter.author) {
+    lines.push(`author: ${frontmatter.author}`);
   }
   if (frontmatter.status) {
     lines.push(`status: ${frontmatter.status}`);

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -29,7 +29,17 @@ export interface PostListItem {
   title: string | null;
   excerpt: string | null;
   published_at: string | null;
+  source_id: number | null;
+  author_id: number | null;
+  source: Source | null;
+  author: Person | null;
   tags: string[];
+}
+
+export interface Person {
+  id: number;
+  name: string;
+  url: string | null;
 }
 
 export interface Post {
@@ -41,6 +51,9 @@ export interface Post {
   excerpt: string | null;
   url: string | null;
   source_id: number | null;
+  source: Source | null;
+  author_id: number | null;
+  author: Person | null;
   published_at: string | null;
   created_at: string;
   updated_at: string;

--- a/drizzle/0009_known_absorbing_man.sql
+++ b/drizzle/0009_known_absorbing_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `posts` ADD `author_id` integer REFERENCES people(id);

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,866 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "74fe4594-6877-4dae-9a97-d04d3a120b6e",
+  "prevId": "548bdb04-4465-4857-b33f-0a7d165c697b",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1777154564761,
       "tag": "0008_nebulous_jamie_braddock",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1777163674440,
+      "tag": "0009_known_absorbing_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -14,6 +14,7 @@ export const posts = sqliteTable("posts", {
   og_image_url: text("og_image_url"),
   og_site_name: text("og_site_name"),
   source_id: integer("source_id").references(() => sources.id),
+  author_id: integer("author_id").references(() => people.id, { onDelete: "set null" }),
   banner_image_id: integer("banner_image_id").references(() => media.id, { onDelete: "set null" }),
   published_at: integer("published_at", { mode: "timestamp" }),
   created_at: integer("created_at", { mode: "timestamp" }).notNull(),

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -308,6 +308,36 @@ describe("POST /api/posts - slug validation", () => {
     expect(json.data.published_at).toBeNull();
   });
 
+  it("stores link author independently from source", async () => {
+    const source = testDb
+      .insert(sources)
+      .values({ name: "Example Source", url: "https://example.com" })
+      .returning()
+      .get();
+    const person = testDb.insert(people).values({ name: "Example Author" }).returning().get();
+
+    const res = await api.request("/posts", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "link",
+        slug: "authored-link",
+        title: "Authored Link",
+        url: "https://example.com/article",
+        content: "Commentary",
+        source_id: source.id,
+        author_id: person.id,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.source_id).toBe(source.id);
+    expect(json.data.source.name).toBe("Example Source");
+    expect(json.data.author_id).toBe(person.id);
+    expect(json.data.author.name).toBe("Example Author");
+  });
+
   it("stores link preview metadata for link posts", async () => {
     global.fetch = mock(
       async () =>
@@ -533,6 +563,50 @@ describe("PUT /api/posts/by-slug/:slug", () => {
 
     expect(res.status).toBe(200);
     expect(mockSendUpdateActivity).toHaveBeenCalledWith(post.id);
+  });
+
+  it("updates and clears link author by slug", async () => {
+    const originalPerson = testDb
+      .insert(people)
+      .values({ name: "Original Author" })
+      .returning()
+      .get();
+    const nextPerson = testDb.insert(people).values({ name: "Next Author" }).returning().get();
+    testDb
+      .insert(posts)
+      .values({
+        slug: "author-update-link",
+        type: "link",
+        title: "Author Update Link",
+        content: "Content",
+        url: "https://example.com/author-update",
+        author_id: originalPerson.id,
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .run();
+
+    const updateRes = await api.request("/posts/by-slug/author-update-link", {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ author_id: nextPerson.id }),
+    });
+
+    expect(updateRes.status).toBe(200);
+    const updated = await updateRes.json();
+    expect(updated.data.author_id).toBe(nextPerson.id);
+    expect(updated.data.author.name).toBe("Next Author");
+
+    const clearRes = await api.request("/posts/by-slug/author-update-link", {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ author_id: null }),
+    });
+
+    expect(clearRes.status).toBe(200);
+    const cleared = await clearRes.json();
+    expect(cleared.data.author_id).toBeNull();
+    expect(cleared.data.author).toBeNull();
   });
 
   it("returns 404 for non-existent slug", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -142,6 +142,8 @@ testDb
   ])
   .run();
 
+testDb.update(posts).set({ author_id: 1 }).where(eq(posts.id, 6)).run();
+
 testDb
   .insert(sourceAuthors)
   .values([
@@ -852,6 +854,7 @@ describe("pages routes", () => {
       expect(html).toContain("via");
       expect(html).toContain('href="/sources/1"');
       expect(html).toContain("Test Blog");
+      expect(html).toContain("by Test Author");
     });
 
     it("backfills OG preview metadata for older link posts during page render", async () => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -96,14 +96,17 @@ const ApiPingSchema = z
   })
   .openapi("ApiPing");
 
-const SourceAuthorSchema = z
+const PersonSchema = z
   .object({
     id: z.number().int().openapi({ example: 1 }),
     name: z.string().openapi({ example: "Paul Graham" }),
     url: NullableStringSchema.openapi({ example: "https://paulgraham.com" }),
-    sort_order: z.number().int().openapi({ example: 0 }),
   })
-  .openapi("SourceAuthor");
+  .openapi("Person");
+
+const SourceAuthorSchema = PersonSchema.extend({
+  sort_order: z.number().int().openapi({ example: 0 }),
+}).openapi("SourceAuthor");
 
 const SourceSummarySchema = z
   .object({
@@ -152,6 +155,10 @@ const PostListItemSchema = z
     title: NullableStringSchema,
     excerpt: NullableStringSchema,
     published_at: IsoDateTimeSchema.nullable(),
+    source_id: z.number().int().nullable(),
+    author_id: z.number().int().nullable(),
+    source: SourceSummarySchema.nullable(),
+    author: PersonSchema.nullable(),
     tags: z.array(z.string()).openapi({ example: ["Tech", "Writing"] }),
   })
   .openapi("PostListItem");
@@ -170,9 +177,11 @@ const PostSchema = z
     og_image_url: NullableStringSchema,
     og_site_name: NullableStringSchema,
     source_id: z.number().int().nullable(),
+    author_id: z.number().int().nullable(),
     banner_image_id: z.number().int().nullable(),
     banner_url: NullableStringSchema,
     source: SourceSummarySchema.nullable(),
+    author: PersonSchema.nullable(),
     published_at: IsoDateTimeSchema.nullable(),
     created_at: IsoDateTimeSchema,
     updated_at: IsoDateTimeSchema,
@@ -228,6 +237,7 @@ const CreatePostBodySchema = z
     excerpt: z.string().optional().nullable(),
     url: z.string().optional().nullable(),
     source_id: z.number().int().optional().nullable(),
+    author_id: z.number().int().optional().nullable(),
     tags: z.array(z.string()).optional(),
     banner_image_id: z.number().int().optional().nullable(),
     published_at: z.string().optional().nullable().openapi({ example: "2024-03-15T10:30:00Z" }),
@@ -241,6 +251,7 @@ const UpdatePostBodySchema = z
     excerpt: z.string().optional().nullable(),
     url: z.string().optional().nullable(),
     source_id: z.number().int().optional().nullable(),
+    author_id: z.number().int().optional().nullable(),
     tags: z.array(z.string()).optional(),
     banner_image_id: z.number().int().optional().nullable(),
   })
@@ -427,6 +438,7 @@ function hasFederatedPostChanges(
     excerpt: string | null;
     url: string | null;
     source_id: number | null;
+    author_id: number | null;
     banner_image_id: number | null;
   },
   input: {
@@ -435,6 +447,7 @@ function hasFederatedPostChanges(
     excerpt?: string | null;
     url?: string | null;
     source_id?: number | null;
+    author_id?: number | null;
     tags?: string[];
     banner_image_id?: number | null;
   }
@@ -456,6 +469,10 @@ function hasFederatedPostChanges(
   }
 
   if (input.source_id !== undefined && input.source_id !== existingPost.source_id) {
+    return true;
+  }
+
+  if (input.author_id !== undefined && input.author_id !== existingPost.author_id) {
     return true;
   }
 
@@ -601,6 +618,7 @@ registerProtectedRoute(
       excerpt,
       url,
       source_id,
+      author_id,
       tags,
       banner_image_id,
       published_at,
@@ -658,6 +676,10 @@ registerProtectedRoute(
       return c.json({ error: "source_id must be a number" }, 400);
     }
 
+    if (author_id !== undefined && author_id !== null && typeof author_id !== "number") {
+      return c.json({ error: "author_id must be a number" }, 400);
+    }
+
     let publishedAtDate: Date | null = null;
     if (published_at !== undefined && published_at !== null) {
       if (typeof published_at !== "string") {
@@ -684,6 +706,7 @@ registerProtectedRoute(
         og_image_url: linkPreview?.og_image_url,
         og_site_name: linkPreview?.og_site_name,
         source_id: source_id ?? null,
+        author_id: author_id ?? null,
         tags: tags || [],
         banner_image_id: banner_image_id ?? null,
         published_at: publishedAtDate,
@@ -780,7 +803,7 @@ registerProtectedRoute(
     }
 
     const body = await c.req.json();
-    const { title, content, excerpt, url, source_id, tags, banner_image_id } = body;
+    const { title, content, excerpt, url, source_id, author_id, tags, banner_image_id } = body;
 
     if (tags !== undefined && !Array.isArray(tags)) {
       return c.json({ error: "Tags must be an array" }, 400);
@@ -798,6 +821,10 @@ registerProtectedRoute(
       return c.json({ error: "source_id must be a number" }, 400);
     }
 
+    if (author_id !== undefined && author_id !== null && typeof author_id !== "number") {
+      return c.json({ error: "author_id must be a number" }, 400);
+    }
+
     try {
       const existingPost = getPost(id);
       if (!existingPost) {
@@ -810,6 +837,7 @@ registerProtectedRoute(
         excerpt,
         url,
         source_id,
+        author_id,
         tags,
         banner_image_id,
       });
@@ -844,6 +872,7 @@ registerProtectedRoute(
             ? (linkPreview?.og_site_name ?? null)
             : undefined,
         source_id,
+        author_id,
         tags,
         banner_image_id,
       });
@@ -1095,7 +1124,7 @@ registerProtectedRoute(
     }
 
     const body = await c.req.json();
-    const { title, content, excerpt, url, source_id, tags, banner_image_id } = body;
+    const { title, content, excerpt, url, source_id, author_id, tags, banner_image_id } = body;
 
     if (tags !== undefined && !Array.isArray(tags)) {
       return c.json({ error: "Tags must be an array" }, 400);
@@ -1113,6 +1142,10 @@ registerProtectedRoute(
       return c.json({ error: "source_id must be a number" }, 400);
     }
 
+    if (author_id !== undefined && author_id !== null && typeof author_id !== "number") {
+      return c.json({ error: "author_id must be a number" }, 400);
+    }
+
     try {
       const shouldFederateUpdate = hasFederatedPostChanges(existingPost, {
         title,
@@ -1120,6 +1153,7 @@ registerProtectedRoute(
         excerpt,
         url,
         source_id,
+        author_id,
         tags,
         banner_image_id,
       });
@@ -1150,6 +1184,7 @@ registerProtectedRoute(
             ? (linkPreview?.og_site_name ?? null)
             : undefined,
         source_id,
+        author_id,
         tags,
         banner_image_id,
       });

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -29,6 +29,7 @@ type Database = typeof defaultDb;
 // Post type for the card component (with optional source)
 type Post = typeof posts.$inferSelect;
 type Source = typeof sources.$inferSelect;
+type Person = typeof people.$inferSelect;
 type SourceAuthor = {
   id: number;
   name: string;
@@ -37,7 +38,7 @@ type SourceAuthor = {
 };
 type SourceWithAuthors = Source & { authors: SourceAuthor[] };
 type Tag = { id: number; name: string; slug: string };
-type PostWithSource = Post & { source?: Source | null };
+type PostWithSource = Post & { source?: Source | null; author?: Person | null };
 
 /** Max length for showing full note content inline */
 const NOTE_INLINE_MAX_LENGTH = 280;
@@ -707,6 +708,12 @@ function FeedPostMeta({ post, tags: postTags }: { post: PostWithSource; tags: Ta
       <time>{formattedDate}</time>
       <span aria-hidden="true">·</span>
       <span class="capitalize">{post.type}</span>
+      {post.author && (
+        <>
+          <span aria-hidden="true">·</span>
+          <span>by {post.author.name}</span>
+        </>
+      )}
       {post.source && (
         <>
           <span aria-hidden="true">·</span>
@@ -904,6 +911,9 @@ function PostCard({ post, tags: postTags = [] }: { post: PostWithSource; tags?: 
                 })
               : "Draft"}
           </time>
+
+          {/* Author attribution for link posts */}
+          {isLink && post.author && <span class="ml-2">• by {post.author.name}</span>}
 
           {/* Source attribution for link posts */}
           {isLink && post.source && (
@@ -1270,9 +1280,11 @@ export function createPagesRoutes(db: Database): Hono {
       .select({
         post: posts,
         source: sources,
+        author: people,
       })
       .from(posts)
       .leftJoin(sources, eq(posts.source_id, sources.id))
+      .leftJoin(people, eq(posts.author_id, people.id))
       .where(isNotNull(posts.published_at))
       .orderBy(desc(posts.published_at))
       .limit(FEED_POSTS_PER_PAGE)
@@ -1282,6 +1294,7 @@ export function createPagesRoutes(db: Database): Hono {
     const pagePosts: PostWithSource[] = results.map((row) => ({
       ...row.post,
       source: row.source,
+      author: row.author,
     }));
 
     // Fetch tags for all displayed posts
@@ -1619,14 +1632,18 @@ export function createPagesRoutes(db: Database): Hono {
     }
 
     const sourceLinks: PostWithSource[] = db
-      .select()
+      .select({
+        post: posts,
+        author: people,
+      })
       .from(posts)
+      .leftJoin(people, eq(posts.author_id, people.id))
       .where(
         and(eq(posts.source_id, source.id), eq(posts.type, "link"), isNotNull(posts.published_at))
       )
       .orderBy(desc(posts.published_at))
       .all()
-      .map((post) => ({ ...post, source }));
+      .map((row) => ({ ...row.post, source, author: row.author }));
 
     return c.html(
       <Layout
@@ -1731,9 +1748,11 @@ export function createPagesRoutes(db: Database): Hono {
       .select({
         post: posts,
         source: sources,
+        author: people,
       })
       .from(posts)
       .leftJoin(sources, eq(posts.source_id, sources.id))
+      .leftJoin(people, eq(posts.author_id, people.id))
       .where(eq(posts.slug, slug))
       .get();
 
@@ -1746,6 +1765,7 @@ export function createPagesRoutes(db: Database): Hono {
 
     let post = result.post;
     const source = result.source;
+    const author = result.author;
     const isLink = post.type === "link";
     const isNote = post.type === "note";
 
@@ -1811,7 +1831,7 @@ export function createPagesRoutes(db: Database): Hono {
       .all().length;
     const followerCount = db.select().from(followers).all().length;
     const followingCount = 0;
-    const feedPost: PostWithSource = { ...post, source };
+    const feedPost: PostWithSource = { ...post, source, author };
 
     return c.html(
       <Layout
@@ -1899,10 +1919,12 @@ export function createPagesRoutes(db: Database): Hono {
       .select({
         post: posts,
         source: sources,
+        author: people,
       })
       .from(posts)
       .innerJoin(postTags, eq(posts.id, postTags.post_id))
       .leftJoin(sources, eq(posts.source_id, sources.id))
+      .leftJoin(people, eq(posts.author_id, people.id))
       .where(and(eq(postTags.tag_id, tag.id), isNotNull(posts.published_at)))
       .orderBy(desc(posts.published_at))
       .all();
@@ -1911,6 +1933,7 @@ export function createPagesRoutes(db: Database): Hono {
     const taggedPosts: PostWithSource[] = results.map((row) => ({
       ...row.post,
       source: row.source,
+      author: row.author,
     }));
 
     // Fetch all tags for the displayed posts

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -11,10 +11,20 @@ export interface PostListItem {
   title: string | null;
   excerpt: string | null;
   published_at: string | null;
+  source_id: number | null;
+  author_id: number | null;
+  source: SourceSummary | null;
+  author: PersonSummary | null;
   tags: string[];
 }
 
 export type PostStatus = "draft" | "published" | "all";
+
+type PersonSummary = {
+  id: number;
+  name: string;
+  url: string | null;
+};
 
 type SourceSummary = {
   id: number;
@@ -32,6 +42,17 @@ type SourceSummary = {
     sort_order: number;
   }>;
 };
+
+function getPersonSummary(personId: number): PersonSummary | null {
+  const person = db.select().from(people).where(eq(people.id, personId)).get();
+  return person ? { id: person.id, name: person.name, url: person.url } : null;
+}
+
+function validatePersonId(personId: number): void {
+  if (!getPersonSummary(personId)) {
+    throw new Error(`Person not found: ${personId}`);
+  }
+}
 
 function getSourceSummary(sourceId: number): SourceSummary | null {
   const sourceRecord = db.select().from(sources).where(eq(sources.id, sourceId)).get();
@@ -131,6 +152,8 @@ export function listPosts(options: ListPostsOptions = {}): PostListItem[] {
       title: posts.title,
       excerpt: posts.excerpt,
       published_at: posts.published_at,
+      source_id: posts.source_id,
+      author_id: posts.author_id,
     })
     .from(posts);
 
@@ -167,6 +190,10 @@ export function listPosts(options: ListPostsOptions = {}): PostListItem[] {
       title: post.title,
       excerpt: post.excerpt,
       published_at: post.published_at?.toISOString() ?? null,
+      source_id: post.source_id,
+      author_id: post.author_id,
+      source: post.source_id ? getSourceSummary(post.source_id) : null,
+      author: post.author_id ? getPersonSummary(post.author_id) : null,
       tags: postTagRecords.map((t) => t.name),
     };
   });
@@ -186,6 +213,7 @@ export interface CreatePostInput {
   og_image_url?: string | null;
   og_site_name?: string | null;
   source_id?: number | null;
+  author_id?: number | null;
   tags?: string[]; // Tag slugs
   banner_image_id?: number | null;
   published_at?: Date | null; // For imports - set to create as already published
@@ -240,6 +268,7 @@ export function createPost(input: CreatePostInput) {
     og_image_url,
     og_site_name,
     source_id,
+    author_id,
     tags: tagSlugs,
     banner_image_id,
     published_at,
@@ -259,6 +288,11 @@ export function createPost(input: CreatePostInput) {
     if (!sourceRecord) {
       throw new Error(`Source not found: ${source_id}`);
     }
+  }
+
+  // Validate author_id if provided
+  if (author_id !== undefined && author_id !== null) {
+    validatePersonId(author_id);
   }
 
   // Auto-generate excerpt if not provided
@@ -282,6 +316,7 @@ export function createPost(input: CreatePostInput) {
       og_image_url: og_image_url ?? null,
       og_site_name: og_site_name ?? null,
       source_id: source_id ?? null,
+      author_id: author_id ?? null,
       banner_image_id: banner_image_id ?? null,
       created_at: published_at ?? now,
       updated_at: published_at ?? now,
@@ -317,13 +352,15 @@ export function createPost(input: CreatePostInput) {
     }
   }
 
-  // Get source info if source_id is set
+  // Get source and author info if set
   const source = post.source_id ? getSourceSummary(post.source_id) : null;
+  const author = post.author_id ? getPersonSummary(post.author_id) : null;
 
   return {
     ...post,
     banner_url,
     source,
+    author,
     published_at: post.published_at?.toISOString() ?? null,
     created_at: post.created_at.toISOString(),
     updated_at: post.updated_at.toISOString(),
@@ -341,6 +378,7 @@ export interface UpdatePostInput {
   og_image_url?: string | null;
   og_site_name?: string | null;
   source_id?: number | null;
+  author_id?: number | null;
   tags?: string[]; // Tag slugs
   banner_image_id?: number | null;
 }
@@ -365,6 +403,7 @@ export function updatePost(id: number, input: UpdatePostInput) {
     og_image_url,
     og_site_name,
     source_id,
+    author_id,
     tags: tagSlugs,
     banner_image_id,
   } = input;
@@ -385,6 +424,11 @@ export function updatePost(id: number, input: UpdatePostInput) {
     }
   }
 
+  // Validate author_id if provided
+  if (author_id !== undefined && author_id !== null) {
+    validatePersonId(author_id);
+  }
+
   // Build update object with only provided fields
   const updates: Record<string, unknown> = {
     updated_at: new Date(),
@@ -399,6 +443,7 @@ export function updatePost(id: number, input: UpdatePostInput) {
   if (og_image_url !== undefined) updates.og_image_url = og_image_url;
   if (og_site_name !== undefined) updates.og_site_name = og_site_name;
   if (source_id !== undefined) updates.source_id = source_id;
+  if (author_id !== undefined) updates.author_id = author_id;
   if (banner_image_id !== undefined) updates.banner_image_id = banner_image_id;
 
   // Update post
@@ -513,13 +558,15 @@ export function getPost(id: number) {
     }
   }
 
-  // Get source info if source_id is set
+  // Get source and author info if set
   const source = post.source_id ? getSourceSummary(post.source_id) : null;
+  const author = post.author_id ? getPersonSummary(post.author_id) : null;
 
   return {
     ...post,
     banner_url,
     source,
+    author,
     published_at: post.published_at?.toISOString() ?? null,
     created_at: post.created_at.toISOString(),
     updated_at: post.updated_at.toISOString(),
@@ -553,13 +600,15 @@ export function getPostBySlug(slug: string) {
     }
   }
 
-  // Get source info if source_id is set
+  // Get source and author info if set
   const source = post.source_id ? getSourceSummary(post.source_id) : null;
+  const author = post.author_id ? getPersonSummary(post.author_id) : null;
 
   return {
     ...post,
     banner_url,
     source,
+    author,
     published_at: post.published_at?.toISOString() ?? null,
     created_at: post.created_at.toISOString(),
     updated_at: post.updated_at.toISOString(),


### PR DESCRIPTION
## Summary

- Adds optional `posts.author_id` pointing to `people.id` with generated migration `0009`.
- Returns direct link authors in API post responses while keeping `source_id` and `source` separate.
- Allows CLI link create/edit/show/list to set, clear, and display direct author attribution.
- Renders direct link author attribution alongside source attribution on feed/post/source-detail views.

## Verification

- `bun test src/routes/__tests__/api.test.tsx src/routes/__tests__/pages.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `make pre-pr`
- Browser verification: `/home/erik/.cache/tmp/screenshot-2026-04-26T00-42-25-711Z.png`

Task: #task-ba65dce4
