### PR TITLE
feat: add person management cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ ec note create --slug thought --content "A quick note"
 
 ec source list                  # List sources (blogroll)
 ec source create --name "HN" --url "https://news.ycombinator.com" --author "Paul Graham" --author "Jessica Livingston"
+ec person list                  # List reusable attribution people
+ec person create --name "Ethan Mollick"
 
 ec tag list                     # List tags with counts
 

--- a/cli/src/__tests__/api-people.test.ts
+++ b/cli/src/__tests__/api-people.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { ApiClient } from "../lib/api";
+
+describe("ApiClient people methods", () => {
+  let client: ApiClient;
+  let mockFetch: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    client = new ApiClient("https://api.example.com", "test-key");
+    mockFetch = mock(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      })
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  it("calls GET /people", async () => {
+    await client.listPeople();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/people",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer test-key" }),
+      })
+    );
+  });
+
+  it("calls GET /people/:id", async () => {
+    await client.getPerson(3);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/people/3",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("calls POST /people with body", async () => {
+    const person = { name: "Ethan Mollick", url: "https://www.oneusefulthing.org/" };
+
+    await client.createPerson(person);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/people",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+        body: JSON.stringify(person),
+      })
+    );
+  });
+
+  it("calls PUT /people/:id with body", async () => {
+    const updates = { name: "Ethan Mollick", url: null };
+
+    await client.updatePerson(3, updates);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.example.com/people/3",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify(updates),
+      })
+    );
+  });
+});

--- a/cli/src/commands/person/create.ts
+++ b/cli/src/commands/person/create.ts
@@ -1,0 +1,96 @@
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+interface CreateOptions {
+  name?: string;
+  url?: string | null;
+}
+
+function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolean } {
+  const options: CreateOptions = {};
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--name" && args[i + 1]) {
+      options.name = args[++i];
+    } else if (arg.startsWith("--name=")) {
+      options.name = arg.split("=").slice(1).join("=");
+    } else if (arg === "--url" && args[i + 1]) {
+      options.url = args[++i];
+    } else if (arg.startsWith("--url=")) {
+      options.url = arg.split("=").slice(1).join("=");
+    }
+
+    i++;
+  }
+
+  return { options, help };
+}
+
+function showCreateHelp(): void {
+  console.log(`ec person create - Create a new person
+
+Usage: ec person create --name <name> [options]
+
+Required:
+  --name <name>       Person name
+
+Options:
+  --url <url>         Person URL (optional)
+  --json              Output as JSON
+  --help, -h          Show this help message
+
+Examples:
+  ec person create --name "Ethan Mollick"
+  ec person create --name "Simon Willison" --url "https://simonwillison.net/"
+`);
+}
+
+export async function create(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { options, help } = parseCreateArgs(args);
+
+  if (help) {
+    showCreateHelp();
+    return;
+  }
+
+  if (!options.name || options.name.trim().length === 0) {
+    console.error("❌ --name is required.");
+    console.error("Usage: ec person create --name <name>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig(globalOptions.configPath);
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.createPerson({
+    name: options.name.trim(),
+    url: options.url?.trim() || null,
+  });
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const person = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(person, null, 2));
+  } else {
+    console.log(`✅ Person created with ID: ${person.id}`);
+  }
+}

