### PR TITLE
Add social accounts to people profiles

### DIFF
--- a/cli/src/commands/person/create.ts
+++ b/cli/src/commands/person/create.ts
@@ -2,13 +2,20 @@ import type { GlobalOptions } from "../../types";
 import { ApiClient } from "../../lib/api";
 import { loadConfig } from "../../lib/config";
 
+interface SocialAccountOption {
+  label: string;
+  url: string;
+  is_activitypub?: boolean;
+}
+
 interface CreateOptions {
   name?: string;
   url?: string | null;
+  socialAccounts: SocialAccountOption[];
 }
 
 function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolean } {
-  const options: CreateOptions = {};
+  const options: CreateOptions = { socialAccounts: [] };
   let help = false;
 
   let i = 0;
@@ -25,12 +32,31 @@ function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolea
       options.url = args[++i];
     } else if (arg.startsWith("--url=")) {
       options.url = arg.split("=").slice(1).join("=");
+    } else if (arg === "--social" && args[i + 1]) {
+      const parsed = parseSocialAccount(args[++i]);
+      if (parsed) options.socialAccounts.push(parsed);
+    } else if (arg.startsWith("--social=")) {
+      const parsed = parseSocialAccount(arg.split("=").slice(1).join("="));
+      if (parsed) options.socialAccounts.push(parsed);
     }
 
     i++;
   }
 
   return { options, help };
+}
+
+function parseSocialAccount(input: string): SocialAccountOption | null {
+  const [label, url, flag] = input.split("|").map((part) => part.trim());
+  if (!label || !url) {
+    return null;
+  }
+
+  return {
+    label,
+    url,
+    is_activitypub: flag === "activitypub" || flag === "ap" || flag === "true",
+  };
 }
 
 function showCreateHelp(): void {
@@ -43,12 +69,14 @@ Required:
 
 Options:
   --url <url>         Person URL (optional)
+  --social <account>  Social account as "label|url|activitypub" (can be repeated)
   --json              Output as JSON
   --help, -h          Show this help message
 
 Examples:
   ec person create --name "Ethan Mollick"
   ec person create --name "Simon Willison" --url "https://simonwillison.net/"
+  ec person create --name "Example" --social "Mastodon|https://example.social/@person|activitypub"
 `);
 }
 
@@ -79,6 +107,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
   const result = await client.createPerson({
     name: options.name.trim(),
     url: options.url?.trim() || null,
+    social_accounts: options.socialAccounts,
   });
 
   if (result.error) {

--- a/cli/src/commands/person/edit.ts
+++ b/cli/src/commands/person/edit.ts
@@ -2,9 +2,16 @@ import type { GlobalOptions } from "../../types";
 import { ApiClient } from "../../lib/api";
 import { loadConfig } from "../../lib/config";
 
+interface SocialAccountOption {
+  label: string;
+  url: string;
+  is_activitypub?: boolean;
+}
+
 interface EditOptions {
   name?: string;
   url?: string | null;
+  socialAccounts?: SocialAccountOption[];
 }
 
 function parseEditArgs(args: string[]): { id: number | null; options: EditOptions; help: boolean } {
@@ -28,6 +35,14 @@ function parseEditArgs(args: string[]): { id: number | null; options: EditOption
       options.url = arg.split("=").slice(1).join("=");
     } else if (arg === "--no-url") {
       options.url = null;
+    } else if (arg === "--social" && args[i + 1]) {
+      const parsed = parseSocialAccount(args[++i]);
+      if (parsed) options.socialAccounts = [...(options.socialAccounts ?? []), parsed];
+    } else if (arg.startsWith("--social=")) {
+      const parsed = parseSocialAccount(arg.split("=").slice(1).join("="));
+      if (parsed) options.socialAccounts = [...(options.socialAccounts ?? []), parsed];
+    } else if (arg === "--no-socials") {
+      options.socialAccounts = [];
     } else if (!arg.startsWith("-") && id === null) {
       const parsed = parseInt(arg, 10);
       if (!isNaN(parsed)) {
@@ -39,6 +54,19 @@ function parseEditArgs(args: string[]): { id: number | null; options: EditOption
   }
 
   return { id, options, help };
+}
+
+function parseSocialAccount(input: string): SocialAccountOption | null {
+  const [label, url, flag] = input.split("|").map((part) => part.trim());
+  if (!label || !url) {
+    return null;
+  }
+
+  return {
+    label,
+    url,
+    is_activitypub: flag === "activitypub" || flag === "ap" || flag === "true",
+  };
 }
 
 function showEditHelp(): void {
@@ -53,12 +81,16 @@ Options:
   --name <name>       Update person name
   --url <url>         Update person URL
   --no-url            Clear person URL
+  --social <account>  Replace social accounts with "label|url|activitypub" entries
+  --no-socials        Remove all social accounts
   --json              Output as JSON
   --help, -h          Show this help message
 
 Examples:
   ec person edit 1 --name "Ethan Mollick"
   ec person edit 1 --url "https://example.com"
+  ec person edit 1 --social "Mastodon|https://example.social/@person|activitypub"
+  ec person edit 1 --no-socials
   ec person edit 1 --no-url
 `);
 }
@@ -77,10 +109,11 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     process.exit(1);
   }
 
