### PR TITLE
Show ActivityPub likes in UI and API

### DIFF
--- a/src/federation/likes.ts
+++ b/src/federation/likes.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, isNotNull } from "drizzle-orm";
+import { and, count, desc, eq, isNotNull } from "drizzle-orm";
 import { Like } from "@fedify/fedify";
 
 import { db, posts, remoteLikes } from "@/db";
@@ -6,6 +6,7 @@ import { logger } from "@/utils/logger";
 import { getOrigin } from "./utils";
 
 const domain = process.env.DOMAIN || "localhost:5000";
+type LikesDatabase = typeof db;
 
 export interface RemoteLike {
   id: number;
@@ -25,6 +26,14 @@ export interface NewRemoteLike {
   actor_uri: string;
   actor_name?: string | null;
   raw_object_uri: string;
+}
+
+export interface RemoteLikeSummary {
+  actor_uri: string;
+  actor_name: string | null;
+  activity_uri: string;
+  object_uri: string;
+  received_at: string;
 }
 
 export function resolveLocalPublishedPostFromObjectUri(objectUri: string) {
@@ -54,8 +63,11 @@ export function resolveLocalPublishedPostFromObjectUri(objectUri: string) {
     .get();
 }
 
-export function addRemoteLike(input: NewRemoteLike): RemoteLike | null {
-  const existing = db
+export function addRemoteLike(
+  input: NewRemoteLike,
+  database: LikesDatabase = db
+): RemoteLike | null {
+  const existing = database
     .select()
     .from(remoteLikes)
     .where(eq(remoteLikes.activity_uri, input.activity_uri))
@@ -66,7 +78,7 @@ export function addRemoteLike(input: NewRemoteLike): RemoteLike | null {
     return existing;
   }
 
-  return db
+  return database
     .insert(remoteLikes)
     .values({
       post_id: input.post_id,
@@ -81,12 +93,12 @@ export function addRemoteLike(input: NewRemoteLike): RemoteLike | null {
     .get();
 }
 
-export function getRemoteLikesForPost(postId: number): RemoteLike[] {
-  return db.select().from(remoteLikes).where(eq(remoteLikes.post_id, postId)).all();
+export function getRemoteLikesForPost(postId: number, database: LikesDatabase = db): RemoteLike[] {
+  return database.select().from(remoteLikes).where(eq(remoteLikes.post_id, postId)).all();
 }
 
-export function getRemoteLikeCountForPost(postId: number): number {
-  const result = db
+export function getRemoteLikeCountForPost(postId: number, database: LikesDatabase = db): number {
+  const result = database
     .select({ count: count() })
     .from(remoteLikes)
     .where(eq(remoteLikes.post_id, postId))
@@ -94,8 +106,30 @@ export function getRemoteLikeCountForPost(postId: number): number {
   return result?.count ?? 0;
 }
 
-export function deleteRemoteLike(activityUri: string): boolean {
-  const deleted = db
+export function listRemoteLikeSummariesForPost(
+  postId: number,
+  database: LikesDatabase = db
+): RemoteLikeSummary[] {
+  return database
+    .select({
+      actor_uri: remoteLikes.actor_uri,
+      actor_name: remoteLikes.actor_name,
+      activity_uri: remoteLikes.activity_uri,
+      object_uri: remoteLikes.object_uri,
+      received_at: remoteLikes.received_at,
+    })
+    .from(remoteLikes)
+    .where(eq(remoteLikes.post_id, postId))
+    .orderBy(desc(remoteLikes.received_at))
+    .all()
+    .map((like) => ({
+      ...like,
+      received_at: like.received_at.toISOString(),
+    }));
+}
+
+export function deleteRemoteLike(activityUri: string, database: LikesDatabase = db): boolean {
+  const deleted = database
     .delete(remoteLikes)
     .where(eq(remoteLikes.activity_uri, activityUri))
     .returning()

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -11,6 +11,7 @@ import {
   personSocialAccounts,
   tags,
   postTags,
+  remoteLikes,
 } from "../../db/schema";
 import { eq } from "drizzle-orm";
 
@@ -71,6 +72,7 @@ mock.module("@/auth/api-key", () => {
 });
 
 beforeEach(() => {
+  testDb.delete(remoteLikes).run();
   testDb.delete(postTags).run();
   testDb.delete(tags).run();
   testDb.delete(posts).run();
@@ -469,6 +471,89 @@ describe("GET /api/posts/by-slug/:slug", () => {
 
     expect(res.status).toBe(404);
     const json = await res.json();
+    expect(json.error).toBe("Post not found");
+  });
+});
+
+describe("GET /api/posts/by-slug/:slug/likes", () => {
+  let api: typeof import("../api").api;
+
+  beforeAll(async () => {
+    const module = await import("../api");
+    api = module.api;
+  });
+
+  it("returns like count and safe metadata for a post", async () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const post = testDb
+      .insert(posts)
+      .values({
+        slug: "liked-api-post",
+        type: "note",
+        content: "Liked API post",
+        published_at: now,
+        created_at: now,
+        updated_at: now,
+      })
+      .returning()
+      .get();
+
+    testDb
+      .insert(remoteLikes)
+      .values({
+        post_id: post.id,
+        object_uri: "https://erikcraddock.me/posts/liked-api-post",
+        activity_uri: "https://remote.example/activities/like-api-post",
+        actor_uri: "https://remote.example/users/alice",
+        actor_name: "Alice",
+        raw_object_uri: "https://erikcraddock.me/posts/liked-api-post",
+        received_at: now,
+      })
+      .run();
+
+    const res = await api.request("/posts/by-slug/liked-api-post/likes", { headers: authHeader });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.count).toBe(1);
+    expect(json.data.likes).toEqual([
+      {
+        actor_uri: "https://remote.example/users/alice",
+        actor_name: "Alice",
+        activity_uri: "https://remote.example/activities/like-api-post",
+        object_uri: "https://erikcraddock.me/posts/liked-api-post",
+        received_at: now.toISOString(),
+      },
+    ]);
+    expect(JSON.stringify(json)).not.toContain("raw_object_uri");
+  });
+
+  it("returns zero and an empty list for posts with no likes", async () => {
+    const now = new Date();
+    testDb
+      .insert(posts)
+      .values({
+        slug: "no-api-likes",
+        type: "note",
+        content: "No likes",
+        published_at: now,
+        created_at: now,
+        updated_at: now,
+      })
+      .run();
+
+    const res = await api.request("/posts/by-slug/no-api-likes/likes", { headers: authHeader });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data).toEqual({ count: 0, likes: [] });
+  });
+
+  it("returns 404 for missing posts", async () => {
+    const res = await api.request("/posts/by-slug/missing-post/likes", { headers: authHeader });
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
     expect(json.error).toBe("Post not found");
   });
 });

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -1521,7 +1521,9 @@ describe("pages routes", () => {
       const html = await res.text();
 
       expect(res.status).toBe(200);
-      expect(html).toContain("♡ 1 Like");
+      expect(html).toContain('aria-label="1 ActivityPub like"');
+      expect(html).toContain("0 Replies");
+      expect(html).toContain("0 Boosts");
     });
 
     it("shows like counts on feed cards", async () => {
@@ -1543,8 +1545,10 @@ describe("pages routes", () => {
       const html = await res.text();
 
       expect(res.status).toBe(200);
-      expect(html).toContain("♡ 1 Like");
-      expect(html).toContain("♡ 0 Likes");
+      expect(html).toContain('aria-label="1 ActivityPub like"');
+      expect(html).toContain('aria-label="0 ActivityPub likes"');
+      expect(html).toContain("0 Replies");
+      expect(html).toContain("0 Boosts");
     });
 
     it("shows zero likes on article cards when there are no stored likes", async () => {
@@ -1553,7 +1557,7 @@ describe("pages routes", () => {
       const html = await res.text();
 
       expect(res.status).toBe(200);
-      expect(html).toContain("♡ 0 Likes");
+      expect(html).toContain('aria-label="0 ActivityPub likes"');
     });
   });
 

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -20,6 +20,7 @@ import {
   people,
   personSocialAccounts,
   media,
+  remoteLikes,
 } from "../../db/schema";
 
 // Create test db immediately
@@ -1497,6 +1498,62 @@ describe("pages routes", () => {
 
       const html = await res.text();
       expect(html).toContain("Tag Not Found");
+    });
+  });
+
+  describe("ActivityPub like counts", () => {
+    it("shows the stored like count on individual post pages", async () => {
+      testDb
+        .insert(remoteLikes)
+        .values({
+          post_id: 1,
+          object_uri: "http://localhost:5000/posts/test-post",
+          activity_uri: "https://remote.example/activities/page-like",
+          actor_uri: "https://remote.example/users/alice",
+          actor_name: "Alice",
+          raw_object_uri: "http://localhost:5000/posts/test-post",
+          received_at: new Date("2026-01-01T00:00:00.000Z"),
+        })
+        .run();
+
+      const app = getApp();
+      const res = await app.request("/posts/test-post");
+      const html = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(html).toContain("♡ 1 Like");
+    });
+
+    it("shows like counts on feed cards", async () => {
+      testDb
+        .insert(remoteLikes)
+        .values({
+          post_id: 3,
+          object_uri: "http://localhost:5000/posts/another-post",
+          activity_uri: "https://remote.example/activities/feed-like",
+          actor_uri: "https://remote.example/users/bob",
+          actor_name: "Bob",
+          raw_object_uri: "http://localhost:5000/posts/another-post",
+          received_at: new Date("2026-01-02T00:00:00.000Z"),
+        })
+        .run();
+
+      const app = getApp();
+      const res = await app.request("/feed");
+      const html = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(html).toContain("♡ 1 Like");
+      expect(html).toContain("♡ 0 Likes");
+    });
+
+    it("shows zero likes on article cards when there are no stored likes", async () => {
+      const app = getApp();
+      const res = await app.request("/articles");
+      const html = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(html).toContain("♡ 0 Likes");
     });
   });
 

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/services/people";
 import { fetchLinkPreview } from "@/services/link-preview";
 import { logger } from "@/utils/logger";
+import { getRemoteLikeCountForPost, listRemoteLikeSummariesForPost } from "@/federation/likes";
 import {
   federatePost,
   sendDeleteActivity,
@@ -200,6 +201,26 @@ const PostListItemSchema = z
     tags: z.array(z.string()).openapi({ example: ["Tech", "Writing"] }),
   })
   .openapi("PostListItem");
+
+const RemoteLikeSchema = z
+  .object({
+    actor_uri: z.string().url().openapi({ example: "https://mastodon.social/users/alice" }),
+    actor_name: NullableStringSchema.openapi({ example: "Alice" }),
+    activity_uri: z
+      .string()
+      .url()
+      .openapi({ example: "https://mastodon.social/users/alice/statuses/1/activity" }),
+    object_uri: z.string().url().openapi({ example: "https://erikcraddock.me/posts/my-post" }),
+    received_at: IsoDateTimeSchema,
+  })
+  .openapi("RemoteLike");
+
+const PostLikesSchema = z
+  .object({
+    count: z.number().int().openapi({ example: 1 }),
+    likes: z.array(RemoteLikeSchema),
+  })
+  .openapi("PostLikes");
 
 const PostSchema = z
   .object({
@@ -1231,6 +1252,43 @@ registerProtectedRoute(
     }
 
     return c.json({ data: post });
+  }
+);
+
+registerProtectedRoute(
+  protectedRoute({
+    method: "get",
+    path: "/posts/by-slug/{slug}/likes",
+    tags: ["posts"],
+    summary: "List ActivityPub likes for a post by slug",
+    request: { params: SlugParamSchema },
+    responses: {
+      200: {
+        description: "The stored ActivityPub likes for the requested post.",
+        content: { "application/json": { schema: dataEnvelope(PostLikesSchema) } },
+      },
+      401: {
+        description: "Missing or invalid API key.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      404: {
+        description: "The post was not found.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+    },
+  }),
+  (c: Context) => {
+    const post = getPostBySlug(c.req.param("slug") ?? "");
+    if (!post) {
+      return c.json({ error: "Post not found" }, 404);
+    }
+
+    return c.json({
+      data: {
+        count: getRemoteLikeCountForPost(post.id),
+        likes: listRemoteLikeSummariesForPost(post.id),
+      },
+    });
   }
 );
 

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -24,6 +24,7 @@ import { fetchLinkPreview } from "../services/link-preview";
 import { postToObject, PublishedPost } from "../federation/post-object";
 import { baseUrl } from "../federation/utils";
 import { logger } from "../utils/logger";
+import { getRemoteLikeCountForPost } from "../federation/likes";
 
 // Database type for dependency injection
 type Database = typeof defaultDb;
@@ -49,7 +50,8 @@ type SourceWithAuthors = Source & {
   social_accounts: SourceSocialAccount[];
 };
 type Tag = { id: number; name: string; slug: string };
-type PostWithSource = Post & { source?: Source | null; author?: Person | null };
+type PostWithLikeCount = Post & { like_count?: number };
+type PostWithSource = PostWithLikeCount & { source?: Source | null; author?: Person | null };
 
 /** Max length for showing full note content inline */
 const NOTE_INLINE_MAX_LENGTH = 280;
@@ -754,12 +756,23 @@ function TagBadges({ tags }: { tags: Tag[] }) {
 }
 
 /** Article card for grid display */
+function LikeCount({ count }: { count?: number }) {
+  const likeCount = count ?? 0;
+  const label = likeCount === 1 ? "Like" : "Likes";
+
+  return (
+    <span aria-label={`${likeCount} ActivityPub ${label.toLowerCase()}`}>
+      ♡ {likeCount} {label}
+    </span>
+  );
+}
+
 function ArticleCard({
   post,
   getBannerUrl,
   tags: postTags = [],
 }: {
-  post: Post;
+  post: PostWithLikeCount;
   getBannerUrl: (id: number) => string | null;
   tags?: Tag[];
 }) {
@@ -805,7 +818,10 @@ function ArticleCard({
           <p class="text-gray-600 dark:text-gray-400 text-sm line-clamp-3 mb-2">
             {post.excerpt || truncate(post.content, 150)}
           </p>
-          {postTags.length > 0 && <TagBadges tags={postTags} />}
+          <div class="mt-3 flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+            <LikeCount count={post.like_count} />
+            {postTags.length > 0 && <TagBadges tags={postTags} />}
+          </div>
         </div>
       </a>
     </article>
@@ -819,7 +835,7 @@ function ArticleCardsSection({
   getTagsForPost,
   hasMore,
 }: {
-  articles: Post[];
+  articles: PostWithLikeCount[];
   getBannerUrl: (id: number) => string | null;
   getTagsForPost: (postId: number) => Tag[];
   hasMore: boolean;
@@ -1191,6 +1207,8 @@ function FeedPostMeta({ post, tags: postTags }: { post: PostWithSource; tags: Ta
       <time>{formattedDate}</time>
       <span aria-hidden="true">·</span>
       <span class="capitalize">{post.type}</span>
+      <span aria-hidden="true">·</span>
+      <LikeCount count={post.like_count} />
       {post.author && (
         <>
           <span aria-hidden="true">·</span>
@@ -1431,6 +1449,10 @@ function PostCard({ post, tags: postTags = [] }: { post: PostWithSource; tags?: 
             </span>
           )}
 
+          <span class="ml-2">
+            • <LikeCount count={post.like_count} />
+          </span>
+
           {/* Tags */}
           {postTags.length > 0 && (
             <span class="ml-2 flex flex-wrap gap-1">
@@ -1531,6 +1553,16 @@ function getSourcesAuthoredByPerson(db: Database, personId: number): Source[] {
     .map((row) => row.source);
 }
 
+function withLikeCounts<T extends { id: number }>(
+  db: Database,
+  postList: T[]
+): Array<T & { like_count: number }> {
+  return postList.map((post) => ({
+    ...post,
+    like_count: getRemoteLikeCountForPost(post.id, db),
+  }));
+}
+
 /**
  * Creates page routes with the given database instance.
  * Allows dependency injection for testing.
@@ -1553,7 +1585,7 @@ export function createPagesRoutes(db: Database): Hono {
 
     // Check if there are more articles beyond what we display
     const hasMoreArticles = fetchedArticles.length > HOME_ARTICLES_LIMIT;
-    const recentArticles = fetchedArticles.slice(0, HOME_ARTICLES_LIMIT);
+    const recentArticles = withLikeCounts(db, fetchedArticles.slice(0, HOME_ARTICLES_LIMIT));
 
     // Get all banner IDs for the articles
     const bannerIds = recentArticles
@@ -1667,14 +1699,17 @@ export function createPagesRoutes(db: Database): Hono {
 
     // Fetch articles for current page
     const offset = (page - 1) * ARTICLES_PER_PAGE;
-    const pageArticles = db
-      .select()
-      .from(posts)
-      .where(and(eq(posts.type, "article"), isNotNull(posts.published_at)))
-      .orderBy(desc(posts.published_at))
-      .limit(ARTICLES_PER_PAGE)
-      .offset(offset)
-      .all();
+    const pageArticles = withLikeCounts(
+      db,
+      db
+        .select()
+        .from(posts)
+        .where(and(eq(posts.type, "article"), isNotNull(posts.published_at)))
+        .orderBy(desc(posts.published_at))
+        .limit(ARTICLES_PER_PAGE)
+        .offset(offset)
+        .all()
+    );
 
     // Get banner URLs
     const bannerIds = pageArticles
@@ -1831,11 +1866,14 @@ export function createPagesRoutes(db: Database): Hono {
       .offset(offset)
       .all();
 
-    const pagePosts: PostWithSource[] = results.map((row) => ({
-      ...row.post,
-      source: row.source,
-      author: row.author,
-    }));
+    const pagePosts: PostWithSource[] = withLikeCounts(
+      db,
+      results.map((row) => ({
+        ...row.post,
+        source: row.source,
+        author: row.author,
+      }))
+    );
 
     // Fetch tags for all displayed posts
     const postIds = pagePosts.map((p) => p.id);
@@ -2450,19 +2488,22 @@ export function createPagesRoutes(db: Database): Hono {
 
     const authoredSources = getSourcesAuthoredByPerson(db, person.id);
     const socialAccounts = getPersonSocialAccounts(db, person.id);
-    const personLinks: PostWithSource[] = db
-      .select({
-        post: posts,
-        source: sources,
-      })
-      .from(posts)
-      .leftJoin(sources, eq(posts.source_id, sources.id))
-      .where(
-        and(eq(posts.author_id, person.id), eq(posts.type, "link"), isNotNull(posts.published_at))
-      )
-      .orderBy(desc(posts.published_at))
-      .all()
-      .map((row) => ({ ...row.post, source: row.source, author: person }));
+    const personLinks: PostWithSource[] = withLikeCounts(
+      db,
+      db
+        .select({
+          post: posts,
+          source: sources,
+        })
+        .from(posts)
+        .leftJoin(sources, eq(posts.source_id, sources.id))
+        .where(
+          and(eq(posts.author_id, person.id), eq(posts.type, "link"), isNotNull(posts.published_at))
+        )
+        .orderBy(desc(posts.published_at))
+        .all()
+        .map((row) => ({ ...row.post, source: row.source, author: person }))
+    );
 
     return c.html(
       <Layout title={`${person.name} | erikcraddock.me`} description={person.url ?? undefined}>
@@ -2523,19 +2564,22 @@ export function createPagesRoutes(db: Database): Hono {
       );
     }
 
-    const sourceLinks: PostWithSource[] = db
-      .select({
-        post: posts,
-        author: people,
-      })
-      .from(posts)
-      .leftJoin(people, eq(posts.author_id, people.id))
-      .where(
-        and(eq(posts.source_id, source.id), eq(posts.type, "link"), isNotNull(posts.published_at))
-      )
-      .orderBy(desc(posts.published_at))
-      .all()
-      .map((row) => ({ ...row.post, source, author: row.author }));
+    const sourceLinks: PostWithSource[] = withLikeCounts(
+      db,
+      db
+        .select({
+          post: posts,
+          author: people,
+        })
+        .from(posts)
+        .leftJoin(people, eq(posts.author_id, people.id))
+        .where(
+          and(eq(posts.source_id, source.id), eq(posts.type, "link"), isNotNull(posts.published_at))
+        )
+        .orderBy(desc(posts.published_at))
+        .all()
+        .map((row) => ({ ...row.post, source, author: row.author }))
+    );
 
     return c.html(
       <Layout
@@ -2723,7 +2767,12 @@ export function createPagesRoutes(db: Database): Hono {
       .all().length;
     const followerCount = db.select().from(followers).all().length;
     const followingCount = 0;
-    const feedPost: PostWithSource = { ...post, source, author };
+    const feedPost: PostWithSource = {
+      ...post,
+      source,
+      author,
+      like_count: getRemoteLikeCountForPost(post.id, db),
+    };
 
     return c.html(
       <Layout
@@ -2825,11 +2874,14 @@ export function createPagesRoutes(db: Database): Hono {
       .all();
 
     // Transform to PostWithSource
-    const taggedPosts: PostWithSource[] = results.map((row) => ({
-      ...row.post,
-      source: row.source,
-      author: row.author,
-    }));
+    const taggedPosts: PostWithSource[] = withLikeCounts(
+      db,
+      results.map((row) => ({
+        ...row.post,
+        source: row.source,
+        author: row.author,
+      }))
+    );
 
     // Fetch all tags for the displayed posts
     const taggedPostIds = taggedPosts.map((p) => p.id);

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -756,14 +756,29 @@ function TagBadges({ tags }: { tags: Tag[] }) {
 }
 
 /** Article card for grid display */
-function LikeCount({ count }: { count?: number }) {
-  const likeCount = count ?? 0;
-  const label = likeCount === 1 ? "Like" : "Likes";
+function EngagementRow({ likeCount = 0 }: { likeCount?: number }) {
+  const likeLabel = likeCount === 1 ? "Like" : "Likes";
 
   return (
-    <span aria-label={`${likeCount} ActivityPub ${label.toLowerCase()}`}>
-      ♡ {likeCount} {label}
-    </span>
+    <div class="mt-4 flex items-center justify-around border-t border-gray-100 pt-3 text-sm text-gray-500 dark:border-gray-800 dark:text-gray-400">
+      <span class="inline-flex items-center gap-2" aria-label="0 ActivityPub replies">
+        <span aria-hidden="true">↩</span>
+        <span>0 Replies</span>
+      </span>
+      <span class="inline-flex items-center gap-2" aria-label="0 ActivityPub boosts">
+        <span aria-hidden="true">↻</span>
+        <span>0 Boosts</span>
+      </span>
+      <span
+        class="inline-flex items-center gap-2"
+        aria-label={`${likeCount} ActivityPub ${likeLabel.toLowerCase()}`}
+      >
+        <span aria-hidden="true">♡</span>
+        <span>
+          {likeCount} {likeLabel}
+        </span>
+      </span>
+    </div>
   );
 }
 
@@ -818,10 +833,12 @@ function ArticleCard({
           <p class="text-gray-600 dark:text-gray-400 text-sm line-clamp-3 mb-2">
             {post.excerpt || truncate(post.content, 150)}
           </p>
-          <div class="mt-3 flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-            <LikeCount count={post.like_count} />
-            {postTags.length > 0 && <TagBadges tags={postTags} />}
-          </div>
+          {postTags.length > 0 && (
+            <div class="mt-3">
+              <TagBadges tags={postTags} />
+            </div>
+          )}
+          <EngagementRow likeCount={post.like_count} />
         </div>
       </a>
     </article>
@@ -1207,8 +1224,6 @@ function FeedPostMeta({ post, tags: postTags }: { post: PostWithSource; tags: Ta
       <time>{formattedDate}</time>
       <span aria-hidden="true">·</span>
       <span class="capitalize">{post.type}</span>
-      <span aria-hidden="true">·</span>
-      <LikeCount count={post.like_count} />
       {post.author && (
         <>
           <span aria-hidden="true">·</span>
@@ -1300,6 +1315,7 @@ function FeedPost({
       {isLink && <FeedLinkPreview post={post} />}
 
       <FeedPostMeta post={post} tags={postTags} />
+      <EngagementRow likeCount={post.like_count} />
     </article>
   );
 }
@@ -1354,6 +1370,7 @@ function SingleFeedPost({
       {isLink && <FeedLinkPreview post={post} />}
 
       <FeedPostMeta post={post} tags={postTags} />
+      <EngagementRow likeCount={post.like_count} />
     </article>
   );
 }
@@ -1449,10 +1466,6 @@ function PostCard({ post, tags: postTags = [] }: { post: PostWithSource; tags?: 
             </span>
           )}
 
-          <span class="ml-2">
-            • <LikeCount count={post.like_count} />
-          </span>
-
           {/* Tags */}
           {postTags.length > 0 && (
             <span class="ml-2 flex flex-wrap gap-1">
@@ -1464,6 +1477,7 @@ function PostCard({ post, tags: postTags = [] }: { post: PostWithSource; tags?: 
           )}
         </div>
       </a>
+      <EngagementRow likeCount={post.like_count} />
     </article>
   );
 }

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -802,8 +802,8 @@ function ArticleCard({
     : null;
 
   return (
-    <article class="bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-shadow">
-      <a href={`/posts/${post.slug}`} class="block">
+    <article class="flex h-full flex-col bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-shadow">
+      <a href={`/posts/${post.slug}`} class="flex h-full flex-col">
         {/* Banner image with date badge */}
         <div class="relative aspect-video bg-gray-200 dark:bg-gray-700">
           {bannerUrl ? (
@@ -826,18 +826,20 @@ function ArticleCard({
         </div>
 
         {/* Content */}
-        <div class="p-4">
-          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2 line-clamp-2 group-hover:text-blue-600">
-            {post.title}
-          </h3>
-          <p class="text-gray-600 dark:text-gray-400 text-sm line-clamp-3 mb-2">
-            {post.excerpt || truncate(post.content, 150)}
-          </p>
-          {postTags.length > 0 && (
-            <div class="mt-3">
-              <TagBadges tags={postTags} />
-            </div>
-          )}
+        <div class="flex flex-1 flex-col p-4">
+          <div class="flex-1">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2 line-clamp-2 group-hover:text-blue-600">
+              {post.title}
+            </h3>
+            <p class="text-gray-600 dark:text-gray-400 text-sm line-clamp-3 mb-2">
+              {post.excerpt || truncate(post.content, 150)}
+            </p>
+            {postTags.length > 0 && (
+              <div class="mt-3">
+                <TagBadges tags={postTags} />
+              </div>
+            )}
+          </div>
           <EngagementRow likeCount={post.like_count} />
         </div>
       </a>


### PR DESCRIPTION
## Summary
- show stored ActivityPub like counts on post pages, feed posts, and article/post cards
- add authenticated API endpoint for per-post ActivityPub like counts and safe like metadata
- extend likes helpers to support injected DB usage and safe API summaries
- add UI and API tests for counts, safe metadata, no-likes, and missing-post behavior

## Verification
- bun test src/routes/__tests__/api.test.tsx src/routes/__tests__/pages.test.tsx
- npm run typecheck
- make check
- browser verification: opened http://localhost:5000/feed and confirmed like count elements render
- make dev-tail grep found no ERROR/WARN/error/Error output