### PR TITLE
Use wider two-pane post layout

### DIFF
--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -1283,16 +1283,18 @@ describe("pages routes", () => {
       expect(html).toContain("/posts/test-post");
     });
 
-    it("uses a single-pane layout for article posts", async () => {
+    it("uses the wider two-pane layout for article posts", async () => {
       const app = getApp();
       const res = await app.request("/posts/test-post");
 
       expect(res.status).toBe(200);
 
       const html = await res.text();
-      expect(html).toContain('class="mx-auto max-w-3xl"');
-      expect(html).not.toContain("Followers");
-      expect(html).not.toContain("Following");
+      expect(html).toContain(
+        'class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,1fr)] lg:items-start"'
+      );
+      expect(html).toContain("Followers");
+      expect(html).toContain("Following");
     });
 
     it("keeps the actor card for link posts", async () => {
@@ -1303,6 +1305,9 @@ describe("pages routes", () => {
 
       const html = await res.text();
       expect(html).toContain("@erik@erikcraddock.me");
+      expect(html).toContain(
+        'class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,1fr)] lg:items-start"'
+      );
       expect(html).toContain("Followers");
       expect(html).toContain("Following");
     });

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -1282,6 +1282,30 @@ describe("pages routes", () => {
       expect(html).toContain('property="og:url"');
       expect(html).toContain("/posts/test-post");
     });
+
+    it("uses a single-pane layout for article posts", async () => {
+      const app = getApp();
+      const res = await app.request("/posts/test-post");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain('class="mx-auto max-w-3xl"');
+      expect(html).not.toContain("Followers");
+      expect(html).not.toContain("Following");
+    });
+
+    it("keeps the actor card for link posts", async () => {
+      const app = getApp();
+      const res = await app.request("/posts/test-link");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("@erik@erikcraddock.me");
+      expect(html).toContain("Followers");
+      expect(html).toContain("Following");
+    });
   });
 
   describe("GET /tags", () => {

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -2517,6 +2517,7 @@ export function createPagesRoutes(db: Database): Hono {
     let post = result.post;
     const source = result.source;
     const author = result.author;
+    const isArticle = post.type === "article";
     const isLink = post.type === "link";
     const isNote = post.type === "note";
 
@@ -2591,14 +2592,22 @@ export function createPagesRoutes(db: Database): Hono {
         description={description}
         canonicalUrl={canonicalUrl}
       >
-        <div class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,42rem)] lg:items-start lg:justify-center">
-          <aside class="lg:sticky lg:top-24">
-            <FeedProfileCard
-              followerCount={followerCount}
-              followingCount={followingCount}
-              postCount={totalPosts}
-            />
-          </aside>
+        <div
+          class={
+            isArticle
+              ? "mx-auto max-w-3xl"
+              : "mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,42rem)] lg:items-start lg:justify-center"
+          }
+        >
+          {!isArticle && (
+            <aside class="lg:sticky lg:top-24">
+              <FeedProfileCard
+                followerCount={followerCount}
+                followingCount={followingCount}
+                postCount={totalPosts}
+              />
+            </aside>
+          )}
           <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">
             <header class="border-b border-gray-200 bg-white/90 px-4 py-4 backdrop-blur dark:border-gray-800 dark:bg-gray-900/90 sm:px-6">
               <a

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1659,7 +1659,7 @@ export function createPagesRoutes(db: Database): Hono {
     if (totalPosts === 0) {
       return c.html(
         <Layout title="Feed | erikcraddock.me">
-          <div class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,42rem)] lg:items-start lg:justify-center">
+          <div class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,1fr)] lg:items-start">
             <aside class="lg:sticky lg:top-24">
               <FeedProfileCard
                 followerCount={followerCount}
@@ -1759,7 +1759,7 @@ export function createPagesRoutes(db: Database): Hono {
 
     return c.html(
       <Layout title={`Feed${page > 1 ? ` - Page ${page}` : ""} | erikcraddock.me`}>
-        <div class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,42rem)] lg:items-start lg:justify-center">
+        <div class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,1fr)] lg:items-start">
           <aside class="lg:sticky lg:top-24">
             <FeedProfileCard
               followerCount={followerCount}
@@ -2517,7 +2517,6 @@ export function createPagesRoutes(db: Database): Hono {
     let post = result.post;
     const source = result.source;
     const author = result.author;
-    const isArticle = post.type === "article";
     const isLink = post.type === "link";
     const isNote = post.type === "note";
 
@@ -2592,22 +2591,14 @@ export function createPagesRoutes(db: Database): Hono {
         description={description}
         canonicalUrl={canonicalUrl}
       >
-        <div
-          class={
-            isArticle
-              ? "mx-auto max-w-3xl"
-              : "mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,42rem)] lg:items-start lg:justify-center"
-          }
-        >
-          {!isArticle && (
-            <aside class="lg:sticky lg:top-24">
-              <FeedProfileCard
-                followerCount={followerCount}
-                followingCount={followingCount}
-                postCount={totalPosts}
-              />
-            </aside>
-          )}
+        <div class="mx-auto grid max-w-6xl gap-6 lg:grid-cols-[20rem_minmax(0,1fr)] lg:items-start">
+          <aside class="lg:sticky lg:top-24">
+            <FeedProfileCard
+              followerCount={followerCount}
+              followingCount={followingCount}
+              postCount={totalPosts}
+            />
+          </aside>
           <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">
             <header class="border-b border-gray-200 bg-white/90 px-4 py-4 backdrop-blur dark:border-gray-800 dark:bg-gray-900/90 sm:px-6">
               <a


### PR DESCRIPTION
## Summary
- Use a wider two-pane layout for feed and single post pages
- Keep the left actor pane at its existing 20rem width
- Expand the right content pane to fill the remaining header-width space
- Keep the actor card visible on article and link post pages
- Update tests for the revised layout

Task: task-1cb77e27

## Verification
- bun test src/routes/__tests__/pages.test.tsx
- make check
- Visual: /feed and /posts/building-a-home-studio use the wider two-pane layout
- make dev-tail 2>&1 | grep -E "(ERROR|WARN|error|Error)" || true