### PR TITLE
Set person default social account

### DIFF
--- a/cli/src/__tests__/api-people.test.ts
+++ b/cli/src/__tests__/api-people.test.ts
@@ -53,7 +53,7 @@ describe("ApiClient people methods", () => {
   });
 
   it("calls PUT /people/:id with body", async () => {
-    const updates = { name: "Ethan Mollick", url: null };
+    const updates = { name: "Ethan Mollick", url: null, default_social_account_id: 7 };
 
     await client.updatePerson(3, updates);
 

--- a/cli/src/commands/person/create.ts
+++ b/cli/src/commands/person/create.ts
@@ -5,7 +5,9 @@ import { loadConfig } from "../../lib/config";
 interface SocialAccountOption {
   label: string;
   url: string;
+  avatar_url?: string | null;
   is_activitypub?: boolean;
+  is_default?: boolean;
 }
 
 interface CreateOptions {
@@ -47,7 +49,7 @@ function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolea
 }
 
 function parseSocialAccount(input: string): SocialAccountOption | null {
-  const [label, url, flag] = input.split("|").map((part) => part.trim());
+  const [label, url, ...flags] = input.split("|").map((part) => part.trim());
   if (!label || !url) {
     return null;
   }
@@ -55,7 +57,9 @@ function parseSocialAccount(input: string): SocialAccountOption | null {
   return {
     label,
     url,
-    is_activitypub: flag === "activitypub" || flag === "ap" || flag === "true",
+    avatar_url: flags.find((flag) => flag.startsWith("avatar="))?.slice("avatar=".length),
+    is_activitypub: flags.some((flag) => ["activitypub", "ap", "true"].includes(flag)),
+    is_default: flags.includes("default"),
   };
 }
 
@@ -69,14 +73,14 @@ Required:
 
 Options:
   --url <url>         Person URL (optional)
-  --social <account>  Social account as "label|url|activitypub" (can be repeated)
+  --social <account>  Social account as "label|url|activitypub|default|avatar=URL" (can be repeated)
   --json              Output as JSON
   --help, -h          Show this help message
 
 Examples:
   ec person create --name "Ethan Mollick"
   ec person create --name "Simon Willison" --url "https://simonwillison.net/"
-  ec person create --name "Example" --social "Mastodon|https://example.social/@person|activitypub"
+  ec person create --name "Example" --social "Mastodon|https://example.social/@person|activitypub|default|avatar=https://example.social/avatar.jpg"
 `);
 }
 

--- a/cli/src/commands/person/edit.ts
+++ b/cli/src/commands/person/edit.ts
@@ -5,13 +5,16 @@ import { loadConfig } from "../../lib/config";
 interface SocialAccountOption {
   label: string;
   url: string;
+  avatar_url?: string | null;
   is_activitypub?: boolean;
+  is_default?: boolean;
 }
 
 interface EditOptions {
   name?: string;
   url?: string | null;
   socialAccounts?: SocialAccountOption[];
+  defaultSocialAccountId?: number | null;
 }
 
 function parseEditArgs(args: string[]): { id: number | null; options: EditOptions; help: boolean } {
@@ -43,6 +46,12 @@ function parseEditArgs(args: string[]): { id: number | null; options: EditOption
       if (parsed) options.socialAccounts = [...(options.socialAccounts ?? []), parsed];
     } else if (arg === "--no-socials") {
       options.socialAccounts = [];
+    } else if (arg === "--default-social" && args[i + 1]) {
+      options.defaultSocialAccountId = parseInt(args[++i], 10);
+    } else if (arg.startsWith("--default-social=")) {
+      options.defaultSocialAccountId = parseInt(arg.split("=").slice(1).join("="), 10);
+    } else if (arg === "--no-default-social") {
+      options.defaultSocialAccountId = null;
     } else if (!arg.startsWith("-") && id === null) {
       const parsed = parseInt(arg, 10);
       if (!isNaN(parsed)) {
@@ -57,7 +66,7 @@ function parseEditArgs(args: string[]): { id: number | null; options: EditOption
 }
 
 function parseSocialAccount(input: string): SocialAccountOption | null {
-  const [label, url, flag] = input.split("|").map((part) => part.trim());
+  const [label, url, ...flags] = input.split("|").map((part) => part.trim());
   if (!label || !url) {
     return null;
   }
@@ -65,7 +74,9 @@ function parseSocialAccount(input: string): SocialAccountOption | null {
   return {
     label,
     url,
-    is_activitypub: flag === "activitypub" || flag === "ap" || flag === "true",
+    avatar_url: flags.find((flag) => flag.startsWith("avatar="))?.slice("avatar=".length),
+    is_activitypub: flags.some((flag) => ["activitypub", "ap", "true"].includes(flag)),
+    is_default: flags.includes("default"),
   };
 }
 
@@ -81,15 +92,18 @@ Options:
   --name <name>       Update person name
   --url <url>         Update person URL
   --no-url            Clear person URL
-  --social <account>  Replace social accounts with "label|url|activitypub" entries
+  --social <account>  Replace social accounts with "label|url|activitypub|default|avatar=URL" entries
   --no-socials        Remove all social accounts
+  --default-social <id>  Mark an existing social account as default
+  --no-default-social   Clear the explicit default social account
   --json              Output as JSON
   --help, -h          Show this help message
 
 Examples:
   ec person edit 1 --name "Ethan Mollick"
   ec person edit 1 --url "https://example.com"
-  ec person edit 1 --social "Mastodon|https://example.social/@person|activitypub"
+  ec person edit 1 --social "Mastodon|https://example.social/@person|activitypub|default|avatar=https://example.social/avatar.jpg"
+  ec person edit 1 --default-social 3
   ec person edit 1 --no-socials
   ec person edit 1 --no-url
 `);
@@ -110,15 +124,29 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
   }
 
   const hasUpdates =
-    options.name !== undefined || options.url !== undefined || options.socialAccounts !== undefined;
+    options.name !== undefined ||
+    options.url !== undefined ||
+    options.socialAccounts !== undefined ||
+    options.defaultSocialAccountId !== undefined;
   if (!hasUpdates) {
     console.error("❌ No update options provided.");
-    console.error("Specify at least one of: --name, --url, --no-url, --social, --no-socials");
+    console.error(
+      "Specify at least one of: --name, --url, --no-url, --social, --no-socials, --default-social, --no-default-social"
+    );
     process.exit(1);
   }
 
   if (options.name !== undefined && options.name.trim().length === 0) {
     console.error("❌ --name cannot be empty.");
+    process.exit(1);
+  }
+
+  if (
+    options.defaultSocialAccountId !== undefined &&
+    options.defaultSocialAccountId !== null &&
+    (isNaN(options.defaultSocialAccountId) || options.defaultSocialAccountId <= 0)
+  ) {
+    console.error("❌ --default-social must be a positive integer.");
     process.exit(1);
   }
 
@@ -136,6 +164,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     name: options.name?.trim(),
     url: options.url === undefined ? undefined : options.url?.trim() || null,
     social_accounts: options.socialAccounts,
+    default_social_account_id: options.defaultSocialAccountId,
   });
 
   if (result.error) {

--- a/cli/src/commands/person/show.ts
+++ b/cli/src/commands/person/show.ts
@@ -46,8 +46,15 @@ function formatPerson(person: Person): void {
   if (person.social_accounts.length > 0) {
     console.log("Social accounts:");
     for (const account of person.social_accounts) {
-      const activityPub = account.is_activitypub ? " (ActivityPub)" : "";
-      console.log(`  - ${account.label}: ${account.url}${activityPub}`);
+      const markers = [
+        account.is_activitypub ? "ActivityPub" : null,
+        account.is_default ? "default" : null,
+      ].filter(Boolean);
+      const suffix = markers.length > 0 ? ` (${markers.join(", ")})` : "";
+      console.log(`  - ${account.label}: ${account.url}${suffix}`);
+      if (account.avatar_url) {
+        console.log(`    Avatar: ${account.avatar_url}`);
+      }
     }
   }
 }

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -185,7 +185,14 @@ export class ApiClient {
   async createPerson(data: {
     name: string;
     url?: string | null;
-    social_accounts?: Array<{ label: string; url: string; is_activitypub?: boolean }>;
+    social_accounts?: Array<{
+      label: string;
+      url: string;
+      avatar_url?: string | null;
+      is_activitypub?: boolean;
+      is_default?: boolean;
+    }>;
+    default_social_account_id?: number | null;
   }): Promise<ApiResponse<Person>> {
     return this.request<Person>("POST", "/people", data);
   }
@@ -195,7 +202,14 @@ export class ApiClient {
     data: {
       name?: string;
       url?: string | null;
-      social_accounts?: Array<{ label: string; url: string; is_activitypub?: boolean }>;
+      social_accounts?: Array<{
+        label: string;
+        url: string;
+        avatar_url?: string | null;
+        is_activitypub?: boolean;
+        is_default?: boolean;
+      }>;
+      default_social_account_id?: number | null;
     }
   ): Promise<ApiResponse<Person>> {
     return this.request<Person>("PUT", `/people/${id}`, data);

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -192,7 +192,6 @@ export class ApiClient {
       is_activitypub?: boolean;
       is_default?: boolean;
     }>;
-    default_social_account_id?: number | null;
   }): Promise<ApiResponse<Person>> {
     return this.request<Person>("POST", "/people", data);
   }

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -41,7 +41,9 @@ export interface PersonSocialAccount {
   person_id: number;
   label: string;
   url: string;
+  avatar_url: string | null;
   is_activitypub: boolean;
+  is_default: boolean;
   sort_order: number;
 }
 
@@ -50,6 +52,7 @@ export interface Person {
   name: string;
   url: string | null;
   social_accounts: PersonSocialAccount[];
+  default_social_account: PersonSocialAccount | null;
 }
 
 export interface Post {

--- a/drizzle/0011_tired_ken_ellis.sql
+++ b/drizzle/0011_tired_ken_ellis.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `person_social_accounts` ADD `avatar_url` text;--> statement-breakpoint
+ALTER TABLE `person_social_accounts` ADD `is_default` integer DEFAULT false NOT NULL;

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,945 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dbd464ad-58e9-479a-a1b6-7ba8551092f7",
+  "prevId": "e2bc0b5b-d164-44eb-96d3-f71afb864470",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "person_social_accounts": {
+      "name": "person_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_social_accounts_person_id_people_id_fk": {
+          "name": "person_social_accounts_person_id_people_id_fk",
+          "tableFrom": "person_social_accounts",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777225658548,
       "tag": "0010_narrow_mephistopheles",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1777228029862,
+      "tag": "0011_tired_ken_ellis",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -68,7 +68,9 @@ export const personSocialAccounts = sqliteTable("person_social_accounts", {
     .references(() => people.id, { onDelete: "cascade" }),
   label: text("label").notNull(),
   url: text("url").notNull(),
+  avatar_url: text("avatar_url"),
   is_activitypub: integer("is_activitypub", { mode: "boolean" }).notNull().default(false),
+  is_default: integer("is_default", { mode: "boolean" }).notNull().default(false),
   sort_order: integer("sort_order").notNull().default(0),
 });
 

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -1348,6 +1348,73 @@ describe("/api/people", () => {
     ]);
     expect(created.data.social_accounts[0].sort_order).toBe(0);
     expect(created.data.social_accounts[1].sort_order).toBe(1);
+    expect(created.data.default_social_account).toMatchObject({
+      label: "Mastodon",
+      is_activitypub: true,
+      is_default: false,
+    });
+  });
+
+  it("marks an explicit social account as the default", async () => {
+    const createRes = await api.request("/people", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Default Person",
+        social_accounts: [
+          { label: "Mastodon", url: "https://example.social/@person", is_activitypub: true },
+          {
+            label: "Bluesky",
+            url: "https://bsky.app/profile/example.com",
+            is_default: true,
+            avatar_url: "https://cdn.example.com/avatar.jpg",
+          },
+        ],
+      }),
+    });
+
+    expect(createRes.status).toBe(201);
+    const created = await createRes.json();
+    expect(created.data.default_social_account).toMatchObject({
+      label: "Bluesky",
+      avatar_url: "https://cdn.example.com/avatar.jpg",
+      is_default: true,
+    });
+    expect(created.data.social_accounts[0].is_default).toBe(false);
+    expect(created.data.social_accounts[1].is_default).toBe(true);
+  });
+
+  it("updates a person's default social account by ID", async () => {
+    const person = testDb.insert(people).values({ name: "Default Update" }).returning().get();
+    const accounts = testDb
+      .insert(personSocialAccounts)
+      .values([
+        {
+          person_id: person.id,
+          label: "Mastodon",
+          url: "https://example.social/@person",
+          is_activitypub: true,
+          sort_order: 0,
+        },
+        {
+          person_id: person.id,
+          label: "Bluesky",
+          url: "https://bsky.app/profile/example.com",
+          sort_order: 1,
+        },
+      ])
+      .returning()
+      .all();
+
+    const res = await api.request(`/people/${person.id}`, {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ default_social_account_id: accounts[1].id }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.default_social_account).toMatchObject({ label: "Bluesky", is_default: true });
   });
 
   it("replaces person social accounts when editing", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -614,7 +614,7 @@ describe("pages routes", () => {
       expect(html).toContain("Test Author");
       expect(html).toContain("Alice");
       expect(html).toContain("https://alice.example.com");
-      expect(html).toContain("No website listed");
+      expect(html).not.toContain("No website listed");
     });
 
     it("uses the sources page card grid pattern", async () => {
@@ -896,12 +896,12 @@ describe("pages routes", () => {
       expect(html).not.toContain("Followers");
     });
 
-    it("lists sources authored by the selected person", async () => {
+    it("lists websites authored by the selected person", async () => {
       const app = getApp();
       const res = await app.request("/people/1");
       const html = await res.text();
 
-      expect(html).toContain("Sources");
+      expect(html).toContain("Websites");
       expect(html).toContain('href="/sources/1"');
       expect(html).toContain("Test Blog");
     });

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -646,6 +646,14 @@ describe("pages routes", () => {
       expect(html).toContain('href="/people/2"');
     });
 
+    it("shows avatars from default social accounts on people cards", async () => {
+      const app = getApp();
+      const res = await app.request("/people");
+      const html = await res.text();
+
+      expect(html).toContain('src="https://mastodon.social/avatar.jpg"');
+    });
+
     it("paginates people", async () => {
       const manyPeopleDb = createTestDb();
       for (let i = 1; i <= 25; i++) {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -160,6 +160,7 @@ testDb
       person_id: 1,
       label: "Mastodon",
       url: "https://mastodon.social/@testauthor",
+      avatar_url: "https://mastodon.social/avatar.jpg",
       is_activitypub: true,
       sort_order: 0,
     },
@@ -908,6 +909,16 @@ describe("pages routes", () => {
       expect(html).toContain("ActivityPub");
       expect(html).toContain('href="https://github.com/testauthor"');
       expect(html).toContain("GitHub");
+    });
+
+    it("uses the effective default social account for avatar and follow button", async () => {
+      const app = getApp();
+      const res = await app.request("/people/1");
+      const html = await res.text();
+
+      expect(html).toContain('src="https://mastodon.social/avatar.jpg"');
+      expect(html).toContain('href="https://mastodon.social/@testauthor"');
+      expect(html).toContain(">Follow</a>");
     });
 
     it("shows links from the selected person with full shared link content", async () => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -118,13 +118,16 @@ const PersonSocialAccountSchema = z
     person_id: z.number().int().openapi({ example: 1 }),
     label: z.string().openapi({ example: "Mastodon" }),
     url: z.string().url().openapi({ example: "https://mastodon.social/@example" }),
+    avatar_url: NullableStringSchema.openapi({ example: "https://example.social/avatar.jpg" }),
     is_activitypub: z.boolean().openapi({ example: true }),
+    is_default: z.boolean().openapi({ example: true }),
     sort_order: z.number().int().openapi({ example: 0 }),
   })
   .openapi("PersonSocialAccount");
 
 const PersonSchema = PersonSummarySchema.extend({
   social_accounts: z.array(PersonSocialAccountSchema),
+  default_social_account: PersonSocialAccountSchema.nullable(),
 }).openapi("Person");
 
 const SourceAuthorSchema = z
@@ -324,7 +327,13 @@ const UpdateSourceBodySchema = z
 const PersonSocialAccountInputSchema = z.object({
   label: z.string().openapi({ example: "Mastodon" }),
   url: z.string().openapi({ example: "https://mastodon.social/@example" }),
+  avatar_url: z
+    .string()
+    .optional()
+    .nullable()
+    .openapi({ example: "https://example.social/avatar.jpg" }),
   is_activitypub: z.boolean().optional().openapi({ example: true }),
+  is_default: z.boolean().optional().openapi({ example: true }),
 });
 
 const CreatePersonBodySchema = z
@@ -332,6 +341,7 @@ const CreatePersonBodySchema = z
     name: z.string().openapi({ example: "Ethan Mollick" }),
     url: z.string().optional().nullable().openapi({ example: "https://example.com" }),
     social_accounts: z.array(PersonSocialAccountInputSchema).optional().nullable(),
+    default_social_account_id: z.number().int().optional().nullable(),
   })
   .openapi("CreatePersonBody");
 
@@ -340,6 +350,7 @@ const UpdatePersonBodySchema = z
     name: z.string().optional().nullable().openapi({ example: "Ethan Mollick" }),
     url: z.string().optional().nullable().openapi({ example: "https://example.com" }),
     social_accounts: z.array(PersonSocialAccountInputSchema).optional().nullable(),
+    default_social_account_id: z.number().int().optional().nullable(),
   })
   .openapi("UpdatePersonBody");
 
@@ -382,14 +393,28 @@ function parsePersonSocialAccounts(
       return `Social account at index ${index} requires a URL`;
     }
 
+    if (
+      candidate.avatar_url !== undefined &&
+      candidate.avatar_url !== null &&
+      typeof candidate.avatar_url !== "string"
+    ) {
+      return `Social account at index ${index} has invalid avatar URL`;
+    }
+
     if (candidate.is_activitypub !== undefined && typeof candidate.is_activitypub !== "boolean") {
       return `Social account at index ${index} has invalid ActivityPub flag`;
+    }
+
+    if (candidate.is_default !== undefined && typeof candidate.is_default !== "boolean") {
+      return `Social account at index ${index} has invalid default flag`;
     }
 
     accounts.push({
       label: candidate.label.trim(),
       url: candidate.url.trim(),
+      avatar_url: parseNullableString(candidate.avatar_url) ?? null,
       is_activitypub: candidate.is_activitypub ?? false,
+      is_default: candidate.is_default ?? false,
     });
   }
 
@@ -1538,7 +1563,7 @@ registerProtectedRoute(
   }),
   async (c: Context) => {
     const body = await c.req.json();
-    const { name, url, social_accounts } = body;
+    const { name, url, social_accounts, default_social_account_id } = body;
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
       return c.json({ error: "Name is required" }, 400);
@@ -1562,6 +1587,7 @@ registerProtectedRoute(
       name: name.trim(),
       url: parseNullableString(url) ?? null,
       social_accounts: parsedSocialAccounts,
+      default_social_account_id: default_social_account_id ?? undefined,
     });
     return c.json({ data: person }, 201);
   }
