### PR TITLE
Add ActivityPub profile metadata fields

### DIFF
--- a/src/federation/__tests__/actor-profile.test.ts
+++ b/src/federation/__tests__/actor-profile.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+import {
+  CryptographicKey,
+  generateCryptoKeyPair,
+  Multikey,
+  type ActorKeyPair,
+} from "@fedify/fedify";
+import {
+  buildActorMetadata,
+  buildActorProfile,
+  buildActorUpdateActivity,
+  type ActorProfileUris,
+} from "../actor-profile";
+
+const origin = "https://erikcraddock.me";
+const actorUri = new URL("/users/erik", origin);
+const uris: ActorProfileUris = {
+  actor: actorUri,
+  inbox: new URL("/users/erik/inbox", origin),
+  outbox: new URL("/users/erik/outbox", origin),
+  followers: new URL("/users/erik/followers", origin),
+  sharedInbox: new URL("/inbox", origin),
+};
+
+async function createTestActorKeyPair(): Promise<ActorKeyPair> {
+  const keyPair = await generateCryptoKeyPair("RSASSA-PKCS1-v1_5");
+  const keyId = new URL("/users/erik#main-key", origin);
+
+  return {
+    ...keyPair,
+    keyId,
+    cryptographicKey: new CryptographicKey({
+      id: keyId,
+      owner: actorUri,
+      publicKey: keyPair.publicKey,
+    }),
+    multikey: new Multikey({
+      id: new URL("/users/erik#main-key-multikey", origin),
+      controller: actorUri,
+      publicKey: keyPair.publicKey,
+    }),
+  };
+}
+
+function getAttachments(json: Record<string, unknown>): Record<string, unknown>[] {
+  const attachment = json.attachment;
+  if (!attachment) {
+    return [];
+  }
+
+  return Array.isArray(attachment)
+    ? (attachment as Record<string, unknown>[])
+    : [attachment as Record<string, unknown>];
+}
+
+function attachmentMap(json: Record<string, unknown>): Map<string, Record<string, unknown>> {
+  return new Map(getAttachments(json).map((attachment) => [String(attachment.name), attachment]));
+}
+
+describe("actor profile metadata", () => {
+  it("builds Mastodon-compatible PropertyValue profile fields", async () => {
+    const metadata = buildActorMetadata(origin);
+
+    expect(metadata).toHaveLength(4);
+
+    const json = await Promise.all(
+      metadata.map((propertyValue) => propertyValue.toJsonLd() as Promise<Record<string, unknown>>)
+    );
+
+    expect(json[0]).toMatchObject({
+      type: "PropertyValue",
+      name: "Website",
+      value: '<a href="https://erikcraddock.me/" rel="me">erikcraddock.me</a>',
+    });
+    expect(json[1]).toMatchObject({
+      type: "PropertyValue",
+      name: "GitHub",
+      value: '<a href="https://github.com/evcraddock" rel="me">github.com/evcraddock</a>',
+    });
+    expect(JSON.stringify(json[0]["@context"])).toContain("schema");
+    expect(JSON.stringify(json[0]["@context"])).toContain("PropertyValue");
+  });
+
+  it("includes profile metadata attachments without regressing actor URLs or keys", async () => {
+    const keys = [await createTestActorKeyPair()];
+    const actor = buildActorProfile({ identifier: "erik", canonicalOrigin: origin, uris, keys });
+    const json = (await actor.toJsonLd()) as Record<string, unknown>;
+    const attachments = attachmentMap(json);
+
+    expect(json).toMatchObject({
+      type: "Person",
+      id: "https://erikcraddock.me/users/erik",
+      preferredUsername: "erik",
+      name: "Erik Craddock",
+      inbox: "https://erikcraddock.me/users/erik/inbox",
+      outbox: "https://erikcraddock.me/users/erik/outbox",
+      followers: "https://erikcraddock.me/users/erik/followers",
+      url: "https://erikcraddock.me/",
+    });
+    expect(json.publicKey).toBeDefined();
+    expect(json.assertionMethod).toBeDefined();
+    expect(attachments.get("Website")).toMatchObject({ type: "PropertyValue" });
+    expect(attachments.get("GitHub")?.value).toBe(
+      '<a href="https://github.com/evcraddock" rel="me">github.com/evcraddock</a>'
+    );
+    expect(attachments.get("LinkedIn")?.type).toBe("PropertyValue");
+    expect(attachments.get("YouTube")?.type).toBe("PropertyValue");
+  });
+
+  it("uses the same metadata for actor Update activities as the actor profile", async () => {
+    const keys = [await createTestActorKeyPair()];
+    const actor = buildActorProfile({ identifier: "erik", canonicalOrigin: origin, uris, keys });
+    const update = buildActorUpdateActivity({
+      identifier: "erik",
+      canonicalOrigin: origin,
+      uris,
+      keys,
+      activityId: new URL("/users/erik#update-test", origin),
+    });
+
+    const actorJson = (await actor.toJsonLd()) as Record<string, unknown>;
+    const updateJson = (await update.toJsonLd()) as Record<string, unknown>;
+    const updateObject = updateJson.object as Record<string, unknown>;
+
+    expect(updateJson).toMatchObject({
+      type: "Update",
+      id: "https://erikcraddock.me/users/erik#update-test",
+      actor: "https://erikcraddock.me/users/erik",
+    });
+    expect(attachmentMap(updateObject)).toEqual(attachmentMap(actorJson));
+  });
+});

