### PR TITLE
feat: add social links feed card

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,6 +33,18 @@ Be explicit about the next human action. Examples:
 - "CI passed; tell me when to request review or merge."
 - "Human approval is required before merging."
 
+When waiting for CI, use code or a tool-driven command to check status on an interval. Do not say you are waiting unless you actually run a wait/check loop. Example:
+
+```bash
+while true; do
+  gh pr view <number> --json statusCheckRollup --jq '.statusCheckRollup[]? | "\(.name): \(.status) \(.conclusion // "")"'
+  if gh pr view <number> --json statusCheckRollup --jq 'all(.statusCheckRollup[]?; .status == "COMPLETED")' | grep -q true; then
+    break
+  fi
+  sleep 30
+done
+```
+
 ### 1. Pick Up a Task
 
 Get assigned a task or pick from available tasks. Understand requirements before starting.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,7 +38,7 @@ When waiting for CI, use code or a tool-driven command to check status on an int
 ```bash
 while true; do
   gh pr view <number> --json statusCheckRollup --jq '.statusCheckRollup[]? | "\(.name): \(.status) \(.conclusion // "")"'
-  if gh pr view <number> --json statusCheckRollup --jq 'all(.statusCheckRollup[]?; .status == "COMPLETED")' | grep -q true; then
+  if gh pr view <number> --json statusCheckRollup --jq '(.statusCheckRollup | length) > 0 and all(.statusCheckRollup[]; .status == "COMPLETED")' | grep -q true; then
     break
   fi
   sleep 30

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -502,7 +502,21 @@ describe("pages routes", () => {
       expect(html).toContain("Follow");
     });
 
-    it("links the actor card to recommended sites", async () => {
+    it("shows a social media card above recommended sites", async () => {
+      const app = getApp();
+      const res = await app.request("/feed");
+      const html = await res.text();
+
+      expect(html).toContain("Find me elsewhere");
+      expect(html).toContain('href="https://github.com/evcraddock"');
+      expect(html).toContain('href="https://www.linkedin.com/in/erik-craddock-42aa9815"');
+      expect(html).toContain('href="https://www.facebook.com/evcraddock"');
+      expect(html).toContain('href="https://youtube.com/@ErikCraddock"');
+      expect(html).toContain('href="/feed.xml"');
+      expect(html.indexOf("Find me elsewhere")).toBeLessThan(html.indexOf("Recommended Sites"));
+    });
+
+    it("links the feed sidebar to recommended sites", async () => {
       const app = getApp();
       const res = await app.request("/feed");
       const html = await res.text();

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -507,13 +507,13 @@ describe("pages routes", () => {
       const res = await app.request("/feed");
       const html = await res.text();
 
-      expect(html).toContain("Find me elsewhere");
+      expect(html).toContain("Follow me");
       expect(html).toContain('href="https://github.com/evcraddock"');
       expect(html).toContain('href="https://www.linkedin.com/in/erik-craddock-42aa9815"');
       expect(html).toContain('href="https://www.facebook.com/evcraddock"');
       expect(html).toContain('href="https://youtube.com/@ErikCraddock"');
       expect(html).toContain('href="/feed.xml"');
-      expect(html.indexOf("Find me elsewhere")).toBeLessThan(html.indexOf("Recommended Sites"));
+      expect(html.indexOf("Follow me")).toBeLessThan(html.indexOf("Recommended Sites"));
     });
 
     it("links the feed sidebar to recommended sites", async () => {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -290,20 +290,20 @@ function RssIcon() {
   );
 }
 
+const SOCIAL_LINKS = [
+  { name: "GitHub", url: "https://github.com/evcraddock", icon: <GitHubIcon /> },
+  {
+    name: "LinkedIn",
+    url: "https://www.linkedin.com/in/erik-craddock-42aa9815",
+    icon: <LinkedInIcon />,
+  },
+  { name: "Facebook", url: "https://www.facebook.com/evcraddock", icon: <FacebookIcon /> },
+  { name: "YouTube", url: "https://youtube.com/@ErikCraddock", icon: <YouTubeIcon /> },
+  { name: "RSS", url: "/feed.xml", icon: <RssIcon /> },
+];
+
 /** Hero section with bio, social links, and logo */
 function HeroSection() {
-  const socialLinks = [
-    { name: "GitHub", url: "https://github.com/evcraddock", icon: <GitHubIcon /> },
-    {
-      name: "LinkedIn",
-      url: "https://www.linkedin.com/in/erik-craddock-42aa9815",
-      icon: <LinkedInIcon />,
-    },
-    { name: "Facebook", url: "https://www.facebook.com/evcraddock", icon: <FacebookIcon /> },
-    { name: "YouTube", url: "https://youtube.com/@ErikCraddock", icon: <YouTubeIcon /> },
-    { name: "RSS", url: "/feed.xml", icon: <RssIcon /> },
-  ];
-
   return (
     <section class="mb-12 py-8 bg-gray-100 dark:bg-gray-800 -mx-4 px-4 rounded-lg">
       <div class="flex flex-col md:flex-row items-stretch gap-8">
@@ -335,7 +335,7 @@ function HeroSection() {
 
             {/* Social links */}
             <div class="flex justify-start gap-4">
-              {socialLinks.map((link) => (
+              {SOCIAL_LINKS.map((link) => (
                 <a
                   key={link.name}
                   href={link.url}
@@ -649,6 +649,30 @@ function FeedProfileCard({
             </div>
           </dl>
         </div>
+      </div>
+    </section>
+  );
+}
+
+function SocialMediaFeedCard() {
+  return (
+    <section class="border-b border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900 lg:mt-4 lg:rounded-2xl lg:border">
+      <h2 class="text-lg font-bold text-gray-950 dark:text-gray-50">Find me elsewhere</h2>
+      <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">
+        Follow along on the other places I post, share, and occasionally remember to update.
+      </p>
+      <div class="mt-4 grid gap-2">
+        {SOCIAL_LINKS.map((link) => (
+          <a
+            href={link.url}
+            target={link.url.startsWith("/") ? undefined : "_blank"}
+            rel={link.url.startsWith("/") ? undefined : "noopener noreferrer"}
+            class="flex items-center gap-3 rounded-xl border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 transition hover:border-teal-200 hover:bg-teal-50 hover:text-teal-700 dark:border-gray-800 dark:text-gray-300 dark:hover:border-teal-900/70 dark:hover:bg-teal-950/20 dark:hover:text-teal-300"
+          >
+            <span class="text-gray-500 dark:text-gray-400">{link.icon}</span>
+            <span>{link.name}</span>
+          </a>
+        ))}
       </div>
     </section>
   );
@@ -1314,6 +1338,7 @@ export function createPagesRoutes(db: Database): Hono {
                 followingCount={followingCount}
                 postCount={totalPosts}
               />
+              <SocialMediaFeedCard />
               <RecommendedSitesFeedCard />
             </aside>
             <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">
@@ -1413,6 +1438,7 @@ export function createPagesRoutes(db: Database): Hono {
               followingCount={followingCount}
               postCount={totalPosts}
             />
+            <SocialMediaFeedCard />
             <RecommendedSitesFeedCard />
           </aside>
           <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">
@@ -1507,18 +1533,6 @@ export function createPagesRoutes(db: Database): Hono {
 
   // About page
   pages.get("/about", (c) => {
-    const socialLinks = [
-      { name: "GitHub", url: "https://github.com/evcraddock", icon: <GitHubIcon /> },
-      {
-        name: "LinkedIn",
-        url: "https://www.linkedin.com/in/erik-craddock-42aa9815",
-        icon: <LinkedInIcon />,
-      },
-      { name: "Facebook", url: "https://www.facebook.com/evcraddock", icon: <FacebookIcon /> },
-      { name: "YouTube", url: "https://youtube.com/@ErikCraddock", icon: <YouTubeIcon /> },
-      { name: "RSS", url: "/feed.xml", icon: <RssIcon /> },
-    ];
-
     return c.html(
       <Layout title="About | Erik Craddock">
         {/* Hero-style header */}
@@ -1549,7 +1563,7 @@ export function createPagesRoutes(db: Database): Hono {
 
               {/* Social links */}
               <div class="flex justify-center md:justify-start gap-4">
-                {socialLinks.map((link) => (
+                {SOCIAL_LINKS.map((link) => (
                   <a
                     href={link.url}
                     target="_blank"

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -657,20 +657,18 @@ function FeedProfileCard({
 function SocialMediaFeedCard() {
   return (
     <section class="border-b border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900 lg:mt-4 lg:rounded-2xl lg:border">
-      <h2 class="text-lg font-bold text-gray-950 dark:text-gray-50">Find me elsewhere</h2>
-      <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">
-        Follow along on the other places I post, share, and occasionally remember to update.
-      </p>
-      <div class="mt-4 grid gap-2">
+      <h2 class="text-lg font-bold text-gray-950 dark:text-gray-50">Follow me</h2>
+      <div class="mt-4 grid grid-cols-5 gap-2">
         {SOCIAL_LINKS.map((link) => (
           <a
             href={link.url}
             target={link.url.startsWith("/") ? undefined : "_blank"}
             rel={link.url.startsWith("/") ? undefined : "noopener noreferrer"}
-            class="flex items-center gap-3 rounded-xl border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 transition hover:border-teal-200 hover:bg-teal-50 hover:text-teal-700 dark:border-gray-800 dark:text-gray-300 dark:hover:border-teal-900/70 dark:hover:bg-teal-950/20 dark:hover:text-teal-300"
+            aria-label={link.name}
+            title={link.name}
+            class="flex aspect-square items-center justify-center rounded-xl border border-gray-200 text-gray-600 transition hover:border-teal-200 hover:bg-teal-50 hover:text-teal-700 dark:border-gray-800 dark:text-gray-400 dark:hover:border-teal-900/70 dark:hover:bg-teal-950/20 dark:hover:text-teal-300"
           >
-            <span class="text-gray-500 dark:text-gray-400">{link.icon}</span>
-            <span>{link.name}</span>
+            {link.icon}
           </a>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add a feed sidebar card listing the same social links used on the About page
- place the social card above the Recommended Sites card
- share social link data between the home/about pages and the new feed card
- add route coverage for card contents and ordering

## Tests
- bun test src/routes/__tests__/pages.test.tsx
- npm run typecheck
- npm run lint
- pre-push full checks
- browser check for /feed

Task: task-06bb342c