@@ -1614,7 +1640,7 @@ registerProtectedRoute(
     }
 
     const body = await c.req.json();
-    const { name, url, social_accounts } = body;
+    const { name, url, social_accounts, default_social_account_id } = body;
 
     if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
       return c.json({ error: "Name cannot be empty" }, 400);
@@ -1636,11 +1662,18 @@ registerProtectedRoute(
       }
     }
 
-    const person = updatePerson(id, {
-      name: name !== undefined ? name.trim() : undefined,
-      url: url !== undefined ? (parseNullableString(url) ?? null) : undefined,
-      social_accounts: parsedSocialAccounts,
-    });
+    let person;
+    try {
+      person = updatePerson(id, {
+        name: name !== undefined ? name.trim() : undefined,
+        url: url !== undefined ? (parseNullableString(url) ?? null) : undefined,
+        social_accounts: parsedSocialAccounts,
+        default_social_account_id:
+          default_social_account_id !== undefined ? default_social_account_id : undefined,
+      });
+    } catch (error) {
+      return c.json({ error: String(error) }, 400);
+    }
 
     if (!person) {
       return c.json({ error: "Person not found" }, 404);

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -341,7 +341,6 @@ const CreatePersonBodySchema = z
     name: z.string().openapi({ example: "Ethan Mollick" }),
     url: z.string().optional().nullable().openapi({ example: "https://example.com" }),
     social_accounts: z.array(PersonSocialAccountInputSchema).optional().nullable(),
-    default_social_account_id: z.number().int().optional().nullable(),
   })
   .openapi("CreatePersonBody");
 