--- a/src/federation/actor-profile.ts
+++ b/src/federation/actor-profile.ts
@@ -1,0 +1,99 @@
+import { Endpoints, Image, Person, PropertyValue, Update, type ActorKeyPair } from "@fedify/fedify";
+
+const ACTOR_NAME = "Erik Craddock";
+const ACTOR_SUMMARY = "Writer, coder, and musician — not always in that order.";
+
+interface ActorProfileField {
+  name: string;
+  href: string;
+  text: string;
+}
+
+const PUBLIC_PROFILE_FIELDS: ActorProfileField[] = [
+  { name: "Website", href: "/", text: "erikcraddock.me" },
+  { name: "GitHub", href: "https://github.com/evcraddock", text: "github.com/evcraddock" },
+  {
+    name: "LinkedIn",
+    href: "https://www.linkedin.com/in/erik-craddock-42aa9815",
+    text: "linkedin.com/in/erik-craddock-42aa9815",
+  },
+  { name: "YouTube", href: "https://youtube.com/@ErikCraddock", text: "youtube.com/@ErikCraddock" },
+];
+
+export interface ActorProfileUris {
+  actor: URL;
+  inbox: URL;
+  outbox: URL;
+  followers: URL;
+  sharedInbox: URL;
+}
+
+export interface BuildActorProfileOptions {
+  identifier: string;
+  canonicalOrigin: string | URL;
+  uris: ActorProfileUris;
+  keys: ActorKeyPair[];
+}
+
+export interface BuildActorUpdateOptions extends BuildActorProfileOptions {
+  activityId: URL;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function resolveProfileFieldUrl(field: ActorProfileField, canonicalOrigin: string | URL): URL {
+  return new URL(field.href, canonicalOrigin);
+}
+
+function profileFieldToHtml(field: ActorProfileField, canonicalOrigin: string | URL): string {
+  const href = resolveProfileFieldUrl(field, canonicalOrigin).toString();
+  return `<a href="${escapeHtml(href)}" rel="me">${escapeHtml(field.text)}</a>`;
+}
+
+export function buildActorMetadata(canonicalOrigin: string | URL): PropertyValue[] {
+  return PUBLIC_PROFILE_FIELDS.map(
+    (field) =>
+      new PropertyValue({
+        name: field.name,
+        value: profileFieldToHtml(field, canonicalOrigin),
+      })
+  );
+}
+
+export function buildActorProfile(options: BuildActorProfileOptions): Person {
+  const { identifier, canonicalOrigin, uris, keys } = options;
+  const iconUrl = new URL("/images/erik-logo.png", canonicalOrigin);
+  const bannerUrl = new URL("/images/banner.png", canonicalOrigin);
+
+  return new Person({
+    id: uris.actor,
+    preferredUsername: identifier,
+    name: ACTOR_NAME,
+    summary: ACTOR_SUMMARY,
+    icon: new Image({ url: iconUrl, mediaType: "image/png" }),
+    image: new Image({ url: bannerUrl, mediaType: "image/png" }),
+    url: new URL("/", canonicalOrigin),
+    inbox: uris.inbox,
+    outbox: uris.outbox,
+    followers: uris.followers,
+    endpoints: new Endpoints({ sharedInbox: uris.sharedInbox }),
+    publicKey: keys[0]?.cryptographicKey,
+    assertionMethods: keys.map((key) => key.multikey),
+    attachments: buildActorMetadata(canonicalOrigin),
+  });
+}
+
+export function buildActorUpdateActivity(options: BuildActorUpdateOptions): Update {
+  return new Update({
+    id: options.activityId,
+    actor: options.uris.actor,
+    object: buildActorProfile(options),
+  });
+}

--- a/src/federation/publish.ts
+++ b/src/federation/publish.ts
@@ -1,4 +1,4 @@
-import { Create, Delete, Update, Image, Person, Endpoints } from "@fedify/fedify";
+import { Create, Delete, Update } from "@fedify/fedify";
 import { eq } from "drizzle-orm";
 import { db, posts, media, postTags, tags } from "@/db";
 import { federation } from "./setup";
@@ -7,6 +7,7 @@ import { logger } from "@/utils/logger";
 import { dateToInstant, baseUrl } from "./utils";
 import { postToObject, PublishedPost, PostTag } from "./post-object";
 import { mediaUrl } from "@/services/media";
+import { buildActorUpdateActivity } from "./actor-profile";
 
 // ActivityPub Public address
 const PUBLIC = new URL("https://www.w3.org/ns/activitystreams#Public");
@@ -315,31 +316,18 @@ export async function sendActorUpdateActivity(): Promise<boolean> {
   // Get key pairs for the actor
   const keys = await ctx.getActorKeyPairs("erik");
 
-  // Build the Person object (same as actor dispatcher)
-  const iconUrl = new URL("/images/erik-logo.png", baseUrl);
-  const bannerUrl = new URL("/images/banner.png", baseUrl);
-
-  const person = new Person({
-    id: actorUri,
-    preferredUsername: "erik",
-    name: "Erik Craddock",
-    summary: "Writer, coder, and musician — not always in that order.",
-    icon: new Image({ url: iconUrl, mediaType: "image/png" }),
-    image: new Image({ url: bannerUrl, mediaType: "image/png" }),
-    url: new URL("/", baseUrl),
-    inbox: ctx.getInboxUri("erik"),
-    outbox: ctx.getOutboxUri("erik"),
-    followers: ctx.getFollowersUri("erik"),
-    endpoints: new Endpoints({ sharedInbox: ctx.getInboxUri() }),
-    publicKey: keys[0].cryptographicKey,
-    assertionMethods: keys.map((key) => key.multikey),
-  });
-
-  const activityUri = new URL(`/users/erik#update-${Date.now()}`, baseUrl);
-  const activity = new Update({
-    id: activityUri,
-    actor: actorUri,
-    object: person,
+  const activity = buildActorUpdateActivity({
+    identifier: "erik",
+    canonicalOrigin: baseUrl,
+    activityId: new URL(`/users/erik#update-${Date.now()}`, baseUrl),
+    uris: {
+      actor: actorUri,
+      inbox: ctx.getInboxUri("erik"),
+      outbox: ctx.getOutboxUri("erik"),
+      followers: ctx.getFollowersUri("erik"),
+      sharedInbox: ctx.getInboxUri(),
+    },
+    keys,
   });
 
   logger.info("federation", `Sending actor Update activity to ${followers.length} followers`);

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -1,8 +1,5 @@
 import {
   createFederation,
-  Person,
-  Image,
-  Endpoints,
   Follow,
   Undo,
   Accept,
@@ -15,6 +12,7 @@ import { addFollower, removeFollower, getAllFollowers, getFollowerCount } from "
 import { getOutboxActivities, getPublishedPostCount } from "./outbox";
 import { getOrigin } from "./utils";
 import { logger } from "@/utils/logger";
+import { buildActorProfile } from "./actor-profile";
 
 // Context type for federation - we use void since we don't need request-specific data
 export type FederationContext = void;
@@ -89,28 +87,17 @@ export function createFedifyFederation() {
       // for both HTTP Signatures (publicKey) and Object Integrity Proofs (assertionMethods)
       const keys = await ctx.getActorKeyPairs(identifier);
 
-      // Build image URLs using canonical origin for correct protocol behind reverse proxy
-      const iconUrl = new URL("/images/erik-logo.png", ctx.canonicalOrigin);
-      const bannerUrl = new URL("/images/banner.png", ctx.canonicalOrigin);
-
-      return new Person({
-        id: ctx.getActorUri(identifier),
-        preferredUsername: identifier,
-        name: "Erik Craddock",
-        summary: "Writer, coder, and musician — not always in that order.",
-        icon: new Image({ url: iconUrl, mediaType: "image/png" }),
-        image: new Image({ url: bannerUrl, mediaType: "image/png" }),
-        // Use canonicalOrigin to ensure correct protocol behind reverse proxy
-        url: new URL("/", ctx.canonicalOrigin),
-        inbox: ctx.getInboxUri(identifier),
-        outbox: ctx.getOutboxUri(identifier),
-        followers: ctx.getFollowersUri(identifier),
-        // Shared inbox for efficient batch delivery to multiple followers on same instance
-        endpoints: new Endpoints({ sharedInbox: ctx.getInboxUri() }),
-        // First key's CryptographicKey for HTTP Signatures (legacy, widely supported)
-        publicKey: keys[0].cryptographicKey,
-        // All keys as Multikey for Object Integrity Proofs (modern standard)
-        assertionMethods: keys.map((key) => key.multikey),
+      return buildActorProfile({
+        identifier,
+        canonicalOrigin: ctx.canonicalOrigin,
+        uris: {
+          actor: ctx.getActorUri(identifier),
+          inbox: ctx.getInboxUri(identifier),
+          outbox: ctx.getOutboxUri(identifier),
+          followers: ctx.getFollowersUri(identifier),
+          sharedInbox: ctx.getInboxUri(),
+        },
+        keys,
       });
     })
     // Set up key pairs dispatcher - provides keys for HTTP signatures and proofs


### PR DESCRIPTION
## Summary
- add a centralized ActivityPub actor profile builder shared by the actor dispatcher and actor Update activities
- add Mastodon-compatible schema.org PropertyValue profile metadata attachments
- add tests for metadata serialization, actor field/key preservation, and actor Update parity

## Verification
- npm run typecheck
- make check
- pre-push hook passed (lint, typecheck, tests, migration check)
- manual ActivityPub check: curl -H 'Accept: application/activity+json' http://localhost:5000/users/erik includes PropertyValue attachments and existing inbox/outbox/followers URLs
- app logs checked with make dev-tail grep; no errors/warnings

Task: #task-93b377c5