-  const hasUpdates = options.name !== undefined || options.url !== undefined;
+  const hasUpdates =
+    options.name !== undefined || options.url !== undefined || options.socialAccounts !== undefined;
   if (!hasUpdates) {
     console.error("❌ No update options provided.");
-    console.error("Specify at least one of: --name, --url, --no-url");
+    console.error("Specify at least one of: --name, --url, --no-url, --social, --no-socials");
     process.exit(1);
   }
 
@@ -102,6 +135,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
   const result = await client.updatePerson(id, {
     name: options.name?.trim(),
     url: options.url === undefined ? undefined : options.url?.trim() || null,
+    social_accounts: options.socialAccounts,
   });
 
   if (result.error) {

--- a/cli/src/commands/person/show.ts
+++ b/cli/src/commands/person/show.ts
@@ -42,6 +42,14 @@ function formatPerson(person: Person): void {
   console.log(`ID:   ${person.id}`);
   console.log(`Name: ${person.name}`);
   console.log(`URL:  ${person.url || "-"}`);
+
+  if (person.social_accounts.length > 0) {
+    console.log("Social accounts:");
+    for (const account of person.social_accounts) {
+      const activityPub = account.is_activitypub ? " (ActivityPub)" : "";
+      console.log(`  - ${account.label}: ${account.url}${activityPub}`);
+    }
+  }
 }
 
 export async function show(args: string[], globalOptions: GlobalOptions): Promise<void> {

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -182,13 +182,21 @@ export class ApiClient {
     return this.request<Person>("GET", `/people/${id}`);
   }
 
-  async createPerson(data: { name: string; url?: string | null }): Promise<ApiResponse<Person>> {
+  async createPerson(data: {
+    name: string;
+    url?: string | null;
+    social_accounts?: Array<{ label: string; url: string; is_activitypub?: boolean }>;
+  }): Promise<ApiResponse<Person>> {
     return this.request<Person>("POST", "/people", data);
   }
 
   async updatePerson(
     id: number,
-    data: { name?: string; url?: string | null }
+    data: {
+      name?: string;
+      url?: string | null;
+      social_accounts?: Array<{ label: string; url: string; is_activitypub?: boolean }>;
+    }
   ): Promise<ApiResponse<Person>> {
     return this.request<Person>("PUT", `/people/${id}`, data);
   }

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -36,10 +36,20 @@ export interface PostListItem {
   tags: string[];
 }
 
+export interface PersonSocialAccount {
+  id: number;
+  person_id: number;
+  label: string;
+  url: string;
+  is_activitypub: boolean;
+  sort_order: number;
+}
+
 export interface Person {
   id: number;
   name: string;
   url: string | null;
+  social_accounts: PersonSocialAccount[];
 }
 
 export interface Post {

--- a/drizzle/0010_narrow_mephistopheles.sql
+++ b/drizzle/0010_narrow_mephistopheles.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `person_social_accounts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`person_id` integer NOT NULL,
+	`label` text NOT NULL,
+	`url` text NOT NULL,
+	`is_activitypub` integer DEFAULT false NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`person_id`) REFERENCES `people`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,930 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e2bc0b5b-d164-44eb-96d3-f71afb864470",
+  "prevId": "74fe4594-6877-4dae-9a97-d04d3a120b6e",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "person_social_accounts": {
+      "name": "person_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_social_accounts_person_id_people_id_fk": {
+          "name": "person_social_accounts_person_id_people_id_fk",
+          "tableFrom": "person_social_accounts",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777163674440,
       "tag": "0009_known_absorbing_man",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1777225658548,
+      "tag": "0010_narrow_mephistopheles",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -61,6 +61,17 @@ export const people = sqliteTable("people", {
   url: text("url"),
 });
 
+export const personSocialAccounts = sqliteTable("person_social_accounts", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  person_id: integer("person_id")
+    .notNull()
+    .references(() => people.id, { onDelete: "cascade" }),
+  label: text("label").notNull(),
+  url: text("url").notNull(),
+  is_activitypub: integer("is_activitypub", { mode: "boolean" }).notNull().default(false),
+  sort_order: integer("sort_order").notNull().default(0),
+});
+
 export const sourceAuthors = sqliteTable("source_authors", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   source_id: integer("source_id")

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -2,7 +2,15 @@
 import { describe, it, expect, beforeAll, beforeEach } from "bun:test";
 import { mock } from "bun:test";
 import { createTestDb } from "../../db/test-utils";
-import { posts, sources, sourceAuthors, people, tags, postTags } from "../../db/schema";
+import {
+  posts,
+  sources,
+  sourceAuthors,
+  people,
+  personSocialAccounts,
+  tags,
+  postTags,
+} from "../../db/schema";
 import { eq } from "drizzle-orm";
 
 // Create test db immediately
@@ -66,6 +74,7 @@ beforeEach(() => {
   testDb.delete(tags).run();
   testDb.delete(posts).run();
   testDb.delete(sourceAuthors).run();
+  testDb.delete(personSocialAccounts).run();
   testDb.delete(people).run();
   testDb.delete(sources).run();
   global.fetch = originalFetch;
@@ -1285,6 +1294,7 @@ describe("/api/people", () => {
     const json = await res.json();
     expect(json.data).toHaveLength(2);
     expect(json.data[0]).toMatchObject({ name: "Ethan Mollick", url: null });
+    expect(json.data[0].social_accounts).toEqual([]);
     expect(json.data[1]).toMatchObject({
       name: "Simon Willison",
       url: "https://simonwillison.net/",
@@ -1303,6 +1313,7 @@ describe("/api/people", () => {
     expect(created.data).toMatchObject({
       name: "Ethan Mollick",
       url: "https://www.oneusefulthing.org/",
+      social_accounts: [],
     });
 
     const showRes = await api.request(`/people/${created.data.id}`, { headers: authHeader });
@@ -1310,6 +1321,77 @@ describe("/api/people", () => {
     expect(showRes.status).toBe(200);
     const shown = await showRes.json();
     expect(shown.data).toEqual(created.data);
+  });
+
+  it("creates a person with multiple social accounts", async () => {
+    const createRes = await api.request("/people", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Seth Godin",
+        social_accounts: [
+          {
+            label: "Mastodon",
+            url: "https://mastodon.social/@seth",
+            is_activitypub: true,
+          },
+          { label: "Website", url: "https://seths.blog/" },
+        ],
+      }),
+    });
+
+    expect(createRes.status).toBe(201);
+    const created = await createRes.json();
+    expect(created.data.social_accounts).toMatchObject([
+      { label: "Mastodon", url: "https://mastodon.social/@seth", is_activitypub: true },
+      { label: "Website", url: "https://seths.blog/", is_activitypub: false },
+    ]);
+    expect(created.data.social_accounts[0].sort_order).toBe(0);
+    expect(created.data.social_accounts[1].sort_order).toBe(1);
+  });
+
+  it("replaces person social accounts when editing", async () => {
+    const person = testDb.insert(people).values({ name: "Old Name" }).returning().get();
+    testDb
+      .insert(personSocialAccounts)
+      .values({
+        person_id: person.id,
+        label: "Old Account",
+        url: "https://old.example.com",
+        is_activitypub: false,
+        sort_order: 0,
+      })
+      .run();
+
+    const res = await api.request(`/people/${person.id}`, {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        social_accounts: [
+          { label: "Bluesky", url: "https://bsky.app/profile/example.com" },
+          { label: "Mastodon", url: "https://example.social/@person", is_activitypub: true },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.social_accounts).toMatchObject([
+      { label: "Bluesky", is_activitypub: false },
+      { label: "Mastodon", is_activitypub: true },
+    ]);
+  });
+
+  it("rejects malformed social accounts", async () => {
+    const res = await api.request("/people", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Bad Social", social_accounts: [{ label: "Mastodon" }] }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(JSON.stringify(json.error)).toContain("social_accounts");
   });
 
   it("rejects blank person names", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -10,7 +10,16 @@ afterEach(() => {
   global.fetch = originalFetch;
 });
 import { createTestDb } from "../../db/test-utils";
-import { posts, tags, postTags, sources, sourceAuthors, people, media } from "../../db/schema";
+import {
+  posts,
+  tags,
+  postTags,
+  sources,
+  sourceAuthors,
+  people,
+  personSocialAccounts,
+  media,
+} from "../../db/schema";
 
 // Create test db immediately
 const testDb = createTestDb();
@@ -143,6 +152,26 @@ testDb
   .run();
 
 testDb.update(posts).set({ author_id: 1 }).where(eq(posts.id, 6)).run();
+
+testDb
+  .insert(personSocialAccounts)
+  .values([
+    {
+      person_id: 1,
+      label: "Mastodon",
+      url: "https://mastodon.social/@testauthor",
+      is_activitypub: true,
+      sort_order: 0,
+    },
+    {
+      person_id: 1,
+      label: "GitHub",
+      url: "https://github.com/testauthor",
+      is_activitypub: false,
+      sort_order: 1,
+    },
+  ])
+  .run();
 
 testDb
   .insert(sourceAuthors)
@@ -866,6 +895,19 @@ describe("pages routes", () => {
       expect(html).toContain("Sources");
       expect(html).toContain('href="/sources/1"');
       expect(html).toContain("Test Blog");
+    });
+
+    it("renders the selected person's social media accounts", async () => {
+      const app = getApp();
+      const res = await app.request("/people/1");
+      const html = await res.text();
+
+      expect(html).toContain("Social Media");
+      expect(html).toContain('href="https://mastodon.social/@testauthor"');
+      expect(html).toContain("Mastodon");
+      expect(html).toContain("ActivityPub");
+      expect(html).toContain('href="https://github.com/testauthor"');
+      expect(html).toContain("GitHub");
     });
 
     it("shows links from the selected person with full shared link content", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -902,7 +902,7 @@ describe("pages routes", () => {
       const res = await app.request("/people/1");
       const html = await res.text();
 
-      expect(html).toContain("Social Media");
+      expect(html).toContain("Follow Test Author");
       expect(html).toContain('href="https://mastodon.social/@testauthor"');
       expect(html).toContain("Mastodon");
       expect(html).toContain("ActivityPub");

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -33,6 +33,7 @@ import {
   getPerson,
   listPeople,
   updatePerson,
+  type PersonSocialAccountInput,
 } from "@/services/people";
 import { fetchLinkPreview } from "@/services/link-preview";
 import { logger } from "@/utils/logger";
@@ -103,17 +104,37 @@ const ApiPingSchema = z
   })
   .openapi("ApiPing");
 
-const PersonSchema = z
+const PersonSummarySchema = z
   .object({
     id: z.number().int().openapi({ example: 1 }),
     name: z.string().openapi({ example: "Paul Graham" }),
     url: NullableStringSchema.openapi({ example: "https://paulgraham.com" }),
   })
-  .openapi("Person");
+  .openapi("PersonSummary");
 
-const SourceAuthorSchema = PersonSchema.extend({
-  sort_order: z.number().int().openapi({ example: 0 }),
-}).openapi("SourceAuthor");
+const PersonSocialAccountSchema = z
+  .object({
+    id: z.number().int().openapi({ example: 1 }),
+    person_id: z.number().int().openapi({ example: 1 }),
+    label: z.string().openapi({ example: "Mastodon" }),
+    url: z.string().url().openapi({ example: "https://mastodon.social/@example" }),
+    is_activitypub: z.boolean().openapi({ example: true }),
+    sort_order: z.number().int().openapi({ example: 0 }),
+  })
+  .openapi("PersonSocialAccount");
+
+const PersonSchema = PersonSummarySchema.extend({
+  social_accounts: z.array(PersonSocialAccountSchema),
+}).openapi("Person");
+
+const SourceAuthorSchema = z
+  .object({
+    id: z.number().int().openapi({ example: 1 }),
+    name: z.string().openapi({ example: "Paul Graham" }),
+    url: NullableStringSchema.openapi({ example: "https://paulgraham.com" }),
+    sort_order: z.number().int().openapi({ example: 0 }),
+  })
+  .openapi("SourceAuthor");
 
 const SourceSummarySchema = z
   .object({
@@ -165,7 +186,7 @@ const PostListItemSchema = z
     source_id: z.number().int().nullable(),
     author_id: z.number().int().nullable(),
     source: SourceSummarySchema.nullable(),
-    author: PersonSchema.nullable(),
+    author: PersonSummarySchema.nullable(),
     tags: z.array(z.string()).openapi({ example: ["Tech", "Writing"] }),
   })
   .openapi("PostListItem");
@@ -188,7 +209,7 @@ const PostSchema = z
     banner_image_id: z.number().int().nullable(),
     banner_url: NullableStringSchema,
     source: SourceSummarySchema.nullable(),
-    author: PersonSchema.nullable(),
+    author: PersonSummarySchema.nullable(),
     published_at: IsoDateTimeSchema.nullable(),
     created_at: IsoDateTimeSchema,
     updated_at: IsoDateTimeSchema,
@@ -300,10 +321,17 @@ const UpdateSourceBodySchema = z
   })
   .openapi("UpdateSourceBody");
 
+const PersonSocialAccountInputSchema = z.object({
+  label: z.string().openapi({ example: "Mastodon" }),
+  url: z.string().openapi({ example: "https://mastodon.social/@example" }),
+  is_activitypub: z.boolean().optional().openapi({ example: true }),
+});
+
 const CreatePersonBodySchema = z
   .object({
     name: z.string().openapi({ example: "Ethan Mollick" }),
     url: z.string().optional().nullable().openapi({ example: "https://example.com" }),
+    social_accounts: z.array(PersonSocialAccountInputSchema).optional().nullable(),
   })
   .openapi("CreatePersonBody");
 
@@ -311,6 +339,7 @@ const UpdatePersonBodySchema = z
   .object({
     name: z.string().optional().nullable().openapi({ example: "Ethan Mollick" }),
     url: z.string().optional().nullable().openapi({ example: "https://example.com" }),
+    social_accounts: z.array(PersonSocialAccountInputSchema).optional().nullable(),
   })
   .openapi("UpdatePersonBody");
 
@@ -320,6 +349,51 @@ function parseNullableString(input: unknown): string | null | undefined {
   }
 
   return typeof input === "string" ? input.trim() || null : null;
+}
+
+function parsePersonSocialAccounts(
+  input: unknown
+): PersonSocialAccountInput[] | string | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  if (input === null) {
+    return [];
+  }
+
+  if (!Array.isArray(input)) {
+    return "Social accounts must be an array";
+  }
+
+  const accounts: PersonSocialAccountInput[] = [];
+
+  for (const [index, account] of input.entries()) {
+    if (!account || typeof account !== "object") {
+      return `Social account at index ${index} must be an object`;
+    }
+
+    const candidate = account as Record<string, unknown>;
+    if (typeof candidate.label !== "string" || candidate.label.trim().length === 0) {
+      return `Social account at index ${index} requires a label`;
+    }
+
+    if (typeof candidate.url !== "string" || candidate.url.trim().length === 0) {
+      return `Social account at index ${index} requires a URL`;
+    }
+
+    if (candidate.is_activitypub !== undefined && typeof candidate.is_activitypub !== "boolean") {
+      return `Social account at index ${index} has invalid ActivityPub flag`;
+    }
+
+    accounts.push({
+      label: candidate.label.trim(),
+      url: candidate.url.trim(),
+      is_activitypub: candidate.is_activitypub ?? false,
+    });
+  }
+
+  return accounts;
 }
 
 function parseSourceAuthors(input: unknown): SourceAuthorInput[] | string | undefined {
@@ -1464,7 +1538,7 @@ registerProtectedRoute(
   }),
   async (c: Context) => {
     const body = await c.req.json();
-    const { name, url } = body;
+    const { name, url, social_accounts } = body;
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
       return c.json({ error: "Name is required" }, 400);
@@ -1474,12 +1548,21 @@ registerProtectedRoute(
       return c.json({ error: "URL must be a string" }, 400);
     }
 
+    const parsedSocialAccounts = parsePersonSocialAccounts(social_accounts);
+    if (typeof parsedSocialAccounts === "string") {
+      return c.json({ error: parsedSocialAccounts }, 400);
+    }
+
     const existing = findPersonByName(name);
     if (existing) {
       return c.json({ error: `Person already exists: ${existing.id}` }, 409);
     }
 
-    const person = createPerson({ name: name.trim(), url: parseNullableString(url) ?? null });
+    const person = createPerson({
+      name: name.trim(),
+      url: parseNullableString(url) ?? null,
+      social_accounts: parsedSocialAccounts,
+    });
     return c.json({ data: person }, 201);
   }
 );
@@ -1531,7 +1614,7 @@ registerProtectedRoute(
     }
 
     const body = await c.req.json();
-    const { name, url } = body;
+    const { name, url, social_accounts } = body;
 
     if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
       return c.json({ error: "Name cannot be empty" }, 400);
@@ -1539,6 +1622,11 @@ registerProtectedRoute(
 
     if (url !== undefined && url !== null && typeof url !== "string") {
       return c.json({ error: "URL must be a string" }, 400);
+    }
+
+    const parsedSocialAccounts = parsePersonSocialAccounts(social_accounts);
+    if (typeof parsedSocialAccounts === "string") {
+      return c.json({ error: parsedSocialAccounts }, 400);
     }
 
     if (typeof name === "string") {
@@ -1551,6 +1639,7 @@ registerProtectedRoute(
     const person = updatePerson(id, {
       name: name !== undefined ? name.trim() : undefined,
       url: url !== undefined ? (parseNullableString(url) ?? null) : undefined,
+      social_accounts: parsedSocialAccounts,
     });
 
     if (!person) {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -9,6 +9,7 @@ import {
   sources,
   sourceAuthors,
   people,
+  personSocialAccounts,
   media,
   followers,
 } from "../db";
@@ -30,6 +31,7 @@ type Database = typeof defaultDb;
 type Post = typeof posts.$inferSelect;
 type Source = typeof sources.$inferSelect;
 type Person = typeof people.$inferSelect;
+type PersonSocialAccount = typeof personSocialAccounts.$inferSelect;
 type SourceAuthor = {
   id: number;
   name: string;
@@ -163,10 +165,12 @@ function PersonCard({
   person,
   titleLink = "detail",
   authoredSources = [],
+  socialAccounts = [],
 }: {
   person: Person;
   titleLink?: "detail" | "website";
   authoredSources?: Source[];
+  socialAccounts?: PersonSocialAccount[];
 }) {
   const hostname = getLinkPreviewSiteLabel(person.url, null) ?? person.url;
   const initial = person.name.charAt(0).toUpperCase();
@@ -202,6 +206,31 @@ function PersonCard({
           )}
         </div>
       </div>
+
+      {socialAccounts.length > 0 ? (
+        <div class="mt-4 border-t border-gray-200 pt-4 dark:border-gray-800">
+          <h3 class="text-sm font-semibold text-gray-950 dark:text-gray-50">Social Media</h3>
+          <ul class="mt-2 space-y-2 text-sm text-gray-600 dark:text-gray-300">
+            {socialAccounts.map((account) => (
+              <li key={account.id} class="flex items-center justify-between gap-3">
+                <a
+                  href={account.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="truncate hover:text-teal-600 dark:hover:text-teal-400"
+                >
+                  {account.label}
+                </a>
+                {account.is_activitypub ? (
+                  <span class="shrink-0 rounded-full bg-teal-100 px-2 py-0.5 text-xs font-medium text-teal-700 dark:bg-teal-900/40 dark:text-teal-300">
+                    ActivityPub
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
 
       {authoredSources.length > 0 ? (
         <div class="mt-4 border-t border-gray-200 pt-4 dark:border-gray-800">
@@ -1222,6 +1251,15 @@ function getPerson(db: Database, personId: number): Person | null {
   return db.select().from(people).where(eq(people.id, personId)).get() ?? null;
 }
 
+function getPersonSocialAccounts(db: Database, personId: number): PersonSocialAccount[] {
+  return db
+    .select()
+    .from(personSocialAccounts)
+    .where(eq(personSocialAccounts.person_id, personId))
+    .orderBy(asc(personSocialAccounts.sort_order), asc(personSocialAccounts.id))
+    .all();
+}
+
 function getSourcesAuthoredByPerson(db: Database, personId: number): Source[] {
   return db
     .select({ source: sources })
@@ -2129,6 +2167,7 @@ export function createPagesRoutes(db: Database): Hono {
     }
 
     const authoredSources = getSourcesAuthoredByPerson(db, person.id);
+    const socialAccounts = getPersonSocialAccounts(db, person.id);
     const personLinks: PostWithSource[] = db
       .select({
         post: posts,
@@ -2147,7 +2186,12 @@ export function createPagesRoutes(db: Database): Hono {
       <Layout title={`${person.name} | erikcraddock.me`} description={person.url ?? undefined}>
         <div class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,42rem)] lg:items-start lg:justify-center">
           <aside class="lg:sticky lg:top-24">
-            <PersonCard person={person} titleLink="website" authoredSources={authoredSources} />
+            <PersonCard
+              person={person}
+              titleLink="website"
+              authoredSources={authoredSources}
+              socialAccounts={socialAccounts}
+            />
           </aside>
           <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">
             <header class="border-b border-gray-200 bg-white/90 px-4 py-4 backdrop-blur dark:border-gray-800 dark:bg-gray-900/90 sm:px-6">

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -209,26 +209,29 @@ function PersonCard({
 
       {socialAccounts.length > 0 ? (
         <div class="mt-4 border-t border-gray-200 pt-4 dark:border-gray-800">
-          <h3 class="text-sm font-semibold text-gray-950 dark:text-gray-50">Social Media</h3>
-          <ul class="mt-2 space-y-2 text-sm text-gray-600 dark:text-gray-300">
+          <h3 class="text-sm font-semibold text-gray-950 dark:text-gray-50">
+            Follow {person.name}
+          </h3>
+          <div class="mt-3 grid grid-cols-4 gap-2">
             {socialAccounts.map((account) => (
-              <li key={account.id} class="flex items-center justify-between gap-3">
-                <a
-                  href={account.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="truncate hover:text-teal-600 dark:hover:text-teal-400"
-                >
-                  {account.label}
-                </a>
+              <a
+                key={account.id}
+                href={account.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`${account.label}${account.is_activitypub ? " (ActivityPub)" : ""}`}
+                title={`${account.label}${account.is_activitypub ? " (ActivityPub)" : ""}`}
+                class="relative flex aspect-square items-center justify-center rounded-xl border border-gray-200 text-sm font-semibold text-gray-600 transition hover:border-teal-200 hover:bg-teal-50 hover:text-teal-700 dark:border-gray-800 dark:text-gray-400 dark:hover:border-teal-900/70 dark:hover:bg-teal-950/20 dark:hover:text-teal-300"
+              >
+                {getSocialAccountIcon(account)}
                 {account.is_activitypub ? (
-                  <span class="shrink-0 rounded-full bg-teal-100 px-2 py-0.5 text-xs font-medium text-teal-700 dark:bg-teal-900/40 dark:text-teal-300">
-                    ActivityPub
+                  <span class="absolute right-1 top-1 rounded-full bg-teal-100 px-1 text-[0.55rem] font-bold leading-3 text-teal-700 dark:bg-teal-900/60 dark:text-teal-200">
+                    AP
                   </span>
                 ) : null}
-              </li>
+              </a>
             ))}
-          </ul>
+          </div>
         </div>
       ) : null}
 
@@ -431,6 +434,78 @@ function RssIcon() {
   );
 }
 
+function MastodonIcon() {
+  return (
+    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M20.94 14.28c-.3 1.53-2.68 3.2-5.42 3.52-1.43.17-2.84.33-4.34.26-2.45-.11-4.38-.58-4.38-.58 0 .24.02.47.05.68.33 2.5 2.39 2.65 4.36 2.72 1.99.06 3.76-.49 3.76-.49l.08 1.8s-1.39.74-3.88.88c-1.37.08-3.07-.03-5.05-.56-4.29-1.15-5.03-5.78-5.14-10.48-.03-1.4-.01-2.72-.01-3.83 0-4.86 3.18-6.28 3.18-6.28C5.76 1.18 8.45.88 11.96.86h.08c3.51.02 6.2.32 7.8 1.06 0 0 3.18 1.42 3.18 6.28 0 0 .04 3.59-.08 6.08ZM18.8 8.57c0-1.2-.31-2.16-.93-2.86-.64-.71-1.47-1.08-2.5-1.08-1.19 0-2.09.46-2.68 1.39l-.58.98-.58-.98c-.59-.93-1.49-1.39-2.68-1.39-1.03 0-1.86.37-2.5 1.08-.62.7-.93 1.66-.93 2.86v5.87h2.33V8.73c0-1.2.5-1.81 1.49-1.81 1.1 0 1.65.71 1.65 2.11v3.13h2.31V9.03c0-1.4.55-2.11 1.65-2.11.99 0 1.49.61 1.49 1.81v5.71h2.34V8.57Z" />
+    </svg>
+  );
+}
+
+function BlueskyIcon() {
+  return (
+    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M5.52 3.2C8.14 5.18 10.96 9.2 12 11.35c1.04-2.15 3.86-6.17 6.48-8.15 1.9-1.43 4.98-2.53 4.98.98 0 .7-.4 5.88-.64 6.72-.82 2.94-3.82 3.69-6.49 3.24 4.66.79 5.85 3.42 3.29 6.04-4.86 4.97-6.99-1.25-7.54-2.85-.1-.29-.15-.43-.08-.43s-.02.14-.12.43c-.55 1.6-2.68 7.82-7.54 2.85-2.56-2.62-1.37-5.25 3.29-6.04-2.67.45-5.67-.3-6.49-3.24C.9 10.06.5 4.88.5 4.18c0-3.51 3.08-2.41 5.02-.98Z" />
+    </svg>
+  );
+}
+
+function TwitterIcon() {
+  return (
+    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817-5.966 6.817H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231Zm-1.16 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z" />
+    </svg>
+  );
+}
+
+function SubstackIcon() {
+  return (
+    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4 3h16v3H4V3Zm0 5h16v3H4V8Zm0 5h16v8l-8-4-8 4v-8Z" />
+    </svg>
+  );
+}
+
+function InstagramIcon() {
+  return (
+    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M7.8 2h8.4A5.8 5.8 0 0 1 22 7.8v8.4a5.8 5.8 0 0 1-5.8 5.8H7.8A5.8 5.8 0 0 1 2 16.2V7.8A5.8 5.8 0 0 1 7.8 2Zm-.2 2A3.6 3.6 0 0 0 4 7.6v8.8A3.6 3.6 0 0 0 7.6 20h8.8a3.6 3.6 0 0 0 3.6-3.6V7.6A3.6 3.6 0 0 0 16.4 4H7.6Zm9.65 1.75a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5ZM12 7a5 5 0 1 1 0 10 5 5 0 0 1 0-10Zm0 2a3 3 0 1 0 0 6 3 3 0 0 0 0-6Z" />
+    </svg>
+  );
+}
+
+function TikTokIcon() {
+  return (
+    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M16.6 2c.36 3.03 2.05 4.84 5.02 5.03v3.41a8.68 8.68 0 0 1-5.02-1.54v6.48c0 8.23-8.97 10.8-12.58 4.9-2.32-3.8-.9-10.47 6.55-10.74v3.6c-.58.09-1.2.24-1.76.52-1.68.85-2.63 2.44-2.37 4.25.5 3.46 6.84 4.48 6.31-2.28V2h3.85Z" />
+    </svg>
+  );
+}
+
+function RedditIcon() {
+  return (
+    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M21.5 12.1c0-1.25-1.02-2.27-2.27-2.27-.61 0-1.16.24-1.57.63-1.4-.9-3.28-1.48-5.35-1.56l.9-4.23 2.94.62a1.6 1.6 0 1 0 .25-1.18l-3.53-.75a.6.6 0 0 0-.71.46l-1.08 5.08c-2.14.06-4.08.64-5.52 1.56a2.26 2.26 0 0 0-1.57-.63 2.27 2.27 0 0 0-.99 4.31c-.03.2-.05.41-.05.62 0 3.24 4.03 5.87 9 5.87s9-2.63 9-5.87c0-.21-.02-.42-.05-.62a2.27 2.27 0 0 0 .6-2.04ZM7.88 13.64a1.35 1.35 0 1 1 2.7 0 1.35 1.35 0 0 1-2.7 0Zm7.35 3.69c-.94.94-2.74 1.01-3.28 1.01s-2.34-.07-3.28-1.01a.5.5 0 0 1 .71-.71c.59.59 1.85.72 2.57.72s1.98-.13 2.57-.72a.5.5 0 0 1 .71.71Zm-.06-2.34a1.35 1.35 0 1 1 0-2.7 1.35 1.35 0 0 1 0 2.7Z" />
+    </svg>
+  );
+}
+
+function PeerTubeIcon() {
+  return (
+    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M5 3v18l7-4.5V21l7-4.5L12 12l7-4.5L12 3v4.5L5 3Zm7 4.5L15.5 10 12 12V7.5ZM8 8.5 11.5 11 8 13.5v-5Zm4 4.5 3.5 2.5L12 18v-5Z" />
+    </svg>
+  );
+}
+
+function LemmyIcon() {
+  return (
+    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M12 2a7 7 0 0 1 7 7v2.1A5.5 5.5 0 0 1 16.5 22h-9A5.5 5.5 0 0 1 5 11.1V9a7 7 0 0 1 7-7Zm-3.5 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm7 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm-7.2 4.2a.75.75 0 0 0-.6 1.37A9.7 9.7 0 0 0 12 18a9.7 9.7 0 0 0 4.3-.93.75.75 0 1 0-.6-1.37c-.86.38-2.1.8-3.7.8s-2.84-.42-3.7-.8ZM6.9 4.2 4.7 2a1 1 0 0 0-1.4 1.4l2.2 2.2a7.02 7.02 0 0 1 1.4-1.4Zm10.2 0 2.2-2.2a1 1 0 1 1 1.4 1.4l-2.2 2.2a7.02 7.02 0 0 0-1.4-1.4Z" />
+    </svg>
+  );
+}
+
 const SOCIAL_LINKS = [
   { name: "GitHub", url: "https://github.com/evcraddock", icon: <GitHubIcon /> },
   {
@@ -442,6 +517,44 @@ const SOCIAL_LINKS = [
   { name: "YouTube", url: "https://youtube.com/@ErikCraddock", icon: <YouTubeIcon /> },
   { name: "RSS", url: "/feed.xml", icon: <RssIcon /> },
 ];
+
+function getSocialAccountIcon(account: PersonSocialAccount) {
+  switch (account.label.trim().toLowerCase()) {
+    case "github":
+      return <GitHubIcon />;
+    case "linkedin":
+      return <LinkedInIcon />;
+    case "facebook":
+      return <FacebookIcon />;
+    case "youtube":
+      return <YouTubeIcon />;
+    case "rss":
+      return <RssIcon />;
+    case "mastodon":
+      return <MastodonIcon />;
+    case "bluesky":
+      return <BlueskyIcon />;
+    case "twitter":
+    case "x":
+      return <TwitterIcon />;
+    case "substack":
+      return <SubstackIcon />;
+    case "instagram":
+      return <InstagramIcon />;
+    case "tiktok":
+    case "tik tok":
+      return <TikTokIcon />;
+    case "reddit":
+      return <RedditIcon />;
+    case "peertube":
+    case "peer tube":
+      return <PeerTubeIcon />;
+    case "lemmy":
+      return <LemmyIcon />;
+    default:
+      return <span class="text-sm font-semibold">{account.label.slice(0, 2).toUpperCase()}</span>;
+  }
+}
 
 /** Hero section with bio, social links, and logo */
 function HeroSection() {

--- a/src/services/people.ts
+++ b/src/services/people.ts
@@ -1,32 +1,91 @@
 import { asc, eq } from "drizzle-orm";
-import { db, people } from "@/db";
+import { db, people, personSocialAccounts } from "@/db";
+
+export interface PersonSocialAccount {
+  id: number;
+  person_id: number;
+  label: string;
+  url: string;
+  is_activitypub: boolean;
+  sort_order: number;
+}
 
 export interface Person {
   id: number;
   name: string;
   url: string | null;
+  social_accounts: PersonSocialAccount[];
+}
+
+export interface PersonSocialAccountInput {
+  label: string;
+  url: string;
+  is_activitypub?: boolean;
 }
 
 export interface CreatePersonInput {
   name: string;
   url?: string | null;
+  social_accounts?: PersonSocialAccountInput[];
 }
 
 export interface UpdatePersonInput {
   name?: string;
   url?: string | null;
+  social_accounts?: PersonSocialAccountInput[];
 }
+
+type PersonRecord = typeof people.$inferSelect;
 
 function normalizeName(name: string): string {
   return name.trim().toLowerCase();
 }
 
+function listSocialAccountsForPerson(personId: number): PersonSocialAccount[] {
+  return db
+    .select()
+    .from(personSocialAccounts)
+    .where(eq(personSocialAccounts.person_id, personId))
+    .orderBy(asc(personSocialAccounts.sort_order), asc(personSocialAccounts.id))
+    .all();
+}
+
+function attachSocialAccounts(person: PersonRecord): Person {
+  return { ...person, social_accounts: listSocialAccountsForPerson(person.id) };
+}
+
+function replaceSocialAccounts(personId: number, accounts: PersonSocialAccountInput[]): void {
+  db.delete(personSocialAccounts).where(eq(personSocialAccounts.person_id, personId)).run();
+
+  if (accounts.length === 0) {
+    return;
+  }
+
+  db.insert(personSocialAccounts)
+    .values(
+      accounts.map((account, index) => ({
+        person_id: personId,
+        label: account.label,
+        url: account.url,
+        is_activitypub: account.is_activitypub ?? false,
+        sort_order: index,
+      }))
+    )
+    .run();
+}
+
 export function listPeople(): Person[] {
-  return db.select().from(people).orderBy(asc(people.name), asc(people.id)).all();
+  return db
+    .select()
+    .from(people)
+    .orderBy(asc(people.name), asc(people.id))
+    .all()
+    .map(attachSocialAccounts);
 }
 
 export function getPerson(id: number): Person | null {
-  return db.select().from(people).where(eq(people.id, id)).get() ?? null;
+  const person = db.select().from(people).where(eq(people.id, id)).get();
+  return person ? attachSocialAccounts(person) : null;
 }
 
 export function findPersonByName(name: string): Person | null {
@@ -35,11 +94,17 @@ export function findPersonByName(name: string): Person | null {
 }
 
 export function createPerson(input: CreatePersonInput): Person {
-  return db
+  const person = db
     .insert(people)
     .values({ name: input.name, url: input.url ?? null })
     .returning()
     .get();
+
+  if (input.social_accounts) {
+    replaceSocialAccounts(person.id, input.social_accounts);
+  }
+
+  return getPerson(person.id)!;
 }
 
 export function updatePerson(id: number, input: UpdatePersonInput): Person | null {
@@ -58,6 +123,10 @@ export function updatePerson(id: number, input: UpdatePersonInput): Person | nul
 
   if (Object.keys(updates).length > 0) {
     db.update(people).set(updates).where(eq(people.id, id)).run();
+  }
+
+  if (input.social_accounts !== undefined) {
+    replaceSocialAccounts(id, input.social_accounts);
   }
 
   return getPerson(id);


### PR DESCRIPTION
## Summary

- add `person_social_accounts` storage for multiple social accounts per person
- expose social accounts through the people API and CLI create/edit/show flows
- render a Social Media card on `/people/:id`, including an ActivityPub badge
- add migration and route/API tests for social account storage and rendering

## Verification

- `make pre-pr`
- visual check: `/people/7` renders Social Media card with Mastodon ActivityPub and Website links
- log check: `make dev-tail 2>&1 | grep -E "(ERROR|WARN|error|Error)" || true`

Task: #task-9fb71ac5
