### PR TITLE
feat: add people page

### DIFF
--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -136,7 +136,7 @@ testDb
   .insert(people)
   .values([
     { id: 1, name: "Test Author" },
-    { id: 2, name: "Alice" },
+    { id: 2, name: "Alice", url: "https://alice.example.com" },
     { id: 3, name: "Bob" },
     { id: 4, name: "Carol" },
   ])
@@ -364,8 +364,9 @@ describe("pages routes", () => {
 
       expect(html).toContain("Recommended Sites");
       expect(html).toContain('href="/sources"');
+      expect(html).toContain('href="/people"');
       expect(html).toContain("websites, publications, and");
-      expect(html).toContain("reading log and part blogroll");
+      expect(html).toContain("reading log and");
     });
 
     it("includes dark mode classes", async () => {
@@ -551,6 +552,75 @@ describe("pages routes", () => {
 
       expect(res.status).toBe(302);
       expect(res.headers.get("Location")).toBe("/feed");
+    });
+  });
+
+  describe("GET /people", () => {
+    it("returns 200 and displays people page", async () => {
+      const app = getApp();
+      const res = await app.request("/people");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("People");
+      expect(html).toContain("Search people");
+    });
+
+    it("lists people from database", async () => {
+      const app = getApp();
+      const res = await app.request("/people");
+      const html = await res.text();
+
+      expect(html).toContain("Test Author");
+      expect(html).toContain("Alice");
+      expect(html).toContain("https://alice.example.com");
+      expect(html).toContain("No website listed");
+    });
+
+    it("uses the sources page card grid pattern", async () => {
+      const app = getApp();
+      const res = await app.request("/people");
+      const html = await res.text();
+
+      expect(html).toContain("mx-auto max-w-6xl");
+      expect(html).toContain("grid gap-5 md:grid-cols-2 lg:grid-cols-3");
+      expect(html).toContain("rounded-2xl border border-gray-200 bg-white p-5 shadow-sm");
+    });
+
+    it("filters people by search query", async () => {
+      const app = getApp();
+      const res = await app.request("/people?q=Alice");
+      const html = await res.text();
+
+      expect(html).toContain("Alice");
+      expect(html).not.toContain("Test Author");
+      expect(html).toContain("matching “Alice”");
+    });
+
+    it("paginates people", async () => {
+      const manyPeopleDb = createTestDb();
+      for (let i = 1; i <= 25; i++) {
+        manyPeopleDb
+          .insert(people)
+          .values({
+            id: i,
+            name: `Person ${String(i).padStart(2, "0")}`,
+            url: `https://person-${i}.example.com`,
+          })
+          .run();
+      }
+      const app = createPagesRoutes(
+        manyPeopleDb as unknown as Parameters<typeof createPagesRoutes>[0]
+      );
+
+      const pageOne = await app.request("/people");
+      const pageOneHtml = await pageOne.text();
+      expect(pageOneHtml).toContain("Person 01");
+      expect(pageOneHtml).toContain("Person 12");
+      expect(pageOneHtml).not.toContain("Person 13");
+      expect(pageOneHtml).toContain("Page 1 of 3");
+      expect(pageOneHtml).toContain('href="/people?page=2"');
     });
   });
 

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -537,6 +537,15 @@ describe("pages routes", () => {
       expect(html).toContain("https://example.com/preview.jpg");
     });
 
