### PR TITLE
Store incoming ActivityPub boosts

### DIFF
--- a/drizzle/0014_cuddly_smiling_tiger.sql
+++ b/drizzle/0014_cuddly_smiling_tiger.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `remote_boosts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`post_id` integer NOT NULL,
+	`object_uri` text NOT NULL,
+	`activity_uri` text NOT NULL,
+	`actor_uri` text NOT NULL,
+	`actor_name` text,
+	`raw_object_uri` text NOT NULL,
+	`received_at` integer NOT NULL,
+	FOREIGN KEY (`post_id`) REFERENCES `posts`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_boosts_activity_uri_unique` ON `remote_boosts` (`activity_uri`);

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1188 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "52bea801-94ad-4f4e-af2d-7dd88971a609",
+  "prevId": "5f85ab8f-1592-47d5-a95b-22e149d75c4c",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "person_social_accounts": {
+      "name": "person_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_social_accounts_person_id_people_id_fk": {
+          "name": "person_social_accounts_person_id_people_id_fk",
+          "tableFrom": "person_social_accounts",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_boosts": {
+      "name": "remote_boosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_boosts_activity_uri_unique": {
+          "name": "remote_boosts_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_boosts_post_id_posts_id_fk": {
+          "name": "remote_boosts_post_id_posts_id_fk",
+          "tableFrom": "remote_boosts",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_likes": {
+      "name": "remote_likes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_likes_activity_uri_unique": {
+          "name": "remote_likes_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_likes_post_id_posts_id_fk": {
+          "name": "remote_likes_post_id_posts_id_fk",
+          "tableFrom": "remote_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_social_accounts": {
+      "name": "source_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_social_accounts_source_id_sources_id_fk": {
+          "name": "source_social_accounts_source_id_sources_id_fk",
+          "tableFrom": "source_social_accounts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1777342283876,
       "tag": "0013_abnormal_black_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1777389372360,
+      "tag": "0014_cuddly_smiling_tiger",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -121,6 +121,20 @@ export const remoteLikes = sqliteTable("remote_likes", {
   received_at: integer("received_at", { mode: "timestamp" }).notNull(),
 });
 
+// ActivityPub boosts received from remote actors
+export const remoteBoosts = sqliteTable("remote_boosts", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  post_id: integer("post_id")
+    .notNull()
+    .references(() => posts.id, { onDelete: "cascade" }),
+  object_uri: text("object_uri").notNull(),
+  activity_uri: text("activity_uri").notNull().unique(),
+  actor_uri: text("actor_uri").notNull(),
+  actor_name: text("actor_name"),
+  raw_object_uri: text("raw_object_uri").notNull(),
+  received_at: integer("received_at", { mode: "timestamp" }).notNull(),
+});
+
 // Actor keys for ActivityPub signing
 export const actorKeys = sqliteTable("actor_keys", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/src/federation/__tests__/boosts.test.ts
+++ b/src/federation/__tests__/boosts.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const tempDir = mkdtempSync(join(tmpdir(), "ec-boosts-test-"));
+
+interface BoostsPayload {
+  localCount: number;
+  duplicateCount: number;
+  nonLocalCount: number;
+  unknownCount: number;
+  unpublishedCount: number;
+  storedActorUri: string | null;
+  storedObjectUri: string | null;
+  storedRawObjectUri: string | null;
+  deleted: boolean;
+  afterDeleteCount: number;
+}
+
+let payload: BoostsPayload | null = null;
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function loadPayload(): BoostsPayload {
+  if (payload) {
+    return payload;
+  }
+
+  const script = String.raw`
+    import { Announce, Person } from "@fedify/fedify";
+    import { createPost } from "./src/services/posts";
+    import {
+      deleteRemoteBoost,
+      getRemoteBoostCountForPost,
+      getRemoteBoostsForPost,
+      handleAnnounceActivity,
+    } from "./src/federation/boosts";
+
+    const publishedPost = createPost({
+      type: "note",
+      slug: "boosted-post",
+      content: "Published post",
+      published_at: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    const unpublishedPost = createPost({
+      type: "note",
+      slug: "draft-post",
+      content: "Draft post",
+    });
+
+    function actor() {
+      return new Person({
+        id: new URL("https://remote.example/users/alice"),
+        name: "Alice",
+        inbox: new URL("https://remote.example/users/alice/inbox"),
+      });
+    }
+
+    function announce(activityPath, objectUri) {
+      return new Announce({
+        id: new URL("https://remote.example/activities/" + activityPath),
+        actor: actor(),
+        object: new URL(objectUri),
+      });
+    }
+
+    await handleAnnounceActivity(announce("announce-1", "http://localhost:5000/posts/boosted-post"));
+    await handleAnnounceActivity(announce("announce-1", "http://localhost:5000/posts/boosted-post"));
+    await handleAnnounceActivity(announce("announce-2", "https://elsewhere.example/posts/boosted-post"));
+    await handleAnnounceActivity(announce("announce-3", "http://localhost:5000/posts/missing-post"));
+    await handleAnnounceActivity(announce("announce-4", "http://localhost:5000/posts/draft-post"));
+
+    const storedBoosts = getRemoteBoostsForPost(publishedPost.id);
+    const deleted = deleteRemoteBoost("https://remote.example/activities/announce-1");
+
+    console.log("__RESULT__" + JSON.stringify({
+      localCount: storedBoosts.length,
+      duplicateCount: storedBoosts.length,
+      nonLocalCount: storedBoosts.length,
+      unknownCount: storedBoosts.length,
+      unpublishedCount: getRemoteBoostCountForPost(unpublishedPost.id),
+      storedActorUri: storedBoosts[0]?.actor_uri ?? null,
+      storedObjectUri: storedBoosts[0]?.object_uri ?? null,
+      storedRawObjectUri: storedBoosts[0]?.raw_object_uri ?? null,
+      deleted,
+      afterDeleteCount: getRemoteBoostCountForPost(publishedPost.id),
+    }));
+  `;
+
+  const result = Bun.spawnSync({
+    cmd: ["bun", "--eval", script],
+    env: {
+      ...process.env,
+      DATABASE_PATH: join(tempDir, "site.db"),
+      FEDIFY_KV_PATH: join(tempDir, "fedify-kv.db"),
+      DOMAIN: "localhost:5000",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (result.exitCode !== 0) {
+    throw new Error(`Remote boost check failed: ${result.stderr.toString()}`);
+  }
+
+  const resultLine = result.stdout
+    .toString()
+    .split("\n")
+    .find((line) => line.startsWith("__RESULT__"));
+
+  if (!resultLine) {
+    throw new Error(`Remote boost check did not return JSON: ${result.stdout.toString()}`);
+  }
+
+  payload = JSON.parse(resultLine.slice("__RESULT__".length)) as BoostsPayload;
+  return payload;
+}
+
+describe("ActivityPub remote boosts", () => {
+  it("stores a valid Announce for a local published post", () => {
+    const result = loadPayload();
+
+    expect(result.localCount).toBe(1);
+    expect(result.storedActorUri).toBe("https://remote.example/users/alice");
+    expect(result.storedObjectUri).toBe("http://localhost:5000/posts/boosted-post");
+    expect(result.storedRawObjectUri).toBe("http://localhost:5000/posts/boosted-post");
+  });
+
+  it("is idempotent for duplicate Announce delivery", () => {
+    const result = loadPayload();
+
+    expect(result.duplicateCount).toBe(1);
+  });
+
+  it("ignores non-local, unknown, and unpublished targets safely", () => {
+    const result = loadPayload();
+
+    expect(result.nonLocalCount).toBe(1);
+    expect(result.unknownCount).toBe(1);
+    expect(result.unpublishedCount).toBe(0);
+  });
+
+  it("supports deleting stored remote boosts", () => {
+    const result = loadPayload();
+
+    expect(result.deleted).toBe(true);
+    expect(result.afterDeleteCount).toBe(0);
+  });
+});

--- a/src/federation/boosts.ts
+++ b/src/federation/boosts.ts
@@ -1,0 +1,143 @@
+import { and, count, eq, isNotNull } from "drizzle-orm";
+import { Announce } from "@fedify/fedify";
+
+import { db, posts, remoteBoosts } from "@/db";
+import { logger } from "@/utils/logger";
+import { getOrigin } from "./utils";
+
+const domain = process.env.DOMAIN || "localhost:5000";
+type BoostsDatabase = typeof db;
+
+export interface RemoteBoost {
+  id: number;
+  post_id: number;
+  object_uri: string;
+  activity_uri: string;
+  actor_uri: string;
+  actor_name: string | null;
+  raw_object_uri: string;
+  received_at: Date;
+}
+
+export interface NewRemoteBoost {
+  post_id: number;
+  object_uri: string;
+  activity_uri: string;
+  actor_uri: string;
+  actor_name?: string | null;
+  raw_object_uri: string;
+}
+
+export function resolveLocalPublishedPostFromAnnouncedObjectUri(objectUri: string) {
+  let url: URL;
+
+  try {
+    url = new URL(objectUri);
+  } catch {
+    return null;
+  }
+
+  const expectedOrigin = getOrigin(domain);
+  if (url.origin !== expectedOrigin) {
+    return null;
+  }
+
+  const match = /^\/posts\/([^/]+)\/?$/.exec(url.pathname);
+  if (!match) {
+    return null;
+  }
+
+  const slug = decodeURIComponent(match[1]!);
+  return db
+    .select({ id: posts.id, slug: posts.slug })
+    .from(posts)
+    .where(and(eq(posts.slug, slug), isNotNull(posts.published_at)))
+    .get();
+}
+
+export function addRemoteBoost(
+  input: NewRemoteBoost,
+  database: BoostsDatabase = db
+): RemoteBoost | null {
+  const existing = database
+    .select()
+    .from(remoteBoosts)
+    .where(eq(remoteBoosts.activity_uri, input.activity_uri))
+    .get();
+
+  if (existing) {
+    logger.debug("federation", `Remote boost already exists: ${input.activity_uri}`);
+    return existing;
+  }
+
+  return database
+    .insert(remoteBoosts)
+    .values({
+      post_id: input.post_id,
+      object_uri: input.object_uri,
+      activity_uri: input.activity_uri,
+      actor_uri: input.actor_uri,
+      actor_name: input.actor_name ?? null,
+      raw_object_uri: input.raw_object_uri,
+      received_at: new Date(),
+    })
+    .returning()
+    .get();
+}
+
+export function getRemoteBoostsForPost(
+  postId: number,
+  database: BoostsDatabase = db
+): RemoteBoost[] {
+  return database.select().from(remoteBoosts).where(eq(remoteBoosts.post_id, postId)).all();
+}
+
+export function getRemoteBoostCountForPost(postId: number, database: BoostsDatabase = db): number {
+  const result = database
+    .select({ count: count() })
+    .from(remoteBoosts)
+    .where(eq(remoteBoosts.post_id, postId))
+    .get();
+  return result?.count ?? 0;
+}
+
+export function deleteRemoteBoost(activityUri: string, database: BoostsDatabase = db): boolean {
+  const deleted = database
+    .delete(remoteBoosts)
+    .where(eq(remoteBoosts.activity_uri, activityUri))
+    .returning()
+    .get();
+  return Boolean(deleted);
+}
+
+export async function handleAnnounceActivity(announce: Announce): Promise<void> {
+  const activityId = announce.id;
+  const actorId = announce.actorId;
+  const objectId = announce.objectId;
+
+  if (!activityId || !actorId || !objectId) {
+    logger.warn("federation", "Announce activity missing id, actor, or object");
+    return;
+  }
+
+  const post = resolveLocalPublishedPostFromAnnouncedObjectUri(objectId.href);
+  if (!post) {
+    logger.debug(
+      "federation",
+      `Ignoring Announce for unknown or non-local object: ${objectId.href}`
+    );
+    return;
+  }
+
+  const stored = addRemoteBoost({
+    post_id: post.id,
+    object_uri: objectId.href,
+    activity_uri: activityId.href,
+    actor_uri: actorId.href,
+    raw_object_uri: objectId.href,
+  });
+
+  if (stored) {
+    logger.info("federation", `Stored Announce ${activityId.href} for post ${post.slug}`);
+  }
+}

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -3,6 +3,7 @@ import {
   Follow,
   Undo,
   Like,
+  Announce,
   Accept,
   isActor,
   InProcessMessageQueue,
@@ -15,6 +16,7 @@ import { getOrigin } from "./utils";
 import { logger } from "@/utils/logger";
 import { buildActorProfile } from "./actor-profile";
 import { handleLikeActivity } from "./likes";
+import { handleAnnounceActivity } from "./boosts";
 
 // Context type for federation - we use void since we don't need request-specific data
 export type FederationContext = void;
@@ -172,6 +174,9 @@ export function createFedifyFederation() {
     })
     .on(Like, async (_ctx, like) => {
       await handleLikeActivity(like);
+    })
+    .on(Announce, async (_ctx, announce) => {
+      await handleAnnounceActivity(announce);
     });
 
   // Set up outbox dispatcher - lists activities sent by this actor


### PR DESCRIPTION
## Summary
- add a remote_boosts table and generated Drizzle migration
- store valid incoming Announce activities for local published posts idempotently
- register Announce inbox handling alongside existing Follow, Undo, and Like handlers
- cover valid, duplicate, ignored, and delete boost behavior with federation tests

## Verification
- bun test src/federation/__tests__/boosts.test.ts src/federation/__tests__/likes.test.ts src/federation/__tests__/following.test.ts
- npm run typecheck
- make check
- make dev-tail grep for errors/warnings
- pre-push checks passed