### PR TITLE
Support email social accounts

### DIFF
--- a/cli/src/commands/source/create.ts
+++ b/cli/src/commands/source/create.ts
@@ -2,15 +2,24 @@ import type { GlobalOptions } from "../../types";
 import { ApiClient } from "../../lib/api";
 import { loadConfig } from "../../lib/config";
 
+interface SocialAccountOption {
+  label: string;
+  url: string;
+  avatar_url?: string | null;
+  is_activitypub?: boolean;
+  is_default?: boolean;
+}
+
 interface CreateOptions {
   name?: string;
   url?: string;
   feedUrl?: string;
   authors: string[];
+  socialAccounts: SocialAccountOption[];
 }
 
 function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolean } {
-  const options: CreateOptions = { authors: [] };
+  const options: CreateOptions = { authors: [], socialAccounts: [] };
   let help = false;
 
   let i = 0;
@@ -35,12 +44,33 @@ function parseCreateArgs(args: string[]): { options: CreateOptions; help: boolea
       options.authors.push(args[++i]);
     } else if (arg.startsWith("--author=")) {
       options.authors.push(arg.split("=").slice(1).join("="));
+    } else if (arg === "--social" && args[i + 1]) {
+      const parsed = parseSocialAccount(args[++i]);
+      if (parsed) options.socialAccounts.push(parsed);
+    } else if (arg.startsWith("--social=")) {
+      const parsed = parseSocialAccount(arg.split("=").slice(1).join("="));
+      if (parsed) options.socialAccounts.push(parsed);
     }
 
     i++;
   }
 
   return { options, help };
+}
+
+function parseSocialAccount(input: string): SocialAccountOption | null {
+  const [label, url, ...flags] = input.split("|").map((part) => part.trim());
+  if (!label || !url) {
+    return null;
+  }
+
+  return {
+    label,
+    url,
+    avatar_url: flags.find((flag) => flag.startsWith("avatar="))?.slice("avatar=".length),
+    is_activitypub: flags.some((flag) => ["activitypub", "ap", "true"].includes(flag)),
+    is_default: flags.includes("default"),
+  };
 }
 
 function showCreateHelp(): void {
@@ -55,6 +85,7 @@ Required:
 Options:
   --feed-url <url>    RSS/Atom feed URL (optional)
   --author <name>     Source author name (can be repeated)
+  --social <account>  Social account as "label|url|activitypub|default|avatar=URL" (can be repeated)
   --json              Output as JSON
   --help, -h          Show this help message
 
@@ -62,6 +93,7 @@ Examples:
   ec source create --name "Hacker News" --url "https://news.ycombinator.com"
   ec source create --name "One Useful Thing" --url "https://www.oneusefulthing.org/" --author "Ethan Mollick" --feed-url "https://www.oneusefulthing.org/feed"
   ec source create --name "Team Blog" --url "https://example.com" --author "Alice" --author "Bob"
+  ec source create --name "Newsletter" --url "https://example.com" --social "Email|hello@example.com"
 `);
 }
 
@@ -100,6 +132,7 @@ export async function create(args: string[], globalOptions: GlobalOptions): Prom
     url: options.url,
     feed_url: options.feedUrl,
     authors: options.authors.map((name) => ({ name })),
+    social_accounts: options.socialAccounts,
   });
 
   if (result.error) {

--- a/cli/src/commands/source/edit.ts
+++ b/cli/src/commands/source/edit.ts
@@ -2,11 +2,20 @@ import type { GlobalOptions } from "../../types";
 import { ApiClient } from "../../lib/api";
 import { loadConfig } from "../../lib/config";
 
+interface SocialAccountOption {
+  label: string;
+  url: string;
+  avatar_url?: string | null;
+  is_activitypub?: boolean;
+  is_default?: boolean;
+}
+
 interface EditOptions {
   name?: string;
   url?: string;
   feedUrl?: string | null;
   authors?: string[];
+  socialAccounts?: SocialAccountOption[];
 }
 
 function parseEditArgs(args: string[]): { id: number | null; options: EditOptions; help: boolean } {
@@ -40,6 +49,14 @@ function parseEditArgs(args: string[]): { id: number | null; options: EditOption
       options.authors = [...(options.authors ?? []), arg.split("=").slice(1).join("=")];
     } else if (arg === "--no-authors") {
       options.authors = [];
+    } else if (arg === "--social" && args[i + 1]) {
+      const parsed = parseSocialAccount(args[++i]);
+      if (parsed) options.socialAccounts = [...(options.socialAccounts ?? []), parsed];
+    } else if (arg.startsWith("--social=")) {
+      const parsed = parseSocialAccount(arg.split("=").slice(1).join("="));
+      if (parsed) options.socialAccounts = [...(options.socialAccounts ?? []), parsed];
+    } else if (arg === "--no-socials") {
+      options.socialAccounts = [];
     } else if (!arg.startsWith("-") && id === null) {
       const parsed = parseInt(arg, 10);
       if (!isNaN(parsed)) {
@@ -51,6 +68,21 @@ function parseEditArgs(args: string[]): { id: number | null; options: EditOption
   }
 
   return { id, options, help };
+}
+
+function parseSocialAccount(input: string): SocialAccountOption | null {
+  const [label, url, ...flags] = input.split("|").map((part) => part.trim());
+  if (!label || !url) {
+    return null;
+  }
+
+  return {
+    label,
+    url,
+    avatar_url: flags.find((flag) => flag.startsWith("avatar="))?.slice("avatar=".length),
+    is_activitypub: flags.some((flag) => ["activitypub", "ap", "true"].includes(flag)),
+    is_default: flags.includes("default"),
+  };
 }
 
 function showEditHelp(): void {
@@ -68,6 +100,8 @@ Options:
   --no-feed-url       Remove feed URL
   --author <name>     Replace source authors (can be repeated)
   --no-authors        Remove all source authors
+  --social <account>  Replace social accounts with "label|url|activitypub|default|avatar=URL" entries
+  --no-socials        Remove all social accounts
   --json              Output as JSON
   --help, -h          Show this help message
 
@@ -77,8 +111,10 @@ Examples:
   ec source edit 1 --feed-url "https://hnrss.org/frontpage"
   ec source edit 1 --author "Paul Graham"
   ec source edit 1 --author "Alice" --author "Bob"
+  ec source edit 1 --social "Email|hello@example.com"
   ec source edit 1 --no-feed-url
   ec source edit 1 --no-authors
+  ec source edit 1 --no-socials
 `);
 }
 