@@ -1563,7 +1562,7 @@ registerProtectedRoute(
   }),
   async (c: Context) => {
     const body = await c.req.json();
-    const { name, url, social_accounts, default_social_account_id } = body;
+    const { name, url, social_accounts } = body;
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
       return c.json({ error: "Name is required" }, 400);
@@ -1587,7 +1586,6 @@ registerProtectedRoute(
       name: name.trim(),
       url: parseNullableString(url) ?? null,
       social_accounts: parsedSocialAccounts,
-      default_social_account_id: default_social_account_id ?? undefined,
     });
     return c.json({ data: person }, 201);
   }

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -174,6 +174,15 @@ function PersonCard({
 }) {
   const hostname = getLinkPreviewSiteLabel(person.url, null) ?? person.url;
   const initial = person.name.charAt(0).toUpperCase();
+  const defaultSocialAccount =
+    socialAccounts.find((account) => account.is_default) ??
+    socialAccounts.find((account) => account.is_activitypub) ??
+    null;
+  const activityPubAccount =
+    (defaultSocialAccount?.is_activitypub ? defaultSocialAccount : null) ??
+    socialAccounts.find((account) => account.is_activitypub) ??
+    null;
+  const avatarUrl = defaultSocialAccount?.avatar_url ?? null;
   const titleHref = titleLink === "website" && person.url ? person.url : `/people/${person.id}`;
   const titleExternalAttrs =
     titleLink === "website" && person.url ? { target: "_blank", rel: "noopener noreferrer" } : {};
@@ -181,8 +190,12 @@ function PersonCard({
   return (
     <article class="flex h-full flex-col rounded-2xl border border-gray-200 bg-white p-5 shadow-sm transition-colors hover:border-teal-200 hover:bg-teal-50/40 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-teal-900/60 dark:hover:bg-teal-950/20">
       <div class="flex items-start gap-4">
-        <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-teal-100 text-lg font-bold text-teal-700 dark:bg-teal-900/40 dark:text-teal-300">
-          {initial}
+        <div class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-teal-100 text-lg font-bold text-teal-700 dark:bg-teal-900/40 dark:text-teal-300">
+          {avatarUrl ? (
+            <img src={avatarUrl} alt="" class="h-full w-full object-cover" loading="lazy" />
+          ) : (
+            initial
+          )}
         </div>
         <div class="min-w-0 flex-1">
           <a
@@ -204,6 +217,16 @@ function PersonCard({
           ) : (
             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">No website listed</p>
           )}
+          {activityPubAccount ? (
+            <a
+              href={activityPubAccount.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="mt-3 inline-flex rounded-full bg-teal-600 px-3 py-1 text-sm font-semibold text-white transition hover:bg-teal-700 dark:bg-teal-500 dark:text-gray-950 dark:hover:bg-teal-400"
+            >
+              Follow
+            </a>
+          ) : null}
         </div>
       </div>
 

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -2084,7 +2084,11 @@ export function createPagesRoutes(db: Database): Hono {
                 </div>
                 <div class="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
                   {pagePeople.map((person) => (
-                    <PersonCard key={person.id} person={person} />
+                    <PersonCard
+                      key={person.id}
+                      person={person}
+                      socialAccounts={getPersonSocialAccounts(db, person.id)}
+                    />
                   ))}
                 </div>
                 {totalPages > 1 ? (

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -166,11 +166,15 @@ function PersonCard({
   titleLink = "detail",
   authoredSources = [],
   socialAccounts = [],
+  showSocialAccounts = true,
+  showFollowButton = true,
 }: {
   person: Person;
   titleLink?: "detail" | "website";
   authoredSources?: Source[];
   socialAccounts?: PersonSocialAccount[];
+  showSocialAccounts?: boolean;
+  showFollowButton?: boolean;
 }) {
   const hostname = getLinkPreviewSiteLabel(person.url, null) ?? person.url;
   const initial = person.name.charAt(0).toUpperCase();
@@ -214,23 +218,23 @@ function PersonCard({
             >
               {hostname}
             </a>
-          ) : (
-            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">No website listed</p>
-          )}
-          {activityPubAccount ? (
-            <a
-              href={activityPubAccount.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="mt-3 inline-flex rounded-full bg-teal-600 px-3 py-1 text-sm font-semibold text-white transition hover:bg-teal-700 dark:bg-teal-500 dark:text-gray-950 dark:hover:bg-teal-400"
-            >
-              Follow
-            </a>
+          ) : null}
+          {showFollowButton && activityPubAccount ? (
+            <div class="mt-3 flex justify-end">
+              <a
+                href={activityPubAccount.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex rounded-full bg-teal-600 px-3 py-1 text-sm font-semibold text-white transition hover:bg-teal-700 dark:bg-teal-500 dark:text-gray-950 dark:hover:bg-teal-400"
+              >
+                Follow
+              </a>
+            </div>
           ) : null}
         </div>
       </div>
 
-      {socialAccounts.length > 0 ? (
+      {showSocialAccounts && socialAccounts.length > 0 ? (
         <div class="mt-4 border-t border-gray-200 pt-4 dark:border-gray-800">
           <h3 class="text-sm font-semibold text-gray-950 dark:text-gray-50">
             Follow {person.name}
@@ -247,11 +251,6 @@ function PersonCard({
                 class="relative flex aspect-square items-center justify-center rounded-xl border border-gray-200 text-sm font-semibold text-gray-600 transition hover:border-teal-200 hover:bg-teal-50 hover:text-teal-700 dark:border-gray-800 dark:text-gray-400 dark:hover:border-teal-900/70 dark:hover:bg-teal-950/20 dark:hover:text-teal-300"
               >
                 {getSocialAccountIcon(account)}
-                {account.is_activitypub ? (
-                  <span class="absolute right-1 top-1 rounded-full bg-teal-100 px-1 text-[0.55rem] font-bold leading-3 text-teal-700 dark:bg-teal-900/60 dark:text-teal-200">
-                    AP
-                  </span>
-                ) : null}
               </a>
             ))}
           </div>
@@ -260,7 +259,7 @@ function PersonCard({
 
       {authoredSources.length > 0 ? (
         <div class="mt-4 border-t border-gray-200 pt-4 dark:border-gray-800">
-          <h3 class="text-sm font-semibold text-gray-950 dark:text-gray-50">Sources</h3>
+          <h3 class="text-sm font-semibold text-gray-950 dark:text-gray-50">Websites</h3>
           <ul class="mt-2 space-y-1 text-sm text-gray-600 dark:text-gray-300">
             {authoredSources.map((source) => (
               <li key={source.id}>
@@ -2088,6 +2087,8 @@ export function createPagesRoutes(db: Database): Hono {
                       key={person.id}
                       person={person}
                       socialAccounts={getPersonSocialAccounts(db, person.id)}
+                      showSocialAccounts={false}
+                      showFollowButton={false}
                     />
                   ))}
                 </div>

--- a/src/services/people.ts
+++ b/src/services/people.ts
@@ -6,7 +6,9 @@ export interface PersonSocialAccount {
   person_id: number;
   label: string;
   url: string;
+  avatar_url: string | null;
   is_activitypub: boolean;
+  is_default: boolean;
   sort_order: number;
 }
 
@@ -15,24 +17,29 @@ export interface Person {
   name: string;
   url: string | null;
   social_accounts: PersonSocialAccount[];
+  default_social_account: PersonSocialAccount | null;
 }
 
 export interface PersonSocialAccountInput {
   label: string;
   url: string;
+  avatar_url?: string | null;
   is_activitypub?: boolean;
+  is_default?: boolean;
 }
 
 export interface CreatePersonInput {
   name: string;
   url?: string | null;
   social_accounts?: PersonSocialAccountInput[];
+  default_social_account_id?: number | null;
 }
 
 export interface UpdatePersonInput {
   name?: string;
   url?: string | null;
   social_accounts?: PersonSocialAccountInput[];
+  default_social_account_id?: number | null;
 }
 
 type PersonRecord = typeof people.$inferSelect;
@@ -50,8 +57,23 @@ function listSocialAccountsForPerson(personId: number): PersonSocialAccount[] {
     .all();
 }
 
+export function getDefaultSocialAccount(
+  accounts: PersonSocialAccount[]
+): PersonSocialAccount | null {
+  return (
+    accounts.find((account) => account.is_default) ??
+    accounts.find((account) => account.is_activitypub) ??
+    null
+  );
+}
+
 function attachSocialAccounts(person: PersonRecord): Person {
-  return { ...person, social_accounts: listSocialAccountsForPerson(person.id) };
+  const socialAccounts = listSocialAccountsForPerson(person.id);
+  return {
+    ...person,
+    social_accounts: socialAccounts,
+    default_social_account: getDefaultSocialAccount(socialAccounts),
+  };
 }
 
 function replaceSocialAccounts(personId: number, accounts: PersonSocialAccountInput[]): void {
@@ -61,17 +83,49 @@ function replaceSocialAccounts(personId: number, accounts: PersonSocialAccountIn
     return;
   }
 
+  const defaultIndex = accounts.findIndex((account) => account.is_default);
+
   db.insert(personSocialAccounts)
     .values(
       accounts.map((account, index) => ({
         person_id: personId,
         label: account.label,
         url: account.url,
+        avatar_url: account.avatar_url ?? null,
         is_activitypub: account.is_activitypub ?? false,
+        is_default: defaultIndex === index,
         sort_order: index,
       }))
     )
     .run();
+}
+
+export function setDefaultSocialAccount(personId: number, socialAccountId: number | null): boolean {
+  const existing = getPerson(personId);
+  if (!existing) {
+    return false;
+  }
+
+  if (socialAccountId !== null) {
+    const account = existing.social_accounts.find((candidate) => candidate.id === socialAccountId);
+    if (!account) {
+      return false;
+    }
+  }
+
+  db.update(personSocialAccounts)
+    .set({ is_default: false })
+    .where(eq(personSocialAccounts.person_id, personId))
+    .run();
+
+  if (socialAccountId !== null) {
+    db.update(personSocialAccounts)
+      .set({ is_default: true })
+      .where(eq(personSocialAccounts.id, socialAccountId))
+      .run();
+  }
+
+  return true;
 }
 
 export function listPeople(): Person[] {
@@ -104,6 +158,10 @@ export function createPerson(input: CreatePersonInput): Person {
     replaceSocialAccounts(person.id, input.social_accounts);
   }
 
+  if (input.default_social_account_id !== undefined) {
+    setDefaultSocialAccount(person.id, input.default_social_account_id);
+  }
+
   return getPerson(person.id)!;
 }
 
@@ -127,6 +185,13 @@ export function updatePerson(id: number, input: UpdatePersonInput): Person | nul
 
   if (input.social_accounts !== undefined) {
     replaceSocialAccounts(id, input.social_accounts);
+  }
+
+  if (input.default_social_account_id !== undefined) {
+    const updated = setDefaultSocialAccount(id, input.default_social_account_id);
+    if (!updated) {
+      throw new Error(`Default social account not found: ${input.default_social_account_id}`);
+    }
   }
 
   return getPerson(id);

--- a/src/services/people.ts
+++ b/src/services/people.ts
@@ -32,7 +32,6 @@ export interface CreatePersonInput {
   name: string;
   url?: string | null;
   social_accounts?: PersonSocialAccountInput[];
-  default_social_account_id?: number | null;
 }
 
 export interface UpdatePersonInput {
@@ -156,10 +155,6 @@ export function createPerson(input: CreatePersonInput): Person {
 
   if (input.social_accounts) {
     replaceSocialAccounts(person.id, input.social_accounts);
-  }
-
-  if (input.default_social_account_id !== undefined) {
-    setDefaultSocialAccount(person.id, input.default_social_account_id);
   }
 
   return getPerson(person.id)!;


### PR DESCRIPTION
## Summary
- add avatar URL and default flag support to person social accounts
- expose effective default social accounts through the people API, with fallback to the first ActivityPub account
- render person avatars and ActivityPub follow buttons from the effective default/fallback account
- add CLI support for social account avatars/defaults and explicit default account updates

## Testing
- `make pre-pr`
- push hook: lint, typecheck, tests, migration check
- manual browser verification on `/people/5` with Simon Willison social/avatar data

## Task
- task-406b9766