+    it("links link post authors to person detail pages", async () => {
+      const app = getApp();
+      const res = await app.request("/feed");
+      const html = await res.text();
+
+      expect(html).toContain('href="/people/1"');
+      expect(html).toContain("Test Author");
+    });
+
     it("includes dark mode classes", async () => {
       const app = getApp();
       const res = await app.request("/feed");
@@ -596,6 +605,15 @@ describe("pages routes", () => {
       expect(html).toContain("Alice");
       expect(html).not.toContain("Test Author");
       expect(html).toContain("matching “Alice”");
+    });
+
+    it("links people cards to person detail pages", async () => {
+      const app = getApp();
+      const res = await app.request("/people");
+      const html = await res.text();
+
+      expect(html).toContain('href="/people/1"');
+      expect(html).toContain('href="/people/2"');
     });
 
     it("paginates people", async () => {
@@ -685,6 +703,7 @@ describe("pages routes", () => {
       const html = await res.text();
 
       expect(html).toContain("by Test Author");
+      expect(html).toContain('href="/people/1"');
     });
 
     it("formats two source authors naturally", async () => {
@@ -816,6 +835,65 @@ describe("pages routes", () => {
     });
   });
 
+  describe("GET /people/:id", () => {
+    it("returns 200 and displays the person detail page", async () => {
+      const app = getApp();
+      const res = await app.request("/people/1");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("Test Author");
+      expect(html).toContain("← People");
+    });
+
+    it("uses the source detail page layout style", async () => {
+      const app = getApp();
+      const res = await app.request("/people/1");
+      const html = await res.text();
+
+      expect(html).toContain("lg:grid-cols-[20rem_minmax(0,42rem)]");
+      expect(html).toContain("sm:rounded-2xl sm:border");
+      expect(html).not.toContain("Writer, coder, and musician");
+      expect(html).not.toContain("Followers");
+    });
+
+    it("lists sources authored by the selected person", async () => {
+      const app = getApp();
+      const res = await app.request("/people/1");
+      const html = await res.text();
+
+      expect(html).toContain("Sources");
+      expect(html).toContain('href="/sources/1"');
+      expect(html).toContain("Test Blog");
+    });
+
+    it("shows links from the selected person with full shared link content", async () => {
+      const app = getApp();
+      const res = await app.request("/people/1");
+      const html = await res.text();
+
+      expect(html).toContain("This is commentary on an external link.");
+      expect(html).toContain("Quoted shared link text.");
+      expect(html).toContain('href="https://example.com/article"');
+      expect(html).toContain("Example Article");
+      expect(html).toContain("by");
+      expect(html).toContain('href="/people/1"');
+      expect(html).toContain("Test Author");
+      expect(html).toContain("via");
+    });
+
+    it("returns 404 for missing people", async () => {
+      const app = getApp();
+      const res = await app.request("/people/999");
+
+      expect(res.status).toBe(404);
+
+      const html = await res.text();
+      expect(html).toContain("Person Not Found");
+    });
+  });
+
   describe("GET /sources/:id", () => {
     it("returns 200 and displays the source detail page", async () => {
       const app = getApp();
@@ -846,6 +924,7 @@ describe("pages routes", () => {
 
       expect(html).toContain("A test source preview description.");
       expect(html).toContain("by Test Author");
+      expect(html).toContain('href="/people/1"');
       expect(html).toContain('src="https://example.com/favicon.ico"');
     });
 
@@ -872,6 +951,7 @@ describe("pages routes", () => {
       expect(html).toContain("A rich preview description.");
       expect(html).toContain('src="https://example.com/preview.jpg"');
       expect(html).toContain("by Test Author");
+      expect(html).toContain('href="/people/1"');
       expect(html).toContain("via");
     });
 
@@ -1075,7 +1155,9 @@ describe("pages routes", () => {
       expect(html).toContain("via");
       expect(html).toContain('href="/sources/1"');
       expect(html).toContain("Test Blog");
-      expect(html).toContain("by Test Author");
+      expect(html).toContain("by");
+      expect(html).toContain('href="/people/1"');
+      expect(html).toContain("Test Author");
     });
 
     it("backfills OG preview metadata for older link posts during page render", async () => {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -43,6 +43,7 @@ type PostWithSource = Post & { source?: Source | null; author?: Person | null };
 /** Max length for showing full note content inline */
 const NOTE_INLINE_MAX_LENGTH = 280;
 const SOURCES_PER_PAGE = 12;
+const PEOPLE_PER_PAGE = 12;
 const ACTOR_HANDLE = "@erik@erikcraddock.me";
 const ACTOR_URI = new URL("/users/erik", baseUrl).toString();
 const WEBFINGER_SUBSCRIBE_REL = "http://ostatus.org/schema/1.0/subscribe";
@@ -130,6 +131,49 @@ function formatAuthorByline(authors: SourceAuthor[]): string | null {
   }
 
   return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+}
+
+function PersonCard({ person }: { person: Person }) {
+  const hostname = getLinkPreviewSiteLabel(person.url, null) ?? person.url;
+  const initial = person.name.charAt(0).toUpperCase();
+
+  return (
+    <article class="flex h-full flex-col rounded-2xl border border-gray-200 bg-white p-5 shadow-sm transition-colors hover:border-teal-200 hover:bg-teal-50/40 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-teal-900/60 dark:hover:bg-teal-950/20">
+      <div class="flex items-start gap-4">
+        <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-teal-100 text-lg font-bold text-teal-700 dark:bg-teal-900/40 dark:text-teal-300">
+          {initial}
+        </div>
+        <div class="min-w-0 flex-1">
+          {person.url ? (
+            <a
+              href={person.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="line-clamp-2 font-semibold text-gray-950 hover:text-teal-600 dark:text-gray-50 dark:hover:text-teal-400"
+            >
+              {person.name}
+            </a>
+          ) : (
+            <h2 class="line-clamp-2 font-semibold text-gray-950 dark:text-gray-50">
+              {person.name}
+            </h2>
+          )}
+          {person.url ? (
+            <a
+              href={person.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="mt-1 block truncate text-sm text-gray-500 hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400"
+            >
+              {hostname}
+            </a>
+          ) : (
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">No website listed</p>
+          )}
+        </div>
+      </div>
+    </article>
+  );
 }
 
 function SourceCard({
@@ -611,6 +655,17 @@ function sourceMatchesSearch(source: SourceWithAuthors, query: string): boolean 
 
 function sourcesUrl(page: number, query: string): string {
   return buildPaginationUrl("/sources", page, { q: query || undefined });
+}
+
+function personMatchesSearch(person: Person, query: string): boolean {
+  const normalizedQuery = query.toLowerCase();
+  const searchableText = [person.name, person.url].filter(Boolean).join(" ").toLowerCase();
+
+  return searchableText.includes(normalizedQuery);
+}
+
+function peopleUrl(page: number, query: string): string {
+  return buildPaginationUrl("/people", page, { q: query || undefined });
 }
 
 function FeedActorAvatar({ className = "" }: { className?: string }) {
@@ -1627,9 +1682,11 @@ export function createPagesRoutes(db: Database): Hono {
           <h2>Recommended Sites</h2>
           <p>
             The <a href="/sources">recommended sites</a> page collects websites, publications, and
-            personal blogs that I have found interesting enough to share links from. It is part
-            reading log and part blogroll: a way to browse the sources behind the links I post and
-            discover the people and sites that keep showing up here.
+            personal blogs that I have found interesting enough to share links from. The{" "}
+            <a href="/people">people page</a> collects reusable public attribution identities for
+            authors and creators who show up in those links. Together they form a reading log and
+            blogroll: a way to browse the sources behind the links I post and discover the people
+            and sites that keep showing up here.
           </p>
 
           <h2>Get in Touch</h2>
@@ -1638,6 +1695,150 @@ export function createPagesRoutes(db: Database): Hono {
             <code>@erik@erikcraddock.me</code> in a post. You can also find me on the social
             platforms linked above.
           </p>
+        </div>
+      </Layout>
+    );
+  });
+
+  // People page
+  pages.get("/people", (c) => {
+    const pageParam = c.req.query("page");
+    const page = pageParam ? parseInt(pageParam, 10) : 1;
+    const searchQuery = (c.req.query("q") ?? "").trim();
+
+    if (isNaN(page) || page < 1) {
+      return c.redirect(peopleUrl(1, searchQuery));
+    }
+
+    const allPeople = db.select().from(people).orderBy(asc(people.name)).all();
+    const filteredPeople = searchQuery
+      ? allPeople.filter((person) => personMatchesSearch(person, searchQuery))
+      : allPeople;
+    const totalPages = Math.max(1, Math.ceil(filteredPeople.length / PEOPLE_PER_PAGE));
+
+    if (page > totalPages) {
+      return c.redirect(peopleUrl(totalPages, searchQuery));
+    }
+
+    const offset = (page - 1) * PEOPLE_PER_PAGE;
+    const pagePeople = filteredPeople.slice(offset, offset + PEOPLE_PER_PAGE);
+
+    return c.html(
+      <Layout title="People | erikcraddock.me">
+        <div class="mx-auto max-w-6xl">
+          <div class="mb-8">
+            <h1 class="text-3xl font-bold text-gray-950 dark:text-gray-50">People</h1>
+          </div>
+
+          <form
+            action="/people"
+            method="get"
+            data-autosubmit-people-search="true"
+            class="mb-6 flex flex-col gap-3 sm:flex-row"
+          >
+            <label class="sr-only" for="people-search">
+              Search people
+            </label>
+            <input
+              id="people-search"
+              type="search"
+              name="q"
+              value={searchQuery}
+              placeholder="Search people"
+              autocomplete="off"
+              autofocus
+              class="min-w-0 flex-1 rounded-xl border border-gray-300 bg-white px-4 py-3 text-gray-950 shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/20 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-50"
+            />
+            <button
+              type="submit"
+              class="rounded-xl bg-teal-600 px-5 py-3 font-semibold text-white transition hover:bg-teal-700 sm:sr-only"
+            >
+              Search
+            </button>
+          </form>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+                (() => {
+                  const form = document.querySelector('[data-autosubmit-people-search="true"]');
+                  const input = form?.querySelector('input[name="q"]');
+                  if (!form || !input) return;
+
+                  input.focus();
+                  const valueLength = input.value.length;
+                  input.setSelectionRange(valueLength, valueLength);
+
+                  let timeout;
+                  let controller;
+
+                  const updateResults = async () => {
+                    const query = input.value.trim();
+                    const url = query ? '/people?q=' + encodeURIComponent(query) : '/people';
+                    controller?.abort();
+                    controller = new AbortController();
+
+                    try {
+                      const response = await fetch(url, { signal: controller.signal });
+                      if (!response.ok) return;
+                      const html = await response.text();
+                      const doc = new DOMParser().parseFromString(html, 'text/html');
+                      const results = document.querySelector('[data-people-results="true"]');
+                      const nextResults = doc.querySelector('[data-people-results="true"]');
+                      if (!results || !nextResults) return;
+                      results.innerHTML = nextResults.innerHTML;
+                      history.replaceState(null, '', url);
+                    } catch (error) {
+                      if (error.name !== 'AbortError') console.error(error);
+                    }
+                  };
+
+                  form.addEventListener('submit', (event) => {
+                    event.preventDefault();
+                    clearTimeout(timeout);
+                    updateResults();
+                  });
+
+                  input.addEventListener('input', () => {
+                    clearTimeout(timeout);
+                    timeout = setTimeout(updateResults, 300);
+                  });
+                })();
+              `,
+            }}
+          />
+
+          <div data-people-results="true">
+            {allPeople.length === 0 ? (
+              <div class="rounded-2xl border border-gray-200 bg-white px-4 py-10 text-center text-gray-600 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400 sm:px-6">
+                No people yet.
+              </div>
+            ) : filteredPeople.length === 0 ? (
+              <div class="rounded-2xl border border-gray-200 bg-white px-4 py-10 text-center text-gray-600 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400 sm:px-6">
+                No people found for “{searchQuery}”.
+              </div>
+            ) : (
+              <>
+                <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+                  Showing {offset + 1}–{Math.min(offset + PEOPLE_PER_PAGE, filteredPeople.length)}{" "}
+                  of {filteredPeople.length} people
+                  {searchQuery ? ` matching “${searchQuery}”` : ""}.
+                </div>
+                <div class="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+                  {pagePeople.map((person) => (
+                    <PersonCard key={person.id} person={person} />
+                  ))}
+                </div>
+                {totalPages > 1 ? (
+                  <Pagination
+                    currentPage={page}
+                    totalPages={totalPages}
+                    baseUrl="/people"
+                    queryParams={{ q: searchQuery || undefined }}
+                  />
+                ) : null}
+              </>
+            )}
+          </div>
         </div>
       </Layout>
     );

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -133,9 +133,46 @@ function formatAuthorByline(authors: SourceAuthor[]): string | null {
   return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
 }
 
-function PersonCard({ person }: { person: Person }) {
+function LinkedSourceAuthorByline({ authors }: { authors: SourceAuthor[] }) {
+  return (
+    <>
+      {authors.map((author, index) => {
+        const separator =
+          index === 0
+            ? ""
+            : authors.length === 2
+              ? " and "
+              : index === authors.length - 1
+                ? ", and "
+                : ", ";
+
+        return (
+          <>
+            {separator}
+            <a href={`/people/${author.id}`} class="hover:text-teal-600 dark:hover:text-teal-400">
+              {author.name}
+            </a>
+          </>
+        );
+      })}
+    </>
+  );
+}
+
+function PersonCard({
+  person,
+  titleLink = "detail",
+  authoredSources = [],
+}: {
+  person: Person;
+  titleLink?: "detail" | "website";
+  authoredSources?: Source[];
+}) {
   const hostname = getLinkPreviewSiteLabel(person.url, null) ?? person.url;
   const initial = person.name.charAt(0).toUpperCase();
+  const titleHref = titleLink === "website" && person.url ? person.url : `/people/${person.id}`;
+  const titleExternalAttrs =
+    titleLink === "website" && person.url ? { target: "_blank", rel: "noopener noreferrer" } : {};
 
   return (
     <article class="flex h-full flex-col rounded-2xl border border-gray-200 bg-white p-5 shadow-sm transition-colors hover:border-teal-200 hover:bg-teal-50/40 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-teal-900/60 dark:hover:bg-teal-950/20">
@@ -144,20 +181,13 @@ function PersonCard({ person }: { person: Person }) {
           {initial}
         </div>
         <div class="min-w-0 flex-1">
-          {person.url ? (
-            <a
-              href={person.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="line-clamp-2 font-semibold text-gray-950 hover:text-teal-600 dark:text-gray-50 dark:hover:text-teal-400"
-            >
-              {person.name}
-            </a>
-          ) : (
-            <h2 class="line-clamp-2 font-semibold text-gray-950 dark:text-gray-50">
-              {person.name}
-            </h2>
-          )}
+          <a
+            href={titleHref}
+            {...titleExternalAttrs}
+            class="line-clamp-2 font-semibold text-gray-950 hover:text-teal-600 dark:text-gray-50 dark:hover:text-teal-400"
+          >
+            {person.name}
+          </a>
           {person.url ? (
             <a
               href={person.url}
@@ -172,6 +202,24 @@ function PersonCard({ person }: { person: Person }) {
           )}
         </div>
       </div>
+
+      {authoredSources.length > 0 ? (
+        <div class="mt-4 border-t border-gray-200 pt-4 dark:border-gray-800">
+          <h3 class="text-sm font-semibold text-gray-950 dark:text-gray-50">Sources</h3>
+          <ul class="mt-2 space-y-1 text-sm text-gray-600 dark:text-gray-300">
+            {authoredSources.map((source) => (
+              <li key={source.id}>
+                <a
+                  href={`/sources/${source.id}`}
+                  class="hover:text-teal-600 dark:hover:text-teal-400"
+                >
+                  {source.name}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
     </article>
   );
 }
@@ -235,8 +283,11 @@ function SourceCard({
       ) : null}
 
       {source.authors.length > 0 ? (
-        <p class="mt-4 text-sm text-gray-600 dark:text-gray-300">
-          by {formatAuthorByline(source.authors)}
+        <p
+          class="mt-4 text-sm text-gray-600 dark:text-gray-300"
+          aria-label={`by ${formatAuthorByline(source.authors)}`}
+        >
+          by <LinkedSourceAuthorByline authors={source.authors} />
         </p>
       ) : null}
 
@@ -864,7 +915,15 @@ function FeedPostMeta({ post, tags: postTags }: { post: PostWithSource; tags: Ta
       {post.author && (
         <>
           <span aria-hidden="true">·</span>
-          <span>by {post.author.name}</span>
+          <span>
+            by{" "}
+            <a
+              href={`/people/${post.author.id}`}
+              class="hover:text-gray-700 dark:hover:text-gray-300"
+            >
+              {post.author.name}
+            </a>
+          </span>
         </>
       )}
       {post.source && (
@@ -1066,7 +1125,18 @@ function PostCard({ post, tags: postTags = [] }: { post: PostWithSource; tags?: 
           </time>
 
           {/* Author attribution for link posts */}
-          {isLink && post.author && <span class="ml-2">• by {post.author.name}</span>}
+          {isLink && post.author && (
+            <span class="ml-2">
+              • by{" "}
+              <a
+                href={`/people/${post.author.id}`}
+                class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {post.author.name}
+              </a>
+            </span>
+          )}
 
           {/* Source attribution for link posts */}
           {isLink && post.source && (
@@ -1146,6 +1216,21 @@ function getSourceWithAuthors(db: Database, sourceId: number): SourceWithAuthors
     ...source,
     authors: getSourceAuthors(db, source.id),
   };
+}
+
+function getPerson(db: Database, personId: number): Person | null {
+  return db.select().from(people).where(eq(people.id, personId)).get() ?? null;
+}
+
+function getSourcesAuthoredByPerson(db: Database, personId: number): Source[] {
+  return db
+    .select({ source: sources })
+    .from(sourceAuthors)
+    .innerJoin(sources, eq(sourceAuthors.source_id, sources.id))
+    .where(eq(sourceAuthors.person_id, personId))
+    .orderBy(asc(sources.name))
+    .all()
+    .map((row) => row.source);
 }
 
 /**
@@ -2010,6 +2095,75 @@ export function createPagesRoutes(db: Database): Hono {
                   />
                 ) : null}
               </>
+            )}
+          </div>
+        </div>
+      </Layout>
+    );
+  });
+
+  // Person detail page
+  pages.get("/people/:id", (c) => {
+    const id = parseInt(c.req.param("id") ?? "", 10);
+
+    if (isNaN(id)) {
+      return c.html(
+        <NotFound
+          title="Person Not Found"
+          message="The person you're looking for doesn't exist."
+        />,
+        404
+      );
+    }
+
+    const person = getPerson(db, id);
+
+    if (!person) {
+      return c.html(
+        <NotFound
+          title="Person Not Found"
+          message="The person you're looking for doesn't exist."
+        />,
+        404
+      );
+    }
+
+    const authoredSources = getSourcesAuthoredByPerson(db, person.id);
+    const personLinks: PostWithSource[] = db
+      .select({
+        post: posts,
+        source: sources,
+      })
+      .from(posts)
+      .leftJoin(sources, eq(posts.source_id, sources.id))
+      .where(
+        and(eq(posts.author_id, person.id), eq(posts.type, "link"), isNotNull(posts.published_at))
+      )
+      .orderBy(desc(posts.published_at))
+      .all()
+      .map((row) => ({ ...row.post, source: row.source, author: person }));
+
+    return c.html(
+      <Layout title={`${person.name} | erikcraddock.me`} description={person.url ?? undefined}>
+        <div class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,42rem)] lg:items-start lg:justify-center">
+          <aside class="lg:sticky lg:top-24">
+            <PersonCard person={person} titleLink="website" authoredSources={authoredSources} />
+          </aside>
+          <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">
+            <header class="border-b border-gray-200 bg-white/90 px-4 py-4 backdrop-blur dark:border-gray-800 dark:bg-gray-900/90 sm:px-6">
+              <a
+                href="/people"
+                class="text-xl font-bold text-gray-950 hover:text-teal-600 dark:text-gray-50 dark:hover:text-teal-400"
+              >
+                ← People
+              </a>
+            </header>
+            {personLinks.length === 0 ? (
+              <div class="px-4 py-5 dark:bg-gray-900 sm:px-6">
+                <p class="text-gray-600 dark:text-gray-400">No links from this person yet.</p>
+              </div>
+            ) : (
+              personLinks.map((post) => <FeedPost key={post.id} post={post} />)
             )}
           </div>
         </div>

--- a/src/services/__tests__/link-preview.test.ts
+++ b/src/services/__tests__/link-preview.test.ts
@@ -42,6 +42,35 @@ describe("fetchLinkPreview", () => {
     });
   });
 
+  it("decodes named and numeric HTML entities in preview text", async () => {
+    global.fetch = mock(
+      async () =>
+        new Response(
+          `
+          <html>
+            <head>
+              <meta property="og:title" content="Seth&#039;s Blog" />
+              <meta property="og:description" content="Bad money&#8230; Gresham&#x2019;s Law &amp; incentives" />
+              <meta property="og:site_name" content="Seth&apos;s Blog" />
+            </head>
+          </html>
+        `,
+          {
+            status: 200,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+            },
+          }
+        )
+    ) as unknown as typeof fetch;
+
+    const preview = await fetchLinkPreview("https://seths.blog/2026/04/bad-money/");
+
+    expect(preview?.title).toBe("Seth's Blog");
+    expect(preview?.description).toBe("Bad money… Gresham’s Law & incentives");
+    expect(preview?.siteName).toBe("Seth's Blog");
+  });
+
   it("falls back to title tag and hostname when og tags are missing", async () => {
     global.fetch = mock(
       async () =>

--- a/src/services/link-preview.ts
+++ b/src/services/link-preview.ts
@@ -56,8 +56,24 @@ function extractLinkHref(html: string, rel: string): string | null {
 
 function decodeHtmlEntities(value: string): string {
   return value
+    .replace(/&#(x[0-9a-f]+|\d+);/gi, (_entity, code: string) => {
+      const codePoint = code.toLowerCase().startsWith("x")
+        ? parseInt(code.slice(1), 16)
+        : parseInt(code, 10);
+
+      if (!Number.isFinite(codePoint)) {
+        return _entity;
+      }
+
+      try {
+        return String.fromCodePoint(codePoint);
+      } catch {
+        return _entity;
+      }
+    })
     .replace(/&amp;/g, "&")
     .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
     .replace(/&#39;/g, "'")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")


### PR DESCRIPTION
## Summary
- add a new `/people` page modeled after the Recommended Sites page
- include people cards, search, pagination, empty states, and source-like grid styling
- link the About page Recommended Sites section to `/people` for discovery
- add route coverage for rendering, listing, styling, search, and pagination

## Tests
- bun test src/routes/__tests__/pages.test.tsx
- npm run typecheck
- npm run lint
- pre-push full checks
- browser checks for /people and /about

Task: task-f36121fc
