### PR TITLE
fix: show full link content on source pages

### DIFF
--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -81,7 +81,7 @@ testDb
       slug: "test-link",
       type: "link",
       title: "Test Link Post",
-      content: "This is commentary on an external link.",
+      content: "This is commentary on an external link.\n\n> Quoted shared link text.",
       url: "https://example.com/article",
       og_title: "Example Article",
       og_description: "A rich preview description.",
@@ -730,15 +730,19 @@ describe("pages routes", () => {
       expect(html).toContain('src="https://example.com/favicon.ico"');
     });
 
-    it("shows links from the selected source as preview links", async () => {
+    it("shows links from the selected source with full shared link content", async () => {
       const app = getApp();
       const res = await app.request("/sources/1");
       const html = await res.text();
 
+      expect(html).toContain("This is commentary on an external link.");
+      expect(html).toContain("Quoted shared link text.");
       expect(html).toContain('href="https://example.com/article"');
       expect(html).toContain("Example Article");
       expect(html).toContain("A rich preview description.");
       expect(html).toContain('src="https://example.com/preview.jpg"');
+      expect(html).toContain("by Test Author");
+      expect(html).toContain("via");
     });
 
     it("returns 404 for missing sources", async () => {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1820,13 +1820,13 @@ export function createPagesRoutes(db: Database): Hono {
                 ← Recommended Sites
               </a>
             </header>
-            <div class="px-4 py-5 dark:bg-gray-900 sm:px-6">
-              {sourceLinks.length === 0 ? (
+            {sourceLinks.length === 0 ? (
+              <div class="px-4 py-5 dark:bg-gray-900 sm:px-6">
                 <p class="text-gray-600 dark:text-gray-400">No links from this source yet.</p>
-              ) : (
-                sourceLinks.map((post) => <FeedLinkPreview key={post.id} post={post} />)
-              )}
-            </div>
+              </div>
+            ) : (
+              sourceLinks.map((post) => <FeedPost key={post.id} post={post} />)
+            )}
           </div>
         </div>
       </Layout>


### PR DESCRIPTION
## Summary

- Render source page links with the same feed post component used by `/feed`.
- Preserve empty-source layout while showing full shared link commentary, quotes, preview card, metadata, and source/author attribution when links exist.
- Add route coverage for quoted shared link content on source detail pages.

## Verification

- `bun test src/routes/__tests__/pages.test.tsx`
- `npm run typecheck`
- `npm run lint`
- pre-push full checks
- Manual visual verification by Erik

Task: #task-3111fbda
