### PR TITLE
Use profile metadata in feed actor card

### DIFF
--- a/src/federation/__tests__/actor-profile.test.ts
+++ b/src/federation/__tests__/actor-profile.test.ts
@@ -9,6 +9,7 @@ import {
   buildActorMetadata,
   buildActorProfile,
   buildActorUpdateActivity,
+  getPublicProfileFields,
   type ActorProfileUris,
 } from "../actor-profile";
 
@@ -59,6 +60,27 @@ function attachmentMap(json: Record<string, unknown>): Map<string, Record<string
 }
 
 describe("actor profile metadata", () => {
+  it("exposes structured public profile fields for page rendering", () => {
+    expect(getPublicProfileFields(origin)).toEqual([
+      { name: "Website", href: "https://erikcraddock.me/", text: "erikcraddock.me" },
+      {
+        name: "GitHub",
+        href: "https://github.com/evcraddock",
+        text: "github.com/evcraddock",
+      },
+      {
+        name: "LinkedIn",
+        href: "https://www.linkedin.com/in/erik-craddock-42aa9815",
+        text: "linkedin.com/in/erik-craddock-42aa9815",
+      },
+      {
+        name: "YouTube",
+        href: "https://youtube.com/@ErikCraddock",
+        text: "youtube.com/@ErikCraddock",
+      },
+    ]);
+  });
+
   it("builds Mastodon-compatible PropertyValue profile fields", async () => {
     const metadata = buildActorMetadata(origin);
 

--- a/src/federation/__tests__/actor-profile.test.ts
+++ b/src/federation/__tests__/actor-profile.test.ts
@@ -74,17 +74,28 @@ describe("actor profile metadata", () => {
         text: "linkedin.com/in/erik-craddock-42aa9815",
       },
       {
+        name: "Facebook",
+        href: "https://www.facebook.com/evcraddock",
+        text: "facebook.com/evcraddock",
+      },
+      {
         name: "YouTube",
         href: "https://youtube.com/@ErikCraddock",
         text: "youtube.com/@ErikCraddock",
       },
+      {
+        name: "Instagram",
+        href: "https://www.instagram.com/evcraddock",
+        text: "instagram.com/evcraddock",
+      },
+      { name: "Email", href: "mailto:erik@craddock.me", text: "erik@craddock.me" },
     ]);
   });
 
   it("builds Mastodon-compatible PropertyValue profile fields", async () => {
     const metadata = buildActorMetadata(origin);
 
-    expect(metadata).toHaveLength(4);
+    expect(metadata).toHaveLength(7);
 
     const json = await Promise.all(
       metadata.map((propertyValue) => propertyValue.toJsonLd() as Promise<Record<string, unknown>>)
@@ -129,6 +140,10 @@ describe("actor profile metadata", () => {
     );
     expect(attachments.get("LinkedIn")?.type).toBe("PropertyValue");
     expect(attachments.get("YouTube")?.type).toBe("PropertyValue");
+    expect(attachments.get("Instagram")?.type).toBe("PropertyValue");
+    expect(attachments.get("Email")?.value).toBe(
+      '<a href="mailto:erik@craddock.me" rel="me">erik@craddock.me</a>'
+    );
   });
 
   it("uses the same metadata for actor Update activities as the actor profile", async () => {

--- a/src/federation/actor-profile.ts
+++ b/src/federation/actor-profile.ts
@@ -3,7 +3,7 @@ import { Endpoints, Image, Person, PropertyValue, Update, type ActorKeyPair } fr
 const ACTOR_NAME = "Erik Craddock";
 const ACTOR_SUMMARY = "Writer, coder, and musician — not always in that order.";
 
-interface ActorProfileField {
+export interface ActorProfileField {
   name: string;
   href: string;
   text: string;
@@ -51,6 +51,13 @@ function escapeHtml(value: string): string {
 
 function resolveProfileFieldUrl(field: ActorProfileField, canonicalOrigin: string | URL): URL {
   return new URL(field.href, canonicalOrigin);
+}
+
+export function getPublicProfileFields(canonicalOrigin: string | URL): ActorProfileField[] {
+  return PUBLIC_PROFILE_FIELDS.map((field) => ({
+    ...field,
+    href: resolveProfileFieldUrl(field, canonicalOrigin).toString(),
+  }));
 }
 
 function profileFieldToHtml(field: ActorProfileField, canonicalOrigin: string | URL): string {

--- a/src/federation/actor-profile.ts
+++ b/src/federation/actor-profile.ts
@@ -17,7 +17,18 @@ const PUBLIC_PROFILE_FIELDS: ActorProfileField[] = [
     href: "https://www.linkedin.com/in/erik-craddock-42aa9815",
     text: "linkedin.com/in/erik-craddock-42aa9815",
   },
+  {
+    name: "Facebook",
+    href: "https://www.facebook.com/evcraddock",
+    text: "facebook.com/evcraddock",
+  },
   { name: "YouTube", href: "https://youtube.com/@ErikCraddock", text: "youtube.com/@ErikCraddock" },
+  {
+    name: "Instagram",
+    href: "https://www.instagram.com/evcraddock",
+    text: "instagram.com/evcraddock",
+  },
+  { name: "Email", href: "mailto:erik@craddock.me", text: "erik@craddock.me" },
 ];
 
 export interface ActorProfileUris {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -580,6 +580,21 @@ describe("pages routes", () => {
       expect(html).toContain("Follow");
     });
 
+    it("renders centralized public profile links in the actor card", async () => {
+      const app = getApp();
+      const res = await app.request("/feed");
+      const html = await res.text();
+
+      expect(html).toMatch(/href="http:\/\/[^"]+\/"/);
+      expect(html).toContain("erikcraddock.me");
+      expect(html).toContain('href="https://github.com/evcraddock"');
+      expect(html).toContain("github.com/evcraddock");
+      expect(html).toContain('href="https://www.linkedin.com/in/erik-craddock-42aa9815"');
+      expect(html).toContain("linkedin.com/in/erik-craddock-42aa9815");
+      expect(html).toContain('href="https://youtube.com/@ErikCraddock"');
+      expect(html).toContain("youtube.com/@ErikCraddock");
+    });
+
     it("shows a social media card above recommended sites", async () => {
       const app = getApp();
       const res = await app.request("/feed");

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -591,25 +591,26 @@ describe("pages routes", () => {
       expect(html).toContain("github.com/evcraddock");
       expect(html).toContain('href="https://www.linkedin.com/in/erik-craddock-42aa9815"');
       expect(html).toContain("linkedin.com/in/erik-craddock-42aa9815");
+      expect(html).toContain('href="https://www.facebook.com/evcraddock"');
+      expect(html).toContain("facebook.com/evcraddock");
       expect(html).toContain('href="https://youtube.com/@ErikCraddock"');
       expect(html).toContain("youtube.com/@ErikCraddock");
+      expect(html).toContain('href="https://www.instagram.com/evcraddock"');
+      expect(html).toContain("instagram.com/evcraddock");
+      expect(html).toContain('href="mailto:erik@craddock.me"');
+      expect(html).toContain("erik@craddock.me");
     });
 
-    it("shows a social media card above recommended sites", async () => {
+    it("hides the separate social media card", async () => {
       const app = getApp();
       const res = await app.request("/feed");
       const html = await res.text();
 
-      expect(html).toContain("Follow me");
-      expect(html).toContain('href="https://github.com/evcraddock"');
-      expect(html).toContain('href="https://www.linkedin.com/in/erik-craddock-42aa9815"');
-      expect(html).toContain('href="https://www.facebook.com/evcraddock"');
-      expect(html).toContain('href="https://youtube.com/@ErikCraddock"');
-      expect(html).toContain('href="/feed.xml"');
-      expect(html.indexOf("Follow me")).toBeLessThan(html.indexOf("Recommended Sites"));
+      expect(html).not.toContain("Follow me");
+      expect(html).not.toContain('aria-label="RSS"');
     });
 
-    it("shows articles below social media and above recommended sites in the feed sidebar", async () => {
+    it("shows articles above recommended sites in the feed sidebar", async () => {
       const app = getApp();
       const res = await app.request("/feed");
       const html = await res.text();
@@ -620,7 +621,6 @@ describe("pages routes", () => {
       expect(html).toContain("Explore Articles");
       expect(html).toContain('href="/sources"');
       expect(html).toContain("Recommended Sites");
-      expect(html.indexOf("Follow me")).toBeLessThan(html.indexOf("Articles"));
       expect(html.indexOf("Articles")).toBeLessThan(html.indexOf("Recommended Sites"));
     });
 
@@ -1395,10 +1395,9 @@ describe("pages routes", () => {
       expect(html).toContain("Articles");
       expect(html).toContain("Read longer essays, project notes, and polished writing");
       expect(html).toContain("Explore Articles");
-      expect(html).toContain("Follow me");
+      expect(html).not.toContain("Follow me");
       expect(html).toContain("Recommended Sites");
       expect(html).toContain("Explore sources");
-      expect(html.indexOf("Follow me")).toBeLessThan(html.indexOf("Articles"));
       expect(html.indexOf("Articles")).toBeLessThan(html.indexOf("Recommended Sites"));
     });
   });

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -23,6 +23,7 @@ import { listTags } from "../services/tags";
 import { fetchLinkPreview } from "../services/link-preview";
 import { postToObject, PublishedPost } from "../federation/post-object";
 import { baseUrl } from "../federation/utils";
+import { getPublicProfileFields } from "../federation/actor-profile";
 import { logger } from "../utils/logger";
 import { getRemoteLikeCountForPost } from "../federation/likes";
 
@@ -1066,6 +1067,21 @@ function FeedProfileCard({
               <dd class="font-semibold text-gray-950 dark:text-gray-50">{postCount}</dd>
             </div>
           </dl>
+          <div class="mt-4 grid grid-cols-2 gap-3 border-t border-gray-200 pt-4 text-sm dark:border-gray-800">
+            {getPublicProfileFields(baseUrl).map((field) => (
+              <a
+                key={field.name}
+                href={field.href}
+                rel="me noopener noreferrer"
+                target={field.href.startsWith(baseUrl) ? undefined : "_blank"}
+                class="text-gray-600 underline-offset-4 hover:text-teal-700 hover:underline dark:text-gray-400 dark:hover:text-teal-300"
+              >
+                <span class="font-medium text-gray-900 dark:text-gray-100">{field.name}</span>
+                <span class="sr-only">: </span>
+                <span class="block truncate">{field.text}</span>
+              </a>
+            ))}
+          </div>
         </div>
       </div>
     </section>

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -439,6 +439,25 @@ async function buildFediverseFollowUrl(input: string): Promise<string | null> {
 }
 
 /** Social link icons */
+function WebsiteIcon() {
+  return (
+    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M3 12h18M12 3a15.3 15.3 0 0 1 4 9 15.3 15.3 0 0 1-4 9 15.3 15.3 0 0 1-4-9 15.3 15.3 0 0 1 4-9Z"
+      />
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+      />
+    </svg>
+  );
+}
+
 function GitHubIcon() {
   return (
     <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -601,6 +620,8 @@ const SOCIAL_LINKS = [
 
 function getSocialAccountIcon(account: SocialAccount) {
   switch (account.label.trim().toLowerCase()) {
+    case "website":
+      return <WebsiteIcon />;
     case "github":
       return <GitHubIcon />;
     case "linkedin":
@@ -1067,44 +1088,30 @@ function FeedProfileCard({
               <dd class="font-semibold text-gray-950 dark:text-gray-50">{postCount}</dd>
             </div>
           </dl>
-          <div class="mt-4 grid grid-cols-2 gap-3 border-t border-gray-200 pt-4 text-sm dark:border-gray-800">
+          <div class="mt-4 grid grid-cols-4 gap-2 border-t border-gray-200 pt-4 dark:border-gray-800">
             {getPublicProfileFields(baseUrl).map((field) => (
               <a
                 key={field.name}
                 href={field.href}
                 rel="me noopener noreferrer"
                 target={field.href.startsWith(baseUrl) ? undefined : "_blank"}
-                class="text-gray-600 underline-offset-4 hover:text-teal-700 hover:underline dark:text-gray-400 dark:hover:text-teal-300"
+                aria-label={field.name}
+                title={field.name}
+                class="flex aspect-square items-center justify-center rounded-xl border border-gray-200 text-gray-600 transition hover:border-teal-200 hover:bg-teal-50 hover:text-teal-700 dark:border-gray-800 dark:text-gray-400 dark:hover:border-teal-900/70 dark:hover:bg-teal-950/20 dark:hover:text-teal-300"
               >
-                <span class="font-medium text-gray-900 dark:text-gray-100">{field.name}</span>
-                <span class="sr-only">: </span>
-                <span class="block truncate">{field.text}</span>
+                {getSocialAccountIcon({
+                  id: 0,
+                  label: field.name,
+                  url: field.href,
+                  avatar_url: null,
+                  is_activitypub: false,
+                  is_default: false,
+                })}
+                <span class="sr-only">{field.text}</span>
               </a>
             ))}
           </div>
         </div>
-      </div>
-    </section>
-  );
-}
-
-function SocialMediaFeedCard() {
-  return (
-    <section class="border-b border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900 lg:mt-4 lg:rounded-2xl lg:border">
-      <h2 class="text-lg font-bold text-gray-950 dark:text-gray-50">Follow me</h2>
-      <div class="mt-4 grid grid-cols-5 gap-2">
-        {SOCIAL_LINKS.map((link) => (
-          <a
-            href={link.url}
-            target={link.url.startsWith("/") ? undefined : "_blank"}
-            rel={link.url.startsWith("/") ? undefined : "noopener noreferrer"}
-            aria-label={link.name}
-            title={link.name}
-            class="flex aspect-square items-center justify-center rounded-xl border border-gray-200 text-gray-600 transition hover:border-teal-200 hover:bg-teal-50 hover:text-teal-700 dark:border-gray-800 dark:text-gray-400 dark:hover:border-teal-900/70 dark:hover:bg-teal-950/20 dark:hover:text-teal-300"
-          >
-            {link.icon}
-          </a>
-        ))}
       </div>
     </section>
   );
@@ -1859,7 +1866,6 @@ export function createPagesRoutes(db: Database): Hono {
                 followingCount={followingCount}
                 postCount={totalPosts}
               />
-              <SocialMediaFeedCard />
               <ArticlesFeedCard />
               <RecommendedSitesFeedCard />
             </aside>
@@ -1963,7 +1969,6 @@ export function createPagesRoutes(db: Database): Hono {
               followingCount={followingCount}
               postCount={totalPosts}
             />
-            <SocialMediaFeedCard />
             <ArticlesFeedCard />
             <RecommendedSitesFeedCard />
           </aside>
@@ -2820,7 +2825,6 @@ export function createPagesRoutes(db: Database): Hono {
               followingCount={followingCount}
               postCount={totalPosts}
             />
-            <SocialMediaFeedCard />
             <ArticlesFeedCard />
             <RecommendedSitesFeedCard />
           </aside>


### PR DESCRIPTION
## Summary
- export structured public actor profile fields from the centralized ActivityPub actor profile module
- render Website, GitHub, LinkedIn, and YouTube in the feed actor card from those shared fields as normal HTML anchors
- add page and federation tests covering the shared profile metadata path

Task: task-0f217193

## Verification
- bun test src/federation/__tests__/actor-profile.test.ts src/routes/__tests__/pages.test.tsx
- npm run typecheck
- make check
- browser verification: opened /feed and confirmed Website/GitHub/LinkedIn/YouTube render in the actor card
- make dev-tail grep found no ERROR/WARN/error/Error output