--- a/cli/src/commands/person/edit.ts
+++ b/cli/src/commands/person/edit.ts
@@ -1,0 +1,119 @@
+import type { GlobalOptions } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+interface EditOptions {
+  name?: string;
+  url?: string | null;
+}
+
+function parseEditArgs(args: string[]): { id: number | null; options: EditOptions; help: boolean } {
+  let id: number | null = null;
+  const options: EditOptions = {};
+  let help = false;
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (arg === "--name" && args[i + 1]) {
+      options.name = args[++i];
+    } else if (arg.startsWith("--name=")) {
+      options.name = arg.split("=").slice(1).join("=");
+    } else if (arg === "--url" && args[i + 1]) {
+      options.url = args[++i];
+    } else if (arg.startsWith("--url=")) {
+      options.url = arg.split("=").slice(1).join("=");
+    } else if (arg === "--no-url") {
+      options.url = null;
+    } else if (!arg.startsWith("-") && id === null) {
+      const parsed = parseInt(arg, 10);
+      if (!isNaN(parsed)) {
+        id = parsed;
+      }
+    }
+
+    i++;
+  }
+
+  return { id, options, help };
+}
+
+function showEditHelp(): void {
+  console.log(`ec person edit - Edit an existing person
+
+Usage: ec person edit <id> [options]
+
+Arguments:
+  <id>                Person ID
+
+Options:
+  --name <name>       Update person name
+  --url <url>         Update person URL
+  --no-url            Clear person URL
+  --json              Output as JSON
+  --help, -h          Show this help message
+
+Examples:
+  ec person edit 1 --name "Ethan Mollick"
+  ec person edit 1 --url "https://example.com"
+  ec person edit 1 --no-url
+`);
+}
+
+export async function edit(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { id, options, help } = parseEditArgs(args);
+
+  if (help) {
+    showEditHelp();
+    return;
+  }
+
+  if (id === null) {
+    console.error("❌ Person ID is required.");
+    console.error("Usage: ec person edit <id> [options]");
+    process.exit(1);
+  }
+
+  const hasUpdates = options.name !== undefined || options.url !== undefined;
+  if (!hasUpdates) {
+    console.error("❌ No update options provided.");
+    console.error("Specify at least one of: --name, --url, --no-url");
+    process.exit(1);
+  }
+
+  if (options.name !== undefined && options.name.trim().length === 0) {
+    console.error("❌ --name cannot be empty.");
+    process.exit(1);
+  }
+
+  const config = await loadConfig(globalOptions.configPath);
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.updatePerson(id, {
+    name: options.name?.trim(),
+    url: options.url === undefined ? undefined : options.url?.trim() || null,
+  });
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const person = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(person, null, 2));
+  } else {
+    console.log(`✅ Person ${person.id} updated.`);
+  }
+}

--- a/cli/src/commands/person/index.ts
+++ b/cli/src/commands/person/index.ts
@@ -1,0 +1,64 @@
+import type { GlobalOptions } from "../../types";
+import { list } from "./list";
+import { show } from "./show";
+import { create } from "./create";
+import { edit } from "./edit";
+
+export function showPersonHelp(): void {
+  console.log(`ec person - Manage reusable attribution people
+
+Usage: ec person <command> [options]
+
+Commands:
+  list              List all people
+  show <id>         Show person details
+  create            Create a new person
+  edit <id>         Edit an existing person
+
+Options:
+  --help, -h        Show help for a command
+
+Examples:
+  ec person list
+  ec person show 1
+  ec person create --name "Ethan Mollick"
+  ec person edit 1 --url "https://example.com"
+  ec person edit 1 --no-url
+`);
+}
+
+export async function personCommand(args: string[], options: GlobalOptions): Promise<void> {
+  if (args.length === 0) {
+    showPersonHelp();
+    return;
+  }
+
+  const [subcmd, ...rest] = args;
+
+  if (options.help) {
+    rest.push("--help");
+  }
+
+  switch (subcmd) {
+    case "list":
+      await list(rest, options);
+      break;
+
+    case "show":
+      await show(rest, options);
+      break;
+
+    case "create":
+      await create(rest, options);
+      break;
+
+    case "edit":
+      await edit(rest, options);
+      break;
+
+    default:
+      console.error(`Unknown person command: ${subcmd}`);
+      console.error("Run 'ec person --help' for usage.");
+      process.exit(1);
+  }
+}

--- a/cli/src/commands/person/list.ts
+++ b/cli/src/commands/person/list.ts
@@ -1,0 +1,86 @@
+import type { GlobalOptions, Person } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function parseListArgs(args: string[]): { help: boolean } {
+  return { help: args.some((arg) => arg === "--help" || arg === "-h") };
+}
+
+function showListHelp(): void {
+  console.log(`ec person list - List all people
+
+Usage: ec person list [options]
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec person list
+  ec person list --json
+`);
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 3) + "...";
+}
+
+function formatTable(people: Person[]): void {
+  if (people.length === 0) {
+    console.log("No people found.");
+    return;
+  }
+
+  const idWidth = Math.max(2, ...people.map((person) => String(person.id).length));
+  const nameWidth = Math.min(30, Math.max(4, ...people.map((person) => person.name.length)));
+  const urlWidth = Math.min(50, Math.max(3, ...people.map((person) => person.url?.length ?? 1)));
+
+  console.log(["ID".padEnd(idWidth), "NAME".padEnd(nameWidth), "URL".padEnd(urlWidth)].join("  "));
+
+  for (const person of people) {
+    console.log(
+      [
+        String(person.id).padEnd(idWidth),
+        truncate(person.name, nameWidth).padEnd(nameWidth),
+        truncate(person.url ?? "-", urlWidth).padEnd(urlWidth),
+      ].join("  ")
+    );
+  }
+
+  console.log(`\nTotal: ${people.length} people`);
+}
+
+export async function list(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { help } = parseListArgs(args);
+
+  if (help) {
+    showListHelp();
+    return;
+  }
+
+  const config = await loadConfig(globalOptions.configPath);
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.listPeople();
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const people = result.data || [];
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(people, null, 2));
+  } else {
+    formatTable(people);
+  }
+}

