### PR TITLE
Add ActivityPub following collection

### DIFF
--- a/src/federation/__tests__/actor-profile.test.ts
+++ b/src/federation/__tests__/actor-profile.test.ts
@@ -19,6 +19,7 @@ const uris: ActorProfileUris = {
   inbox: new URL("/users/erik/inbox", origin),
   outbox: new URL("/users/erik/outbox", origin),
   followers: new URL("/users/erik/followers", origin),
+  following: new URL("/users/erik/following", origin),
   sharedInbox: new URL("/inbox", origin),
 };
 
@@ -95,6 +96,7 @@ describe("actor profile metadata", () => {
       inbox: "https://erikcraddock.me/users/erik/inbox",
       outbox: "https://erikcraddock.me/users/erik/outbox",
       followers: "https://erikcraddock.me/users/erik/followers",
+      following: "https://erikcraddock.me/users/erik/following",
       url: "https://erikcraddock.me/",
     });
     expect(json.publicKey).toBeDefined();

--- a/src/federation/__tests__/following.test.ts
+++ b/src/federation/__tests__/following.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const tempDir = mkdtempSync(join(tmpdir(), "ec-following-test-"));
+
+interface FollowingEndpointPayload {
+  actorStatus: number;
+  actor: Record<string, unknown>;
+  followingStatus: number;
+  following: Record<string, unknown>;
+  missingStatus: number;
+}
+
+let payload: FollowingEndpointPayload | null = null;
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function loadPayload(): FollowingEndpointPayload {
+  if (payload) {
+    return payload;
+  }
+
+  const script = String.raw`
+    import { federation } from "./src/federation/setup";
+
+    function activityRequest(path) {
+      return new Request("http://localhost:5000" + path, {
+        headers: { Accept: "application/activity+json" },
+      });
+    }
+
+    const actorResponse = await federation.fetch(activityRequest("/users/erik"), {
+      contextData: undefined,
+    });
+    const followingResponse = await federation.fetch(activityRequest("/users/erik/following"), {
+      contextData: undefined,
+    });
+    const missingResponse = await federation.fetch(activityRequest("/users/alice/following"), {
+      contextData: undefined,
+      onNotFound: async () => new Response("Not found", { status: 404 }),
+    });
+
+    console.log("__RESULT__" + JSON.stringify({
+      actorStatus: actorResponse.status,
+      actor: await actorResponse.json(),
+      followingStatus: followingResponse.status,
+      following: await followingResponse.json(),
+      missingStatus: missingResponse.status,
+    }));
+  `;
+
+  const result = Bun.spawnSync({
+    cmd: ["bun", "--eval", script],
+    env: {
+      ...process.env,
+      DATABASE_PATH: join(tempDir, "site.db"),
+      FEDIFY_KV_PATH: join(tempDir, "fedify-kv.db"),
+      DOMAIN: "localhost:5000",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (result.exitCode !== 0) {
+    throw new Error(`Following endpoint check failed: ${result.stderr.toString()}`);
+  }
+
+  const resultLine = result.stdout
+    .toString()
+    .split("\n")
+    .find((line) => line.startsWith("__RESULT__"));
+
+  if (!resultLine) {
+    throw new Error(`Following endpoint check did not return JSON: ${result.stdout.toString()}`);
+  }
+
+  payload = JSON.parse(resultLine.slice("__RESULT__".length)) as FollowingEndpointPayload;
+  return payload;
+}
+
+describe("ActivityPub following collection", () => {
+  it("includes following URL on the actor JSON", () => {
+    const result = loadPayload();
+
+    expect(result.actorStatus).toBe(200);
+    expect(result.actor.following).toBe("http://localhost:5000/users/erik/following");
+    expect(result.actor.followers).toBe("http://localhost:5000/users/erik/followers");
+    expect(result.actor.outbox).toBe("http://localhost:5000/users/erik/outbox");
+  });
+
+  it("returns an empty following collection for erik", () => {
+    const result = loadPayload();
+
+    expect(result.followingStatus).toBe(200);
+    expect(result.following).toMatchObject({
+      id: "http://localhost:5000/users/erik/following",
+      type: "OrderedCollection",
+      totalItems: 0,
+    });
+    expect(result.following.items).toBeUndefined();
+    expect(result.following.orderedItems).toBeUndefined();
+  });
+
+  it("returns not found for non-erik following collections", () => {
+    const result = loadPayload();
+
+    expect(result.missingStatus).toBe(404);
+  });
+});

--- a/src/federation/actor-profile.ts
+++ b/src/federation/actor-profile.ts
@@ -25,6 +25,7 @@ export interface ActorProfileUris {
   inbox: URL;
   outbox: URL;
   followers: URL;
+  following: URL;
   sharedInbox: URL;
 }
 
@@ -83,6 +84,7 @@ export function buildActorProfile(options: BuildActorProfileOptions): Person {
     inbox: uris.inbox,
     outbox: uris.outbox,
     followers: uris.followers,
+    following: uris.following,
     endpoints: new Endpoints({ sharedInbox: uris.sharedInbox }),
     publicKey: keys[0]?.cryptographicKey,
     assertionMethods: keys.map((key) => key.multikey),

--- a/src/federation/publish.ts
+++ b/src/federation/publish.ts
@@ -325,6 +325,7 @@ export async function sendActorUpdateActivity(): Promise<boolean> {
       inbox: ctx.getInboxUri("erik"),
       outbox: ctx.getOutboxUri("erik"),
       followers: ctx.getFollowersUri("erik"),
+      following: ctx.getFollowingUri("erik"),
       sharedInbox: ctx.getInboxUri(),
     },
     keys,

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -95,6 +95,7 @@ export function createFedifyFederation() {
           inbox: ctx.getInboxUri(identifier),
           outbox: ctx.getOutboxUri(identifier),
           followers: ctx.getFollowersUri(identifier),
+          following: ctx.getFollowingUri(identifier),
           sharedInbox: ctx.getInboxUri(),
         },
         keys,
@@ -207,6 +208,17 @@ export function createFedifyFederation() {
       // First page starts at offset 0
       return "0";
     });
+
+  // Set up following collection dispatcher - this single-user site does not follow actors yet
+  federation
+    .setFollowingDispatcher("/users/{identifier}/following", async (_ctx, identifier) => {
+      if (identifier !== "erik") {
+        return null;
+      }
+
+      return { items: [] };
+    })
+    .setCounter((_ctx, identifier) => (identifier === "erik" ? 0 : null));
 
   // Set up followers collection dispatcher - returns list of followers
   federation


### PR DESCRIPTION
## Summary
- add the actor following URL to the centralized ActivityPub actor profile and actor Update payload
- expose /users/{identifier}/following through Fedify for the single erik actor
- add tests for actor JSON, empty following collection, and non-erik not-found behavior

## Verification
- bun test src/federation/__tests__/following.test.ts
- npm run typecheck
- make check
- manual curl: /users/erik includes following, /users/erik/following returns OrderedCollection totalItems 0, non-erik returns 404
- make dev-tail grep found no ERROR/WARN/error/Error output