@@ -101,12 +137,13 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     options.name !== undefined ||
     options.url !== undefined ||
     options.feedUrl !== undefined ||
-    options.authors !== undefined;
+    options.authors !== undefined ||
+    options.socialAccounts !== undefined;
 
   if (!hasUpdates) {
     console.error("❌ No update options provided.");
     console.error(
-      "Specify at least one of: --name, --url, --feed-url, --no-feed-url, --author, --no-authors"
+      "Specify at least one of: --name, --url, --feed-url, --no-feed-url, --author, --no-authors, --social, --no-socials"
     );
     process.exit(1);
   }
@@ -126,6 +163,7 @@ export async function edit(args: string[], globalOptions: GlobalOptions): Promis
     url: options.url,
     feed_url: options.feedUrl,
     authors: options.authors?.map((name) => ({ name })),
+    social_accounts: options.socialAccounts,
   });
 
   if (result.error) {

--- a/cli/src/commands/source/show.ts
+++ b/cli/src/commands/source/show.ts
@@ -49,6 +49,19 @@ function formatSource(source: Source): void {
   console.log(`URL:       ${source.url}`);
   console.log(`Authors:   ${formatAuthors(source)}`);
   console.log(`Feed URL:  ${source.feed_url || "-"}`);
+
+  if (source.social_accounts.length > 0) {
+    console.log("Socials:");
+    for (const account of source.social_accounts) {
+      const flags = [
+        account.is_activitypub ? "ActivityPub" : null,
+        account.is_default ? "default" : null,
+      ].filter(Boolean);
+      console.log(
+        `  - ${account.id}: ${account.label} ${account.url}${flags.length ? ` (${flags.join(", ")})` : ""}`
+      );
+    }
+  }
 }
 
 export async function show(args: string[], globalOptions: GlobalOptions): Promise<void> {

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -234,6 +234,13 @@ export class ApiClient {
     preview_site_name?: string | null;
     favicon_url?: string | null;
     authors?: Array<{ name: string }>;
+    social_accounts?: Array<{
+      label: string;
+      url: string;
+      avatar_url?: string | null;
+      is_activitypub?: boolean;
+      is_default?: boolean;
+    }>;
   }): Promise<ApiResponse<Source>> {
     return this.request<Source>("POST", "/sources", data);
   }
@@ -250,6 +257,13 @@ export class ApiClient {
       preview_site_name?: string | null;
       favicon_url?: string | null;
       authors?: Array<{ name: string }>;
+      social_accounts?: Array<{
+        label: string;
+        url: string;
+        avatar_url?: string | null;
+        is_activitypub?: boolean;
+        is_default?: boolean;
+      }>;
     }
   ): Promise<ApiResponse<Source>> {
     return this.request<Source>("PUT", `/sources/${id}`, data);

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -90,6 +90,17 @@ export interface SourceAuthor {
   sort_order: number;
 }
 
+export interface SourceSocialAccount {
+  id: number;
+  source_id: number;
+  label: string;
+  url: string;
+  avatar_url: string | null;
+  is_activitypub: boolean;
+  is_default: boolean;
+  sort_order: number;
+}
+
 export interface Source {
   id: number;
   name: string;
@@ -101,6 +112,7 @@ export interface Source {
   preview_site_name: string | null;
   favicon_url: string | null;
   authors: SourceAuthor[];
+  social_accounts: SourceSocialAccount[];
 }
 
 export interface TagWithCount {

--- a/drizzle/0012_productive_wallow.sql
+++ b/drizzle/0012_productive_wallow.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `source_social_accounts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`source_id` integer NOT NULL,
+	`label` text NOT NULL,
+	`url` text NOT NULL,
+	`avatar_url` text,
+	`is_activitypub` integer DEFAULT false NOT NULL,
+	`is_default` integer DEFAULT false NOT NULL,
+	`sort_order` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`source_id`) REFERENCES `sources`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1024 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "734bbc09-e886-43f3-8fa0-7221cb73e86d",
+  "prevId": "dbd464ad-58e9-479a-a1b6-7ba8551092f7",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "person_social_accounts": {
+      "name": "person_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_social_accounts_person_id_people_id_fk": {
+          "name": "person_social_accounts_person_id_people_id_fk",
+          "tableFrom": "person_social_accounts",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_social_accounts": {
+      "name": "source_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_social_accounts_source_id_sources_id_fk": {
+          "name": "source_social_accounts_source_id_sources_id_fk",
+          "tableFrom": "source_social_accounts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777228029862,
       "tag": "0011_tired_ken_ellis",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1777326641451,
+      "tag": "0012_productive_wallow",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -74,6 +74,19 @@ export const personSocialAccounts = sqliteTable("person_social_accounts", {
   sort_order: integer("sort_order").notNull().default(0),
 });
 
+export const sourceSocialAccounts = sqliteTable("source_social_accounts", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  source_id: integer("source_id")
+    .notNull()
+    .references(() => sources.id, { onDelete: "cascade" }),
+  label: text("label").notNull(),
+  url: text("url").notNull(),
+  avatar_url: text("avatar_url"),
+  is_activitypub: integer("is_activitypub", { mode: "boolean" }).notNull().default(false),
+  is_default: integer("is_default", { mode: "boolean" }).notNull().default(false),
+  sort_order: integer("sort_order").notNull().default(0),
+});
+
 export const sourceAuthors = sqliteTable("source_authors", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   source_id: integer("source_id")

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -6,6 +6,7 @@ import {
   posts,
   sources,
   sourceAuthors,
+  sourceSocialAccounts,
   people,
   personSocialAccounts,
   tags,
@@ -74,6 +75,7 @@ beforeEach(() => {
   testDb.delete(tags).run();
   testDb.delete(posts).run();
   testDb.delete(sourceAuthors).run();
+  testDb.delete(sourceSocialAccounts).run();
   testDb.delete(personSocialAccounts).run();
   testDb.delete(people).run();
   testDb.delete(sources).run();
@@ -930,6 +932,32 @@ describe("POST /api/sources", () => {
     expect(persistedPeople.map((person) => person.name)).toEqual(["Alice", "Bob"]);
   });
 
+  it("creates source with email social account", async () => {
+    const res = await api.request("/sources", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Email Source",
+        url: "https://email.example.com",
+        social_accounts: [{ label: "Email", url: "hello@example.com" }],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.data.social_accounts).toMatchObject([
+      { label: "Email", url: "mailto:hello@example.com", is_activitypub: false },
+    ]);
+    expect(json.data.social_accounts[0].source_id).toBe(json.data.id);
+
+    const persistedAccounts = testDb
+      .select()
+      .from(sourceSocialAccounts)
+      .where(eq(sourceSocialAccounts.source_id, json.data.id))
+      .all();
+    expect(persistedAccounts).toHaveLength(1);
+  });
+
   it("creates source without authors", async () => {
     const res = await api.request("/sources", {
       method: "POST",
@@ -1079,6 +1107,38 @@ describe("PUT /api/sources/:id", () => {
     expect(json.data.authors.map((author: { name: string }) => author.name)).toEqual([
       "Alice",
       "Bob",
+    ]);
+  });
+
+  it("replaces source social accounts when editing", async () => {
+    const source = testDb
+      .insert(sources)
+      .values({ name: "Test", url: "https://example.com" })
+      .returning()
+      .get();
+    testDb
+      .insert(sourceSocialAccounts)
+      .values({
+        source_id: source.id,
+        label: "Old Account",
+        url: "https://old.example.com",
+        is_activitypub: false,
+        sort_order: 0,
+      })
+      .run();
+
+    const res = await api.request(`/sources/${source.id}`, {
+      method: "PUT",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        social_accounts: [{ label: "Email", url: "mailto:new@example.com" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.data.social_accounts).toMatchObject([
+      { label: "Email", url: "mailto:new@example.com", is_activitypub: false },
     ]);
   });
 
@@ -1415,6 +1475,23 @@ describe("/api/people", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.default_social_account).toMatchObject({ label: "Bluesky", is_default: true });
+  });
+
+  it("creates a person with an email social account as mailto link", async () => {
+    const createRes = await api.request("/people", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Email Person",
+        social_accounts: [{ label: "Email", url: "person@example.com" }],
+      }),
+    });
+
+    expect(createRes.status).toBe(201);
+    const created = await createRes.json();
+    expect(created.data.social_accounts).toMatchObject([
+      { label: "Email", url: "mailto:person@example.com", is_activitypub: false },
+    ]);
   });
 
   it("replaces person social accounts when editing", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -16,6 +16,7 @@ import {
   postTags,
   sources,
   sourceAuthors,
+  sourceSocialAccounts,
   people,
   personSocialAccounts,
   media,
@@ -170,6 +171,26 @@ testDb
       url: "https://github.com/testauthor",
       is_activitypub: false,
       sort_order: 1,
+    },
+    {
+      person_id: 1,
+      label: "Email",
+      url: "mailto:testauthor@example.com",
+      is_activitypub: false,
+      sort_order: 2,
+    },
+  ])
+  .run();
+
+testDb
+  .insert(sourceSocialAccounts)
+  .values([
+    {
+      source_id: 1,
+      label: "Email",
+      url: "mailto:hello@example.com",
+      is_activitypub: false,
+      sort_order: 0,
     },
   ])
   .run();
@@ -948,6 +969,8 @@ describe("pages routes", () => {
       expect(html).toContain("ActivityPub");
       expect(html).toContain('href="https://github.com/testauthor"');
       expect(html).toContain("GitHub");
+      expect(html).toContain('href="mailto:testauthor@example.com"');
+      expect(html).toContain("Email");
     });
 
     it("uses the effective default social account for avatar and follow button", async () => {
@@ -1018,6 +1041,9 @@ describe("pages routes", () => {
       expect(html).toContain("by Test Author");
       expect(html).toContain('href="/people/1"');
       expect(html).toContain('src="https://example.com/favicon.ico"');
+      expect(html).toContain("Follow Test Blog");
+      expect(html).toContain('href="mailto:hello@example.com"');
+      expect(html).toContain('aria-label="Email"');
     });
 
     it("links the selected source card title and URL to the source website", async () => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -25,6 +25,7 @@ import {
   updateSource,
   deleteSource,
   type SourceAuthorInput,
+  type SourceSocialAccountInput,
 } from "@/services/sources";
 import { listTags } from "@/services/tags";
 import {
@@ -112,18 +113,23 @@ const PersonSummarySchema = z
   })
   .openapi("PersonSummary");
 
-const PersonSocialAccountSchema = z
-  .object({
-    id: z.number().int().openapi({ example: 1 }),
-    person_id: z.number().int().openapi({ example: 1 }),
-    label: z.string().openapi({ example: "Mastodon" }),
-    url: z.string().url().openapi({ example: "https://mastodon.social/@example" }),
-    avatar_url: NullableStringSchema.openapi({ example: "https://example.social/avatar.jpg" }),
-    is_activitypub: z.boolean().openapi({ example: true }),
-    is_default: z.boolean().openapi({ example: true }),
-    sort_order: z.number().int().openapi({ example: 0 }),
-  })
-  .openapi("PersonSocialAccount");
+const SocialAccountFieldsSchema = z.object({
+  id: z.number().int().openapi({ example: 1 }),
+  label: z.string().openapi({ example: "Mastodon" }),
+  url: z.string().openapi({ example: "https://mastodon.social/@example" }),
+  avatar_url: NullableStringSchema.openapi({ example: "https://example.social/avatar.jpg" }),
+  is_activitypub: z.boolean().openapi({ example: true }),
+  is_default: z.boolean().openapi({ example: true }),
+  sort_order: z.number().int().openapi({ example: 0 }),
+});
+
+const PersonSocialAccountSchema = SocialAccountFieldsSchema.extend({
+  person_id: z.number().int().openapi({ example: 1 }),
+}).openapi("PersonSocialAccount");
+
+const SourceSocialAccountSchema = SocialAccountFieldsSchema.extend({
+  source_id: z.number().int().openapi({ example: 1 }),
+}).openapi("SourceSocialAccount");
 
 const PersonSchema = PersonSummarySchema.extend({
   social_accounts: z.array(PersonSocialAccountSchema),
@@ -155,6 +161,7 @@ const SourceSummarySchema = z
 
 const SourceSchema = SourceSummarySchema.extend({
   feed_url: NullableStringSchema,
+  social_accounts: z.array(SourceSocialAccountSchema),
 }).openapi("Source");
 
 const TagSchema = z
@@ -304,27 +311,7 @@ const SourceMetadataBodySchema = {
   favicon_url: z.string().optional().nullable(),
 };
 
-const CreateSourceBodySchema = z
-  .object({
-    name: z.string().openapi({ example: "Hacker News" }),
-    url: z.string().openapi({ example: "https://news.ycombinator.com" }),
-    feed_url: z.string().optional().nullable().openapi({ example: "https://hnrss.org/frontpage" }),
-    authors: z.array(SourceAuthorInputSchema).optional().nullable(),
-    ...SourceMetadataBodySchema,
-  })
-  .openapi("CreateSourceBody");
-
-const UpdateSourceBodySchema = z
-  .object({
-    name: z.string().optional().nullable(),
-    url: z.string().optional().nullable(),
-    feed_url: z.string().optional().nullable(),
-    authors: z.array(SourceAuthorInputSchema).optional().nullable(),
-    ...SourceMetadataBodySchema,
-  })
-  .openapi("UpdateSourceBody");
-
-const PersonSocialAccountInputSchema = z.object({
+const SocialAccountInputSchema = z.object({
   label: z.string().openapi({ example: "Mastodon" }),
   url: z.string().openapi({ example: "https://mastodon.social/@example" }),
   avatar_url: z
@@ -336,11 +323,33 @@ const PersonSocialAccountInputSchema = z.object({
   is_default: z.boolean().optional().openapi({ example: true }),
 });
 
+const CreateSourceBodySchema = z
+  .object({
+    name: z.string().openapi({ example: "Hacker News" }),
+    url: z.string().openapi({ example: "https://news.ycombinator.com" }),
+    feed_url: z.string().optional().nullable().openapi({ example: "https://hnrss.org/frontpage" }),
+    authors: z.array(SourceAuthorInputSchema).optional().nullable(),
+    social_accounts: z.array(SocialAccountInputSchema).optional().nullable(),
+    ...SourceMetadataBodySchema,
+  })
+  .openapi("CreateSourceBody");
+
+const UpdateSourceBodySchema = z
+  .object({
+    name: z.string().optional().nullable(),
+    url: z.string().optional().nullable(),
+    feed_url: z.string().optional().nullable(),
+    authors: z.array(SourceAuthorInputSchema).optional().nullable(),
+    social_accounts: z.array(SocialAccountInputSchema).optional().nullable(),
+    ...SourceMetadataBodySchema,
+  })
+  .openapi("UpdateSourceBody");
+
 const CreatePersonBodySchema = z
   .object({
     name: z.string().openapi({ example: "Ethan Mollick" }),
     url: z.string().optional().nullable().openapi({ example: "https://example.com" }),
-    social_accounts: z.array(PersonSocialAccountInputSchema).optional().nullable(),
+    social_accounts: z.array(SocialAccountInputSchema).optional().nullable(),
   })
   .openapi("CreatePersonBody");
 
@@ -348,7 +357,7 @@ const UpdatePersonBodySchema = z
   .object({
     name: z.string().optional().nullable().openapi({ example: "Ethan Mollick" }),
     url: z.string().optional().nullable().openapi({ example: "https://example.com" }),
-    social_accounts: z.array(PersonSocialAccountInputSchema).optional().nullable(),
+    social_accounts: z.array(SocialAccountInputSchema).optional().nullable(),
     default_social_account_id: z.number().int().optional().nullable(),
   })
   .openapi("UpdatePersonBody");
@@ -361,9 +370,22 @@ function parseNullableString(input: unknown): string | null | undefined {
   return typeof input === "string" ? input.trim() || null : null;
 }
 
-function parsePersonSocialAccounts(
+function normalizeSocialAccountUrl(label: string, url: string): string {
+  if (label.trim().toLowerCase() !== "email") {
+    return url.trim();
+  }
+
+  const trimmedUrl = url.trim();
+  if (trimmedUrl.toLowerCase().startsWith("mailto:")) {
+    return trimmedUrl;
+  }
+
+  return `mailto:${trimmedUrl}`;
+}
+
+function parseSocialAccounts<T extends PersonSocialAccountInput | SourceSocialAccountInput>(
   input: unknown
-): PersonSocialAccountInput[] | string | undefined {
+): T[] | string | undefined {
   if (input === undefined) {
     return undefined;
   }
@@ -376,7 +398,7 @@ function parsePersonSocialAccounts(
     return "Social accounts must be an array";
   }
 
-  const accounts: PersonSocialAccountInput[] = [];
+  const accounts: T[] = [];
 
   for (const [index, account] of input.entries()) {
     if (!account || typeof account !== "object") {
@@ -408,16 +430,29 @@ function parsePersonSocialAccounts(
       return `Social account at index ${index} has invalid default flag`;
     }
 
+    const label = candidate.label.trim();
     accounts.push({
-      label: candidate.label.trim(),
-      url: candidate.url.trim(),
+      label,
+      url: normalizeSocialAccountUrl(label, candidate.url),
       avatar_url: parseNullableString(candidate.avatar_url) ?? null,
       is_activitypub: candidate.is_activitypub ?? false,
       is_default: candidate.is_default ?? false,
-    });
+    } as T);
   }
 
   return accounts;
+}
+
+function parsePersonSocialAccounts(
+  input: unknown
+): PersonSocialAccountInput[] | string | undefined {
+  return parseSocialAccounts<PersonSocialAccountInput>(input);
+}
+
+function parseSourceSocialAccounts(
+  input: unknown
+): SourceSocialAccountInput[] | string | undefined {
+  return parseSocialAccounts<SourceSocialAccountInput>(input);
 }
 
 function parseSourceAuthors(input: unknown): SourceAuthorInput[] | string | undefined {
@@ -1785,6 +1820,7 @@ registerProtectedRoute(
       preview_image_url,
       preview_site_name,
       favicon_url,
+      social_accounts,
     } = body;
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
@@ -1800,6 +1836,11 @@ registerProtectedRoute(
       return c.json({ error: parsedAuthors }, 400);
     }
 
+    const parsedSocialAccounts = parseSourceSocialAccounts(social_accounts);
+    if (typeof parsedSocialAccounts === "string") {
+      return c.json({ error: parsedSocialAccounts }, 400);
+    }
+
     try {
       const sourceUrl = url.trim();
       const fetchedPreview = await getSourcePreviewData(sourceUrl);
@@ -1808,6 +1849,7 @@ registerProtectedRoute(
         url: sourceUrl,
         feed_url: feed_url?.trim() || null,
         authors: parsedAuthors,
+        social_accounts: parsedSocialAccounts,
         preview_title: parseNullableString(preview_title) ?? fetchedPreview?.preview_title ?? null,
         preview_description:
           parseNullableString(preview_description) ?? fetchedPreview?.preview_description ?? null,
@@ -1878,6 +1920,7 @@ registerProtectedRoute(
       preview_image_url,
       preview_site_name,
       favicon_url,
+      social_accounts,
     } = body;
 
     if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
@@ -1893,6 +1936,11 @@ registerProtectedRoute(
       return c.json({ error: parsedAuthors }, 400);
     }
 
+    const parsedSocialAccounts = parseSourceSocialAccounts(social_accounts);
+    if (typeof parsedSocialAccounts === "string") {
+      return c.json({ error: parsedSocialAccounts }, 400);
+    }
+
     try {
       const existingSource = getSource(id);
       const sourceUrl = url?.trim() || existingSource?.url;
@@ -1903,6 +1951,7 @@ registerProtectedRoute(
         url: url?.trim(),
         feed_url: feed_url !== undefined ? feed_url?.trim() || null : undefined,
         authors: parsedAuthors,
+        social_accounts: parsedSocialAccounts,
         preview_title:
           preview_title !== undefined
             ? parseNullableString(preview_title)

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -8,6 +8,7 @@ import {
   postTags,
   sources,
   sourceAuthors,
+  sourceSocialAccounts,
   people,
   personSocialAccounts,
   media,
@@ -32,13 +33,21 @@ type Post = typeof posts.$inferSelect;
 type Source = typeof sources.$inferSelect;
 type Person = typeof people.$inferSelect;
 type PersonSocialAccount = typeof personSocialAccounts.$inferSelect;
+type SourceSocialAccount = typeof sourceSocialAccounts.$inferSelect;
+type SocialAccount = Pick<
+  PersonSocialAccount | SourceSocialAccount,
+  "id" | "label" | "url" | "avatar_url" | "is_activitypub" | "is_default"
+>;
 type SourceAuthor = {
   id: number;
   name: string;
   url: string | null;
   sort_order: number;
 };
-type SourceWithAuthors = Source & { authors: SourceAuthor[] };
+type SourceWithAuthors = Source & {
+  authors: SourceAuthor[];
+  social_accounts: SourceSocialAccount[];
+};
 type Tag = { id: number; name: string; slug: string };
 type PostWithSource = Post & { source?: Source | null; author?: Person | null };
 
@@ -172,7 +181,7 @@ function PersonCard({
   person: Person;
   titleLink?: "detail" | "website";
   authoredSources?: Source[];
-  socialAccounts?: PersonSocialAccount[];
+  socialAccounts?: SocialAccount[];
   showSocialAccounts?: boolean;
   showFollowButton?: boolean;
 }) {
@@ -345,6 +354,29 @@ function SourceCard({
         </p>
       ) : null}
 
+      {source.social_accounts.length > 0 ? (
+        <div class="mt-4 border-t border-gray-200 pt-4 dark:border-gray-800">
+          <h3 class="text-sm font-semibold text-gray-950 dark:text-gray-50">
+            Follow {source.name}
+          </h3>
+          <div class="mt-3 grid grid-cols-4 gap-2">
+            {source.social_accounts.map((account) => (
+              <a
+                key={account.id}
+                href={account.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`${account.label}${account.is_activitypub ? " (ActivityPub)" : ""}`}
+                title={`${account.label}${account.is_activitypub ? " (ActivityPub)" : ""}`}
+                class="relative flex aspect-square items-center justify-center rounded-xl border border-gray-200 text-sm font-semibold text-gray-600 transition hover:border-teal-200 hover:bg-teal-50 hover:text-teal-700 dark:border-gray-800 dark:text-gray-400 dark:hover:border-teal-900/70 dark:hover:bg-teal-950/20 dark:hover:text-teal-300"
+              >
+                {getSocialAccountIcon(account)}
+              </a>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
       {source.feed_url ? (
         <div class="mt-auto pt-5 text-sm font-medium">
           <a
@@ -480,6 +512,30 @@ function TwitterIcon() {
   );
 }
 
+function EmailIcon() {
+  return (
+    <svg
+      class="w-6 h-6"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M3 8l7.89 5.26a2 2 0 0 0 2.22 0L21 8"
+      />
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M5 19h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2Z"
+      />
+    </svg>
+  );
+}
+
 function SubstackIcon() {
   return (
     <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -540,7 +596,7 @@ const SOCIAL_LINKS = [
   { name: "RSS", url: "/feed.xml", icon: <RssIcon /> },
 ];
 
-function getSocialAccountIcon(account: PersonSocialAccount) {
+function getSocialAccountIcon(account: SocialAccount) {
   switch (account.label.trim().toLowerCase()) {
     case "github":
       return <GitHubIcon />;
@@ -552,6 +608,8 @@ function getSocialAccountIcon(account: PersonSocialAccount) {
       return <YouTubeIcon />;
     case "rss":
       return <RssIcon />;
+    case "email":
+      return <EmailIcon />;
     case "mastodon":
       return <MastodonIcon />;
     case "bluesky":
@@ -1426,6 +1484,15 @@ function getSourceAuthors(db: Database, sourceId: number): SourceAuthor[] {
     .all();
 }
 
+function getSourceSocialAccounts(db: Database, sourceId: number): SourceSocialAccount[] {
+  return db
+    .select()
+    .from(sourceSocialAccounts)
+    .where(eq(sourceSocialAccounts.source_id, sourceId))
+    .orderBy(asc(sourceSocialAccounts.sort_order), asc(sourceSocialAccounts.id))
+    .all();
+}
+
 function getSourceWithAuthors(db: Database, sourceId: number): SourceWithAuthors | null {
   const source = db.select().from(sources).where(eq(sources.id, sourceId)).get();
 
@@ -1436,6 +1503,7 @@ function getSourceWithAuthors(db: Database, sourceId: number): SourceWithAuthors
   return {
     ...source,
     authors: getSourceAuthors(db, source.id),
+    social_accounts: getSourceSocialAccounts(db, source.id),
   };
 }
 
@@ -2204,9 +2272,22 @@ export function createPagesRoutes(db: Database): Hono {
       authorsBySourceId.set(author.sourceId, existing);
     }
 
+    const sourceSocialAccountRows = db
+      .select()
+      .from(sourceSocialAccounts)
+      .orderBy(asc(sourceSocialAccounts.sort_order), asc(sourceSocialAccounts.id))
+      .all();
+    const socialAccountsBySourceId = new Map<number, SourceSocialAccount[]>();
+    for (const account of sourceSocialAccountRows) {
+      const existing = socialAccountsBySourceId.get(account.source_id) ?? [];
+      existing.push(account);
+      socialAccountsBySourceId.set(account.source_id, existing);
+    }
+
     const allSources: SourceWithAuthors[] = allSourceRows.map((source) => ({
       ...source,
       authors: authorsBySourceId.get(source.id) ?? [],
+      social_accounts: socialAccountsBySourceId.get(source.id) ?? [],
     }));
     const filteredSources = searchQuery
       ? allSources.filter((source) => sourceMatchesSearch(source, searchQuery))

--- a/src/services/sources.ts
+++ b/src/services/sources.ts
@@ -1,10 +1,21 @@
 import { asc, eq } from "drizzle-orm";
-import { db, people, sourceAuthors, sources } from "@/db";
+import { db, people, sourceAuthors, sourceSocialAccounts, sources } from "@/db";
 
 export interface SourceAuthor {
   id: number;
   name: string;
   url: string | null;
+  sort_order: number;
+}
+
+export interface SourceSocialAccount {
+  id: number;
+  source_id: number;
+  label: string;
+  url: string;
+  avatar_url: string | null;
+  is_activitypub: boolean;
+  is_default: boolean;
   sort_order: number;
 }
 
@@ -19,11 +30,20 @@ export interface Source {
   preview_site_name: string | null;
   favicon_url: string | null;
   authors: SourceAuthor[];
+  social_accounts: SourceSocialAccount[];
 }
 
 export interface SourceAuthorInput {
   name: string;
   url?: string | null;
+}
+
+export interface SourceSocialAccountInput {
+  label: string;
+  url: string;
+  avatar_url?: string | null;
+  is_activitypub?: boolean;
+  is_default?: boolean;
 }
 
 type SourceRecord = typeof sources.$inferSelect;
@@ -43,8 +63,21 @@ function listAuthorsForSource(sourceId: number): SourceAuthor[] {
     .all();
 }
 
-function attachAuthors(source: SourceRecord): Source {
-  return { ...source, authors: listAuthorsForSource(source.id) };
+function listSocialAccountsForSource(sourceId: number): SourceSocialAccount[] {
+  return db
+    .select()
+    .from(sourceSocialAccounts)
+    .where(eq(sourceSocialAccounts.source_id, sourceId))
+    .orderBy(asc(sourceSocialAccounts.sort_order), asc(sourceSocialAccounts.id))
+    .all();
+}
+
+function attachSourceDetails(source: SourceRecord): Source {
+  return {
+    ...source,
+    authors: listAuthorsForSource(source.id),
+    social_accounts: listSocialAccountsForSource(source.id),
+  };
 }
 
 function getOrCreatePerson(author: SourceAuthorInput): number {
@@ -83,15 +116,35 @@ function replaceSourceAuthors(sourceId: number, authors: SourceAuthorInput[]): v
     .run();
 }
 
+function replaceSourceSocialAccounts(sourceId: number, accounts: SourceSocialAccountInput[]): void {
+  db.delete(sourceSocialAccounts).where(eq(sourceSocialAccounts.source_id, sourceId)).run();
+
+  if (accounts.length === 0) {
+    return;
+  }
+
+  const defaultIndex = accounts.findIndex((account) => account.is_default);
+
+  db.insert(sourceSocialAccounts)
+    .values(
+      accounts.map((account, index) => ({
+        source_id: sourceId,
+        label: account.label,
+        url: account.url,
+        avatar_url: account.avatar_url ?? null,
+        is_activitypub: account.is_activitypub ?? false,
+        is_default: defaultIndex === index,
+        sort_order: index,
+      }))
+    )
+    .run();
+}
+
 /**
  * List all sources
  */
 export function listSources(): Source[] {
-  return db
-    .select()
-    .from(sources)
-    .all()
-    .map((source) => attachAuthors(source));
+  return db.select().from(sources).all().map(attachSourceDetails);
 }
 
 /**
@@ -99,7 +152,7 @@ export function listSources(): Source[] {
  */
 export function getSource(id: number): Source | null {
   const source = db.select().from(sources).where(eq(sources.id, id)).get();
-  return source ? attachAuthors(source) : null;
+  return source ? attachSourceDetails(source) : null;
 }
 
 export interface SourceMetadataInput {
@@ -115,6 +168,7 @@ export interface CreateSourceInput extends SourceMetadataInput {
   url: string;
   feed_url?: string | null;
   authors?: SourceAuthorInput[];
+  social_accounts?: SourceSocialAccountInput[];
 }
 
 /**
@@ -126,6 +180,7 @@ export function createSource(input: CreateSourceInput): Source {
     url,
     feed_url,
     authors,
+    social_accounts,
     preview_title,
     preview_description,
     preview_image_url,
@@ -149,8 +204,9 @@ export function createSource(input: CreateSourceInput): Source {
     .get();
 
   replaceSourceAuthors(source.id, authors ?? []);
+  replaceSourceSocialAccounts(source.id, social_accounts ?? []);
 
-  return attachAuthors(source);
+  return attachSourceDetails(source);
 }
 
 export interface UpdateSourceInput extends SourceMetadataInput {
@@ -158,6 +214,7 @@ export interface UpdateSourceInput extends SourceMetadataInput {
   url?: string;
   feed_url?: string | null;
   authors?: SourceAuthorInput[];
+  social_accounts?: SourceSocialAccountInput[];
 }
 
 /**
@@ -211,6 +268,10 @@ export function updateSource(id: number, input: UpdateSourceInput): Source | nul
 
   if (input.authors !== undefined) {
     replaceSourceAuthors(id, input.authors);
+  }
+
+  if (input.social_accounts !== undefined) {
+    replaceSourceSocialAccounts(id, input.social_accounts);
   }
 
   return getSource(id);


### PR DESCRIPTION
## Summary
- add source social account storage/API/CLI support alongside existing person social accounts
- normalize Email social account values to mailto: links for people and sources
- render email social accounts with a dedicated email icon on person/source cards

## Verification
- npm run typecheck
- make check
- pre-push hook passed (lint, typecheck, tests, migration check)
- visual check: opened http://localhost:5000/sources in browser and captured /home/erik/.cache/tmp/screenshot-2026-04-27T21-53-27-664Z.png

Task: #task-64758cbc