--- a/cli/src/commands/person/show.ts
+++ b/cli/src/commands/person/show.ts
@@ -1,0 +1,85 @@
+import type { GlobalOptions, Person } from "../../types";
+import { ApiClient } from "../../lib/api";
+import { loadConfig } from "../../lib/config";
+
+function parseShowArgs(args: string[]): { id: number | null; help: boolean } {
+  let id: number | null = null;
+  let help = false;
+
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+    } else if (!arg.startsWith("-") && id === null) {
+      const parsed = parseInt(arg, 10);
+      if (!isNaN(parsed)) {
+        id = parsed;
+      }
+    }
+  }
+
+  return { id, help };
+}
+
+function showShowHelp(): void {
+  console.log(`ec person show - Show person details
+
+Usage: ec person show <id> [options]
+
+Arguments:
+  <id>              Person ID
+
+Options:
+  --json            Output as JSON
+  --help, -h        Show this help message
+
+Examples:
+  ec person show 1
+  ec person show 1 --json
+`);
+}
+
+function formatPerson(person: Person): void {
+  console.log(`ID:   ${person.id}`);
+  console.log(`Name: ${person.name}`);
+  console.log(`URL:  ${person.url || "-"}`);
+}
+
+export async function show(args: string[], globalOptions: GlobalOptions): Promise<void> {
+  const { id, help } = parseShowArgs(args);
+
+  if (help) {
+    showShowHelp();
+    return;
+  }
+
+  if (id === null) {
+    console.error("❌ Person ID is required.");
+    console.error("Usage: ec person show <id>");
+    process.exit(1);
+  }
+
+  const config = await loadConfig(globalOptions.configPath);
+  const apiUrl = globalOptions.apiUrl || config.api_url;
+  const apiKey = globalOptions.apiKey || config.api_key;
+
+  if (!apiUrl || !apiKey) {
+    console.error("❌ Not configured. Run 'ec login' first.");
+    process.exit(1);
+  }
+
+  const client = new ApiClient(apiUrl, apiKey);
+  const result = await client.getPerson(id);
+
+  if (result.error) {
+    console.error(`❌ Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const person = result.data!;
+
+  if (globalOptions.json) {
+    console.log(JSON.stringify(person, null, 2));
+  } else {
+    formatPerson(person);
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@ import { postCommand, showPostHelp } from "./commands/post";
 import { linkCommand } from "./commands/link";
 import { noteCommand } from "./commands/note";
 import { sourceCommand, showSourceHelp } from "./commands/source";
+import { personCommand, showPersonHelp } from "./commands/person";
 import { tagCommand, showTagHelp } from "./commands/tag";
 import { imageCommand, showImageHelp } from "./commands/image";
 import { federationCommand, showFederationHelp } from "./commands/federation";
@@ -65,6 +66,7 @@ Commands:
   link            Manage links (list, show, create, edit, delete, publish)
   note            Manage notes (list, show, create, edit, delete, publish)
   source          Manage sources (list, show, create, edit, delete)
+  person          Manage attribution people (list, show, create, edit)
   tag             Manage tags (list)
   image           Manage images (upload, delete)
   federation      Manage ActivityPub federation (delete)
@@ -87,6 +89,7 @@ Examples:
   ec link create --url "https://..." --slug my-link --content "Commentary"
   ec note create --slug quick-thought --content "Just a thought"
   ec source list
+  ec person list
   ec tag list
   ec image upload ./photo.jpg
   ec version
@@ -201,6 +204,14 @@ async function main(): Promise<void> {
         return;
       }
       await sourceCommand(command.slice(1), options);
+      break;
+
+    case "person":
+      if (options.help && !subcmd) {
+        showPersonHelp();
+        return;
+      }
+      await personCommand(command.slice(1), options);
       break;
 
     case "tag":

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   Post,
   Media,
   Source,
+  Person,
   TagWithCount,
 } from "../types";
 
@@ -169,6 +170,27 @@ export class ApiClient {
 
   async deleteMedia(id: number): Promise<ApiResponse<{ success: boolean }>> {
     return this.request<{ success: boolean }>("DELETE", `/media/${id}`);
+  }
+
+  // Person methods
+
+  async listPeople(): Promise<ApiResponse<Person[]>> {
+    return this.request<Person[]>("GET", "/people");
+  }
+
+  async getPerson(id: number): Promise<ApiResponse<Person>> {
+    return this.request<Person>("GET", `/people/${id}`);
+  }
+
+  async createPerson(data: { name: string; url?: string | null }): Promise<ApiResponse<Person>> {
+    return this.request<Person>("POST", "/people", data);
+  }
+
+  async updatePerson(
+    id: number,
+    data: { name?: string; url?: string | null }
+  ): Promise<ApiResponse<Person>> {
+    return this.request<Person>("PUT", `/people/${id}`, data);
   }
 
   // Source methods

--- a/docs/CLI_DESIGN.md
+++ b/docs/CLI_DESIGN.md
@@ -92,6 +92,11 @@ ec source show <id>
 ec source create --name "..." --url "..." [--feed-url "..."] [--author "..."]...
 ec source edit <id> [--name "..."] [--url "..."] [--feed-url "..."] [--author "..."]... [--no-authors]
 ec source delete <id>
+
+ec person list
+ec person show <id>
+ec person create --name "..." [--url "..."]
+ec person edit <id> [--name "..."] [--url "..."] [--no-url]
 ```
 
 ### Tags
@@ -386,6 +391,10 @@ interesting-article   Interesting Article      published   2026-01-27
 | source create  | `POST /api/sources`                                     |
 | source edit    | `PUT /api/sources/:id` ⚠️ needs endpoint                |
 | source delete  | `DELETE /api/sources/:id` ⚠️ needs endpoint             |
+| person list    | `GET /api/people`                                       |
+| person show    | `GET /api/people/:id`                                   |
+| person create  | `POST /api/people`                                      |
+| person edit    | `PUT /api/people/:id`                                   |
 | tag list       | `GET /api/tags` ⚠️ needs endpoint                       |
 | image upload   | `POST /api/media`                                       |
 | image delete   | `DELETE /api/media/:id`                                 |

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -1263,3 +1263,104 @@ describe("GET /api/tags", () => {
     expect(json.data[0].count).toBe(0);
   });
 });
+
+describe("/api/people", () => {
+  let api: typeof import("../api").api;
+
+  beforeAll(async () => {
+    const module = await import("../api");
+    api = module.api;
+  });
+
+  it("lists people", async () => {
+    testDb.insert(people).values({ name: "Ethan Mollick", url: null }).run();
+    testDb
+      .insert(people)
+      .values({ name: "Simon Willison", url: "https://simonwillison.net/" })
+      .run();
+
+    const res = await api.request("/people", { headers: authHeader });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data).toHaveLength(2);
+    expect(json.data[0]).toMatchObject({ name: "Ethan Mollick", url: null });
+    expect(json.data[1]).toMatchObject({
+      name: "Simon Willison",
+      url: "https://simonwillison.net/",
+    });
+  });
+
+  it("creates and shows a person", async () => {
+    const createRes = await api.request("/people", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Ethan Mollick", url: "https://www.oneusefulthing.org/" }),
+    });
+
+    expect(createRes.status).toBe(201);
+    const created = await createRes.json();
+    expect(created.data).toMatchObject({
+      name: "Ethan Mollick",
+      url: "https://www.oneusefulthing.org/",
+    });
+
+    const showRes = await api.request(`/people/${created.data.id}`, { headers: authHeader });
+
+    expect(showRes.status).toBe(200);
+    const shown = await showRes.json();
+    expect(shown.data).toEqual(created.data);
+  });
+
+  it("rejects blank person names", async () => {
+    const res = await api.request("/people", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "   " }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Name is required");
+  });
+
+  it("returns conflict for duplicate normalized names", async () => {
+    testDb.insert(people).values({ name: "Ethan Mollick", url: null }).run();
+
+    const res = await api.request("/people", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: " ethan mollick " }),
+    });
+
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toContain("Person already exists:");
+  });
+
+  it("edits a person and clears url", async () => {
+    const person = testDb
+      .insert(people)
+      .values({ name: "Old Name", url: "https://example.com" })
+      .returning()
+      .get();
+
+    const res = await api.request(`/people/${person.id}`, {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "New Name", url: null }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data).toMatchObject({ id: person.id, name: "New Name", url: null });
+  });
+
+  it("returns not found for missing people", async () => {
+    const res = await api.request("/people/999", { headers: authHeader });
+
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("Person not found");
+  });
+});

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -27,6 +27,13 @@ import {
   type SourceAuthorInput,
 } from "@/services/sources";
 import { listTags } from "@/services/tags";
