### PR TITLE
Update header footer and post sidebars

### DIFF
--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -243,6 +243,28 @@ describe("pages routes", () => {
       expect(footer).not.toContain("Follow on the Fediverse");
     });
 
+    it("links the hero avatar to the about page", async () => {
+      const app = getApp();
+      const res = await app.request("/");
+      const html = await res.text();
+
+      expect(html).toContain('href="/about"');
+      expect(html).toContain('aria-label="About Erik Craddock"');
+      expect(html).toContain('alt="Erik Craddock"');
+    });
+
+    it("displays a latest updates feed teaser", async () => {
+      const app = getApp();
+      const res = await app.request("/");
+      const html = await res.text();
+
+      expect(html).toContain("Latest updates");
+      expect(html).toContain("Notes, Links &amp; Updates");
+      expect(html).toContain("Browse the full feed for shorter notes");
+      expect(html).toContain('href="/feed"');
+      expect(html).toContain("Open Feed");
+    });
+
     it("displays Recent Articles section", async () => {
       const app = getApp();
       const res = await app.request("/");
@@ -550,7 +572,7 @@ describe("pages routes", () => {
       expect(html.indexOf("Follow me")).toBeLessThan(html.indexOf("Recommended Sites"));
     });
 
-    it("shows articles and recommended sites in the feed sidebar", async () => {
+    it("shows articles below social media and above recommended sites in the feed sidebar", async () => {
       const app = getApp();
       const res = await app.request("/feed");
       const html = await res.text();
@@ -561,6 +583,8 @@ describe("pages routes", () => {
       expect(html).toContain("Explore Articles");
       expect(html).toContain('href="/sources"');
       expect(html).toContain("Recommended Sites");
+      expect(html.indexOf("Follow me")).toBeLessThan(html.indexOf("Articles"));
+      expect(html.indexOf("Articles")).toBeLessThan(html.indexOf("Recommended Sites"));
     });
 
     it("shows stored link previews in feed items", async () => {
@@ -1332,6 +1356,8 @@ describe("pages routes", () => {
       expect(html).toContain("Follow me");
       expect(html).toContain("Recommended Sites");
       expect(html).toContain("Explore sources");
+      expect(html.indexOf("Follow me")).toBeLessThan(html.indexOf("Articles"));
+      expect(html.indexOf("Articles")).toBeLessThan(html.indexOf("Recommended Sites"));
     });
   });
 

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -227,17 +227,20 @@ describe("pages routes", () => {
       expect(html).toContain("dark:border-gray-700");
     });
 
-    it("includes navigation links to Articles and Feed", async () => {
+    it("moves navigation links from header to footer", async () => {
       const app = getApp();
       const res = await app.request("/");
       const html = await res.text();
+      const header = html.match(/<header[\s\S]*?<\/header>/)?.[0] ?? "";
+      const footer = html.match(/<footer[\s\S]*?<\/footer>/)?.[0] ?? "";
 
-      expect(html).toContain('href="/articles"');
-      expect(html).toContain('href="/feed"');
-      // Sources removed from nav
-      expect(html).not.toContain('href="/sources"');
-      // About is linked from footer and Fediverse icon, but not in main nav
-      expect(html).toContain('href="/about"');
+      expect(header).not.toContain('href="/articles"');
+      expect(header).not.toContain('href="/feed"');
+      expect(header).not.toContain('href="/about"');
+      expect(footer).toContain('href="/articles"');
+      expect(footer).toContain('href="/feed"');
+      expect(footer).toContain('href="/about"');
+      expect(footer).not.toContain("Follow on the Fediverse");
     });
 
     it("displays Recent Articles section", async () => {
@@ -547,11 +550,15 @@ describe("pages routes", () => {
       expect(html.indexOf("Follow me")).toBeLessThan(html.indexOf("Recommended Sites"));
     });
 
-    it("links the feed sidebar to recommended sites", async () => {
+    it("shows articles and recommended sites in the feed sidebar", async () => {
       const app = getApp();
       const res = await app.request("/feed");
       const html = await res.text();
 
+      expect(html).toContain('href="/articles"');
+      expect(html).toContain("Articles");
+      expect(html).toContain("Read longer essays, project notes, and polished writing");
+      expect(html).toContain("Explore Articles");
       expect(html).toContain('href="/sources"');
       expect(html).toContain("Recommended Sites");
     });
@@ -767,7 +774,7 @@ describe("pages routes", () => {
 
       expect(html).toContain("dark:bg-gray-900");
       expect(html).toContain("dark:text-gray-100");
-      expect(html).toContain("dark:text-teal-400");
+      expect(html).toContain("dark:hover:text-teal-400");
     });
 
     it("shows an auto-submitting search form for recommended sites", async () => {
@@ -1072,7 +1079,7 @@ describe("pages routes", () => {
       const res = await app.request("/posts/test-post");
       const html = await res.text();
 
-      expect(html).toContain("dark:text-teal-400");
+      expect(html).toContain("dark:hover:text-teal-400");
       expect(html).toContain("dark:bg-gray-900");
       expect(html).toContain("dark:text-gray-300");
     });
@@ -1310,6 +1317,21 @@ describe("pages routes", () => {
       );
       expect(html).toContain("Followers");
       expect(html).toContain("Following");
+    });
+
+    it("shows feed sidebar sections on post pages", async () => {
+      const app = getApp();
+      const res = await app.request("/posts/test-post");
+
+      expect(res.status).toBe(200);
+
+      const html = await res.text();
+      expect(html).toContain("Articles");
+      expect(html).toContain("Read longer essays, project notes, and polished writing");
+      expect(html).toContain("Explore Articles");
+      expect(html).toContain("Follow me");
+      expect(html).toContain("Recommended Sites");
+      expect(html).toContain("Explore sources");
     });
   });
 

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -585,13 +585,17 @@ function HeroSection() {
       <div class="flex flex-col md:flex-row items-stretch gap-8">
         {/* Logo - shown first on mobile, second on desktop */}
         <div class="order-first md:order-last flex-shrink-0">
-          <div class="w-64 h-64 md:w-80 md:h-80 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700 border-4 border-gray-300 dark:border-gray-600 shadow-lg">
+          <a
+            href="/about"
+            class="block w-64 h-64 md:w-80 md:h-80 rounded-full overflow-hidden bg-gray-200 dark:bg-gray-700 border-4 border-gray-300 dark:border-gray-600 shadow-lg transition-transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-4 dark:focus:ring-offset-gray-800"
+            aria-label="About Erik Craddock"
+          >
             <img
               src="/images/erik-logo.png"
               alt="Erik Craddock"
               class="w-full h-full object-cover"
             />
-          </div>
+          </a>
         </div>
 
         {/* Bio and social links */}
@@ -627,6 +631,40 @@ function HeroSection() {
             </div>
           </div>
         </div>
+      </div>
+    </section>
+  );
+}
+
+function HomeFeedTeaser() {
+  return (
+    <section class="mb-12 rounded-lg bg-white p-6 shadow-md dark:bg-gray-800 sm:p-8">
+      <div class="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Latest updates
+          </p>
+          <h2 class="mt-2 text-2xl font-bold text-gray-900 dark:text-gray-100">
+            Notes, Links & Updates
+          </h2>
+          <p class="mt-2 max-w-2xl text-gray-600 dark:text-gray-400">
+            Browse the full feed for shorter notes, links worth sharing, and new articles.
+          </p>
+        </div>
+        <a
+          href="/feed"
+          class="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg bg-teal-600 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-teal-700 dark:bg-teal-500 dark:text-gray-950 dark:hover:bg-teal-400"
+        >
+          Open Feed
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        </a>
       </div>
     </section>
   );
@@ -734,7 +772,7 @@ function ArticleCardsSection({
 
   return (
     <section class="mb-12">
-      <h2 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">Recent Articles</h2>
+      <h2 class="mb-6 text-2xl font-bold text-gray-900 dark:text-gray-100">Recent Articles</h2>
 
       {/* Responsive grid: 1 col mobile, 2 tablet, 3 desktop */}
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -753,10 +791,10 @@ function ArticleCardsSection({
         <div class="mt-8 text-center">
           <a
             href="/articles"
-            class="inline-flex items-center gap-2 px-6 py-3 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-lg transition-colors"
+            class="inline-flex items-center gap-2 rounded-lg bg-teal-600 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-teal-700 dark:bg-teal-500 dark:text-gray-950 dark:hover:bg-teal-400"
           >
             More Articles
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -1511,6 +1549,7 @@ export function createPagesRoutes(db: Database): Hono {
     return c.html(
       <Layout title="Home | erikcraddock.me">
         <HeroSection />
+        <HomeFeedTeaser />
         <ArticleCardsSection
           articles={recentArticles}
           getBannerUrl={getBannerUrl}
@@ -1685,8 +1724,8 @@ export function createPagesRoutes(db: Database): Hono {
                 followingCount={followingCount}
                 postCount={totalPosts}
               />
-              <ArticlesFeedCard />
               <SocialMediaFeedCard />
+              <ArticlesFeedCard />
               <RecommendedSitesFeedCard />
             </aside>
             <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">
@@ -1786,8 +1825,8 @@ export function createPagesRoutes(db: Database): Hono {
               followingCount={followingCount}
               postCount={totalPosts}
             />
-            <ArticlesFeedCard />
             <SocialMediaFeedCard />
+            <ArticlesFeedCard />
             <RecommendedSitesFeedCard />
           </aside>
           <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">
@@ -2619,8 +2658,8 @@ export function createPagesRoutes(db: Database): Hono {
               followingCount={followingCount}
               postCount={totalPosts}
             />
-            <ArticlesFeedCard />
             <SocialMediaFeedCard />
+            <ArticlesFeedCard />
             <RecommendedSitesFeedCard />
           </aside>
           <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -982,6 +982,25 @@ function RecommendedSitesFeedCard() {
   );
 }
 
+function ArticlesFeedCard() {
+  return (
+    <a
+      href="/articles"
+      class="group block border-b border-gray-200 bg-white p-5 transition hover:border-teal-200 hover:bg-teal-50/50 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-teal-900/70 dark:hover:bg-teal-950/20 lg:mt-4 lg:rounded-2xl lg:border"
+    >
+      <h2 class="text-lg font-bold text-gray-950 group-hover:text-teal-700 dark:text-gray-50 dark:group-hover:text-teal-300">
+        Articles
+      </h2>
+      <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">
+        Read longer essays, project notes, and polished writing from the site archive.
+      </p>
+      <span class="mt-4 inline-flex text-sm font-semibold text-teal-700 dark:text-teal-300">
+        Explore Articles →
+      </span>
+    </a>
+  );
+}
+
 function FeedArticlePreview({
   post,
   bannerUrl,
@@ -1666,6 +1685,7 @@ export function createPagesRoutes(db: Database): Hono {
                 followingCount={followingCount}
                 postCount={totalPosts}
               />
+              <ArticlesFeedCard />
               <SocialMediaFeedCard />
               <RecommendedSitesFeedCard />
             </aside>
@@ -1766,6 +1786,7 @@ export function createPagesRoutes(db: Database): Hono {
               followingCount={followingCount}
               postCount={totalPosts}
             />
+            <ArticlesFeedCard />
             <SocialMediaFeedCard />
             <RecommendedSitesFeedCard />
           </aside>
@@ -2598,6 +2619,9 @@ export function createPagesRoutes(db: Database): Hono {
               followingCount={followingCount}
               postCount={totalPosts}
             />
+            <ArticlesFeedCard />
+            <SocialMediaFeedCard />
+            <RecommendedSitesFeedCard />
           </aside>
           <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">
             <header class="border-b border-gray-200 bg-white/90 px-4 py-4 backdrop-blur dark:border-gray-800 dark:bg-gray-900/90 sm:px-6">

--- a/src/templates/layout.tsx
+++ b/src/templates/layout.tsx
@@ -76,6 +76,14 @@ export function Layout({ title, children, ogImage, description, canonicalUrl }: 
               Erik Craddock
             </a>
             <div class="flex items-center gap-6">
+              <ThemeToggle />
+            </div>
+          </nav>
+        </header>
+        <main class="flex-1 max-w-6xl mx-auto px-4 py-8 w-full">{children}</main>
+        <footer class="bg-white border-t dark:bg-gray-800 dark:border-gray-700">
+          <div class="max-w-6xl mx-auto px-4 py-6 text-center text-gray-500 dark:text-gray-400 text-sm">
+            <nav aria-label="Footer navigation" class="mb-3 flex justify-center gap-6">
               <a
                 href="/articles"
                 class="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
@@ -94,22 +102,7 @@ export function Layout({ title, children, ogImage, description, canonicalUrl }: 
               >
                 About
               </a>
-              <ThemeToggle />
-            </div>
-          </nav>
-        </header>
-        <main class="flex-1 max-w-6xl mx-auto px-4 py-8 w-full">{children}</main>
-        <footer class="bg-white border-t dark:bg-gray-800 dark:border-gray-700">
-          <div class="max-w-6xl mx-auto px-4 py-6 text-center text-gray-500 dark:text-gray-400 text-sm">
-            <p class="mb-2">
-              Follow on the Fediverse:{" "}
-              <a
-                href="/about"
-                class="text-teal-600 hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300"
-              >
-                @erik@erikcraddock.me
-              </a>
-            </p>
+            </nav>
             <p>&copy; {new Date().getFullYear()} Erik Craddock</p>
           </div>
         </footer>


### PR DESCRIPTION
## Summary
- Move header navigation links into the footer and remove the Fediverse follow footer line
- Add an Articles sidebar card with descriptive text and Explore Articles link
- Add feed sidebar sections to post detail pages and place Articles below Follow me
- Add a home page Latest updates feed teaser, link the hero avatar to About, and align More Articles button styling with feed CTAs
- Update page tests for navigation, footer, sidebar ordering, home feed teaser, and avatar link changes

Task: task-f17e33cf

## Verification
- bun test src/routes/__tests__/pages.test.tsx
- npm run typecheck
- make check
- Pre-push checks
- CI Quality Checks
- Visual checks:
  - / header only shows site title and theme toggle; footer shows Articles, Feed, About with no follow line
  - / home page shows Latest updates card, Open Feed CTA, More Articles CTA styling, and avatar links to /about
  - /feed sidebar shows Follow me, Articles, and Recommended Sites in order
  - /posts/building-a-home-studio sidebar shows Follow me, Articles, and Recommended Sites in order
- make dev-tail 2>&1 | grep -E "(ERROR|WARN|error|Error)" || true