+import {
+  createPerson,
+  findPersonByName,
+  getPerson,
+  listPeople,
+  updatePerson,
+} from "@/services/people";
 import { fetchLinkPreview } from "@/services/link-preview";
 import { logger } from "@/utils/logger";
 import {
@@ -61,7 +68,7 @@ api.doc("/openapi.json", (c: Context) => ({
     title: "erikcraddock.me API",
     version,
     description:
-      "Authenticated content management API for posts, sources, tags, media, and federation actions.",
+      "Authenticated content management API for posts, people, sources, tags, media, and federation actions.",
   },
   servers: [
     {
@@ -292,6 +299,20 @@ const UpdateSourceBodySchema = z
     ...SourceMetadataBodySchema,
   })
   .openapi("UpdateSourceBody");
+
+const CreatePersonBodySchema = z
+  .object({
+    name: z.string().openapi({ example: "Ethan Mollick" }),
+    url: z.string().optional().nullable().openapi({ example: "https://example.com" }),
+  })
+  .openapi("CreatePersonBody");
+
+const UpdatePersonBodySchema = z
+  .object({
+    name: z.string().optional().nullable().openapi({ example: "Ethan Mollick" }),
+    url: z.string().optional().nullable().openapi({ example: "https://example.com" }),
+  })
+  .openapi("UpdatePersonBody");
 
 function parseNullableString(input: unknown): string | null | undefined {
   if (input === undefined) {
@@ -1342,6 +1363,201 @@ registerProtectedRoute(
     }
 
     return c.json({ data: post });
+  }
+);
+
+registerProtectedRoute(
+  protectedRoute({
+    method: "get",
+    path: "/people",
+    tags: ["people"],
+    summary: "List people",
+    responses: {
+      200: {
+        description: "All reusable attribution people.",
+        content: { "application/json": { schema: dataEnvelope(z.array(PersonSchema)) } },
+      },
+      401: {
+        description: "Missing or invalid API key.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+    },
+  }),
+  (c: Context) => c.json({ data: listPeople() })
+);
+
+registerProtectedRoute(
+  protectedRoute({
+    method: "get",
+    path: "/people/{id}",
+    tags: ["people"],
+    summary: "Get a person by ID",
+    request: { params: IdParamSchema },
+    responses: {
+      200: {
+        description: "The requested person.",
+        content: { "application/json": { schema: dataEnvelope(PersonSchema) } },
+      },
+      400: {
+        description: "The ID was invalid.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      401: {
+        description: "Missing or invalid API key.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      404: {
+        description: "The person was not found.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+    },
+  }),
+  (c: Context) => {
+    const id = parseInt(c.req.param("id") ?? "", 10);
+    if (isNaN(id)) {
+      return c.json({ error: "Invalid person ID" }, 400);
+    }
+
+    const person = getPerson(id);
+    if (!person) {
+      return c.json({ error: "Person not found" }, 404);
+    }
+
+    return c.json({ data: person });
+  }
+);
+
+registerProtectedRoute(
+  protectedRoute({
+    method: "post",
+    path: "/people",
+    tags: ["people"],
+    summary: "Create a person",
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: CreatePersonBodySchema,
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: "The person was created.",
+        content: { "application/json": { schema: dataEnvelope(PersonSchema) } },
+      },
+      400: {
+        description: "The request body failed validation.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      401: {
+        description: "Missing or invalid API key.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      409: {
+        description: "A person with the same normalized name already exists.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+    },
+  }),
+  async (c: Context) => {
+    const body = await c.req.json();
+    const { name, url } = body;
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      return c.json({ error: "Name is required" }, 400);
+    }
+
+    if (url !== undefined && url !== null && typeof url !== "string") {
+      return c.json({ error: "URL must be a string" }, 400);
+    }
+
+    const existing = findPersonByName(name);
+    if (existing) {
+      return c.json({ error: `Person already exists: ${existing.id}` }, 409);
+    }
+
+    const person = createPerson({ name: name.trim(), url: parseNullableString(url) ?? null });
+    return c.json({ data: person }, 201);
+  }
+);
+
+registerProtectedRoute(
+  protectedRoute({
+    method: "put",
+    path: "/people/{id}",
+    tags: ["people"],
+    summary: "Update a person",
+    request: {
+      params: IdParamSchema,
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: UpdatePersonBodySchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "The updated person.",
+        content: { "application/json": { schema: dataEnvelope(PersonSchema) } },
+      },
+      400: {
+        description: "The request body or ID was invalid.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      401: {
+        description: "Missing or invalid API key.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      404: {
+        description: "The person was not found.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      409: {
+        description: "A different person with the same normalized name already exists.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+    },
+  }),
+  async (c: Context) => {
+    const id = parseInt(c.req.param("id") ?? "", 10);
+    if (isNaN(id)) {
+      return c.json({ error: "Invalid person ID" }, 400);
+    }
+
+    const body = await c.req.json();
+    const { name, url } = body;
+
+    if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
+      return c.json({ error: "Name cannot be empty" }, 400);
+    }
+
+    if (url !== undefined && url !== null && typeof url !== "string") {
+      return c.json({ error: "URL must be a string" }, 400);
+    }
+
+    if (typeof name === "string") {
+      const existing = findPersonByName(name);
+      if (existing && existing.id !== id) {
+        return c.json({ error: `Person already exists: ${existing.id}` }, 409);
+      }
+    }
+
+    const person = updatePerson(id, {
+      name: name !== undefined ? name.trim() : undefined,
+      url: url !== undefined ? (parseNullableString(url) ?? null) : undefined,
+    });
+
+    if (!person) {
+      return c.json({ error: "Person not found" }, 404);
+    }
+
+    return c.json({ data: person });
   }
 );
 

--- a/src/services/people.ts
+++ b/src/services/people.ts
@@ -1,0 +1,64 @@
+import { asc, eq } from "drizzle-orm";
+import { db, people } from "@/db";
+
+export interface Person {
+  id: number;
+  name: string;
+  url: string | null;
+}
+
+export interface CreatePersonInput {
+  name: string;
+  url?: string | null;
+}
+
+export interface UpdatePersonInput {
+  name?: string;
+  url?: string | null;
+}
+
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+export function listPeople(): Person[] {
+  return db.select().from(people).orderBy(asc(people.name), asc(people.id)).all();
+}
+
+export function getPerson(id: number): Person | null {
+  return db.select().from(people).where(eq(people.id, id)).get() ?? null;
+}
+
+export function findPersonByName(name: string): Person | null {
+  const normalized = normalizeName(name);
+  return listPeople().find((person) => normalizeName(person.name) === normalized) ?? null;
+}
+
+export function createPerson(input: CreatePersonInput): Person {
+  return db
+    .insert(people)
+    .values({ name: input.name, url: input.url ?? null })
+    .returning()
+    .get();
+}
+
+export function updatePerson(id: number, input: UpdatePersonInput): Person | null {
+  const existing = getPerson(id);
+  if (!existing) {
+    return null;
+  }
+
+  const updates: Partial<{ name: string; url: string | null }> = {};
+  if (input.name !== undefined) {
+    updates.name = input.name;
+  }
+  if (input.url !== undefined) {
+    updates.url = input.url;
+  }
+
+  if (Object.keys(updates).length > 0) {
+    db.update(people).set(updates).where(eq(people.id, id)).run();
+  }
+
+  return getPerson(id);
+}


### PR DESCRIPTION
## Summary

- Adds protected `/api/people` endpoints for listing, showing, creating, and editing reusable attribution people.
- Adds `ec person list/show/create/edit` CLI commands with JSON output support.
- Uses the existing `people` table and explicit duplicate-name conflicts for safer backfill automation.
- Updates CLI help/docs to include the new person command group.

## Verification

- `bun test src/routes/__tests__/api.test.tsx cli/src/__tests__/api-people.test.ts`
- `npm run typecheck`
- `npm run lint`
- `make pre-pr`
- Manual dev CLI checks:
  - `bun cli/src/index.ts --config cli/dev-config.yaml person list --json`
  - `bun cli/src/index.ts --config cli/dev-config.yaml person create --name "Task BB Test Person" --url "https://example.com/person" --json`
  - `bun cli/src/index.ts --config cli/dev-config.yaml person show 6 --json`
  - `bun cli/src/index.ts --config cli/dev-config.yaml person edit 6 --no-url --json`
  - duplicate create returns `Person already exists: 6`
- Dev logs: no ERROR/WARN matches from `make dev-tail 2>&1 | grep -E "(ERROR|WARN|error|Error)"`

Task: #task-bb4fba69
