### PR TITLE
Store incoming ActivityPub replies as pending comments

### DIFF
--- a/drizzle/0015_heavy_wolfpack.sql
+++ b/drizzle/0015_heavy_wolfpack.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `remote_comments` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`post_id` integer NOT NULL,
+	`activity_uri` text NOT NULL,
+	`object_uri` text NOT NULL,
+	`actor_uri` text NOT NULL,
+	`actor_name` text,
+	`actor_url` text,
+	`content_html` text NOT NULL,
+	`content_text` text NOT NULL,
+	`in_reply_to_uri` text NOT NULL,
+	`moderation_status` text DEFAULT 'pending' NOT NULL,
+	`raw_source` text NOT NULL,
+	`published_at` integer,
+	`received_at` integer NOT NULL,
+	FOREIGN KEY (`post_id`) REFERENCES `posts`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_comments_activity_uri_unique` ON `remote_comments` (`activity_uri`);--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_comments_object_uri_unique` ON `remote_comments` (`object_uri`);

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1318 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e8405231-bcac-4818-9676-01d03d51ff6e",
+  "prevId": "52bea801-94ad-4f4e-af2d-7dd88971a609",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "person_social_accounts": {
+      "name": "person_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_social_accounts_person_id_people_id_fk": {
+          "name": "person_social_accounts_person_id_people_id_fk",
+          "tableFrom": "person_social_accounts",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_boosts": {
+      "name": "remote_boosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_boosts_activity_uri_unique": {
+          "name": "remote_boosts_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_boosts_post_id_posts_id_fk": {
+          "name": "remote_boosts_post_id_posts_id_fk",
+          "tableFrom": "remote_boosts",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_comments": {
+      "name": "remote_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_url": {
+          "name": "actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "in_reply_to_uri": {
+          "name": "in_reply_to_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "raw_source": {
+          "name": "raw_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_comments_activity_uri_unique": {
+          "name": "remote_comments_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        },
+        "remote_comments_object_uri_unique": {
+          "name": "remote_comments_object_uri_unique",
+          "columns": ["object_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_comments_post_id_posts_id_fk": {
+          "name": "remote_comments_post_id_posts_id_fk",
+          "tableFrom": "remote_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_likes": {
+      "name": "remote_likes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_likes_activity_uri_unique": {
+          "name": "remote_likes_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_likes_post_id_posts_id_fk": {
+          "name": "remote_likes_post_id_posts_id_fk",
+          "tableFrom": "remote_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_social_accounts": {
+      "name": "source_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_social_accounts_source_id_sources_id_fk": {
+          "name": "source_social_accounts_source_id_sources_id_fk",
+          "tableFrom": "source_social_accounts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1777389372360,
       "tag": "0014_cuddly_smiling_tiger",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1777391490638,
+      "tag": "0015_heavy_wolfpack",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -135,6 +135,26 @@ export const remoteBoosts = sqliteTable("remote_boosts", {
   received_at: integer("received_at", { mode: "timestamp" }).notNull(),
 });
 
+// ActivityPub replies received from remote actors and stored as moderated comments
+export const remoteComments = sqliteTable("remote_comments", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  post_id: integer("post_id")
+    .notNull()
+    .references(() => posts.id, { onDelete: "cascade" }),
+  activity_uri: text("activity_uri").notNull().unique(),
+  object_uri: text("object_uri").notNull().unique(),
+  actor_uri: text("actor_uri").notNull(),
+  actor_name: text("actor_name"),
+  actor_url: text("actor_url"),
+  content_html: text("content_html").notNull(),
+  content_text: text("content_text").notNull(),
+  in_reply_to_uri: text("in_reply_to_uri").notNull(),
+  moderation_status: text("moderation_status").notNull().default("pending"),
+  raw_source: text("raw_source").notNull(),
+  published_at: integer("published_at", { mode: "timestamp" }),
+  received_at: integer("received_at", { mode: "timestamp" }).notNull(),
+});
+
 // Actor keys for ActivityPub signing
 export const actorKeys = sqliteTable("actor_keys", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/src/federation/__tests__/replies.test.ts
+++ b/src/federation/__tests__/replies.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const tempDir = mkdtempSync(join(tmpdir(), "ec-replies-test-"));
+
+interface RepliesPayload {
+  localCount: number;
+  duplicateCount: number;
+  nonLocalCount: number;
+  unknownCount: number;
+  unpublishedCount: number;
+  unsupportedCount: number;
+  storedActivityUri: string | null;
+  storedObjectUri: string | null;
+  storedActorUri: string | null;
+  storedActorName: string | null;
+  storedActorUrl: string | null;
+  storedContentHtml: string | null;
+  storedContentText: string | null;
+  storedInReplyToUri: string | null;
+  storedModerationStatus: string | null;
+  storedPublishedAt: string | null;
+  rawSourceIncludesContent: boolean;
+  deleted: boolean;
+  afterDeleteCount: number;
+}
+
+let payload: RepliesPayload | null = null;
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function loadPayload(): RepliesPayload {
+  if (payload) {
+    return payload;
+  }
+
+  const script = String.raw`
+    import { Article, Create, Note, Person } from "@fedify/fedify";
+    import { Temporal } from "@js-temporal/polyfill";
+    import { createPost } from "./src/services/posts";
+    import {
+      deleteRemoteCommentByActivityUri,
+      getRemoteCommentCountForPost,
+      getRemoteCommentsForPost,
+      handleCreateActivity,
+    } from "./src/federation/replies";
+    import { dateToInstant } from "./src/federation/utils";
+
+    const publishedPost = createPost({
+      type: "note",
+      slug: "commented-post",
+      content: "Published post",
+      published_at: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    const unpublishedPost = createPost({
+      type: "note",
+      slug: "draft-post",
+      content: "Draft post",
+    });
+
+    function actor() {
+      return new Person({
+        id: new URL("https://remote.example/users/alice"),
+        name: "Alice Example",
+        url: new URL("https://remote.example/@alice"),
+        inbox: new URL("https://remote.example/users/alice/inbox"),
+      });
+    }
+
+    function note(objectPath, replyTarget, content = '<p>Hello <strong>world</strong><script>alert("xss")</script></p>') {
+      return new Note({
+        id: new URL("https://remote.example/objects/" + objectPath),
+        content,
+        replyTarget: new URL(replyTarget),
+        published: dateToInstant(new Date("2026-02-03T04:05:06.000Z")),
+      });
+    }
+
+    function create(activityPath, object) {
+      return new Create({
+        id: new URL("https://remote.example/activities/" + activityPath),
+        actor: actor(),
+        object,
+        published: Temporal.Instant.from("2026-02-03T04:05:07Z"),
+      });
+    }
+
+    await handleCreateActivity(create("create-1", note("reply-1", "http://localhost:5000/posts/commented-post")));
+    await handleCreateActivity(create("create-1", note("reply-1", "http://localhost:5000/posts/commented-post")));
+    await handleCreateActivity(create("create-2", note("reply-2", "https://elsewhere.example/posts/commented-post")));
+    await handleCreateActivity(create("create-3", note("reply-3", "http://localhost:5000/posts/missing-post")));
+    await handleCreateActivity(create("create-4", note("reply-4", "http://localhost:5000/posts/draft-post")));
+    await handleCreateActivity(create("create-5", new Article({
+      id: new URL("https://remote.example/objects/article-1"),
+      content: "Unsupported",
+      replyTarget: new URL("http://localhost:5000/posts/commented-post"),
+    })));
+
+    const storedComments = getRemoteCommentsForPost(publishedPost.id);
+    const deleted = deleteRemoteCommentByActivityUri("https://remote.example/activities/create-1");
+
+    console.log("__RESULT__" + JSON.stringify({
+      localCount: storedComments.length,
+      duplicateCount: storedComments.length,
+      nonLocalCount: storedComments.length,
+      unknownCount: storedComments.length,
+      unpublishedCount: getRemoteCommentCountForPost(unpublishedPost.id),
+      unsupportedCount: storedComments.length,
+      storedActivityUri: storedComments[0]?.activity_uri ?? null,
+      storedObjectUri: storedComments[0]?.object_uri ?? null,
+      storedActorUri: storedComments[0]?.actor_uri ?? null,
+      storedActorName: storedComments[0]?.actor_name ?? null,
+      storedActorUrl: storedComments[0]?.actor_url ?? null,
+      storedContentHtml: storedComments[0]?.content_html ?? null,
+      storedContentText: storedComments[0]?.content_text ?? null,
+      storedInReplyToUri: storedComments[0]?.in_reply_to_uri ?? null,
+      storedModerationStatus: storedComments[0]?.moderation_status ?? null,
+      storedPublishedAt: storedComments[0]?.published_at?.toISOString() ?? null,
+      rawSourceIncludesContent: storedComments[0]?.raw_source.includes("Hello") ?? false,
+      deleted,
+      afterDeleteCount: getRemoteCommentCountForPost(publishedPost.id),
+    }));
+  `;
+
+  const result = Bun.spawnSync({
+    cmd: ["bun", "--eval", script],
+    env: {
+      ...process.env,
+      DATABASE_PATH: join(tempDir, "site.db"),
+      FEDIFY_KV_PATH: join(tempDir, "fedify-kv.db"),
+      DOMAIN: "localhost:5000",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  if (result.exitCode !== 0) {
+    throw new Error(`Remote reply check failed: ${result.stderr.toString()}`);
+  }
+
+  const resultLine = result.stdout
+    .toString()
+    .split("\n")
+    .find((line) => line.startsWith("__RESULT__"));
+
+  if (!resultLine) {
+    throw new Error(`Remote reply check did not return JSON: ${result.stdout.toString()}`);
+  }
+
+  payload = JSON.parse(resultLine.slice("__RESULT__".length)) as RepliesPayload;
+  return payload;
+}
+
+describe("ActivityPub remote replies", () => {
+  it("stores a valid Create(Note) reply for a local published post as pending", () => {
+    const result = loadPayload();
+
+    expect(result.localCount).toBe(1);
+    expect(result.storedActivityUri).toBe("https://remote.example/activities/create-1");
+    expect(result.storedObjectUri).toBe("https://remote.example/objects/reply-1");
+    expect(result.storedActorUri).toBe("https://remote.example/users/alice");
+    expect(result.storedActorName).toBe("Alice Example");
+    expect(result.storedActorUrl).toBe("https://remote.example/@alice");
+    expect(result.storedInReplyToUri).toBe("http://localhost:5000/posts/commented-post");
+    expect(result.storedModerationStatus).toBe("pending");
+    expect(result.storedPublishedAt).toBe("2026-02-03T04:05:06.000Z");
+    expect(result.rawSourceIncludesContent).toBe(true);
+  });
+
+  it("is idempotent for duplicate Create delivery", () => {
+    const result = loadPayload();
+
+    expect(result.duplicateCount).toBe(1);
+  });
+
+  it("ignores non-local, unknown, unpublished, and unsupported replies safely", () => {
+    const result = loadPayload();
+
+    expect(result.nonLocalCount).toBe(1);
+    expect(result.unknownCount).toBe(1);
+    expect(result.unpublishedCount).toBe(0);
+    expect(result.unsupportedCount).toBe(1);
+  });
+
+  it("stores sanitized display-safe content", () => {
+    const result = loadPayload();
+
+    expect(result.storedContentHtml).toBe("Hello worldalert(&quot;xss&quot;)");
+    expect(result.storedContentText).toBe('Hello worldalert("xss")');
+    expect(result.storedContentHtml).not.toContain("<script>");
+    expect(result.storedContentHtml).not.toContain("<strong>");
+  });
+
+  it("supports deleting stored remote replies", () => {
+    const result = loadPayload();
+
+    expect(result.deleted).toBe(true);
+    expect(result.afterDeleteCount).toBe(0);
+  });
+});

--- a/src/federation/replies.ts
+++ b/src/federation/replies.ts
@@ -1,0 +1,240 @@
+import { and, count, eq, isNotNull, or } from "drizzle-orm";
+import { Create, isActor, Link, Note } from "@fedify/fedify";
+
+import { db, posts, remoteComments } from "@/db";
+import { escapeHtml, stripHtml } from "@/utils/markdown";
+import { logger } from "@/utils/logger";
+import { getOrigin } from "./utils";
+
+const domain = process.env.DOMAIN || "localhost:5000";
+type RepliesDatabase = typeof db;
+
+export const REMOTE_COMMENT_PENDING_STATUS = "pending";
+
+export interface RemoteComment {
+  id: number;
+  post_id: number;
+  activity_uri: string;
+  object_uri: string;
+  actor_uri: string;
+  actor_name: string | null;
+  actor_url: string | null;
+  content_html: string;
+  content_text: string;
+  in_reply_to_uri: string;
+  moderation_status: string;
+  raw_source: string;
+  published_at: Date | null;
+  received_at: Date;
+}
+
+export interface NewRemoteComment {
+  post_id: number;
+  activity_uri: string;
+  object_uri: string;
+  actor_uri: string;
+  actor_name?: string | null;
+  actor_url?: string | null;
+  content_html: string;
+  content_text: string;
+  in_reply_to_uri: string;
+  raw_source: string;
+  published_at?: Date | null;
+  moderation_status?: string;
+}
+
+interface LocalPostReference {
+  id: number;
+  slug: string;
+}
+
+export function sanitizeRemoteReplyContent(content: string): { html: string; text: string } {
+  const text = stripHtml(content).trim();
+  return {
+    html: escapeHtml(text),
+    text,
+  };
+}
+
+export function resolveLocalPublishedPostFromReplyTargetUri(
+  replyTargetUri: string
+): LocalPostReference | null {
+  let url: URL;
+
+  try {
+    url = new URL(replyTargetUri);
+  } catch {
+    return null;
+  }
+
+  const expectedOrigin = getOrigin(domain);
+  if (url.origin !== expectedOrigin) {
+    return null;
+  }
+
+  const match = /^\/posts\/([^/]+)\/?$/.exec(url.pathname);
+  if (!match) {
+    return null;
+  }
+
+  const slug = decodeURIComponent(match[1]!);
+  return (
+    db
+      .select({ id: posts.id, slug: posts.slug })
+      .from(posts)
+      .where(and(eq(posts.slug, slug), isNotNull(posts.published_at)))
+      .get() ?? null
+  );
+}
+
+export function addRemoteComment(
+  input: NewRemoteComment,
+  database: RepliesDatabase = db
+): RemoteComment | null {
+  const existing = database
+    .select()
+    .from(remoteComments)
+    .where(
+      or(
+        eq(remoteComments.activity_uri, input.activity_uri),
+        eq(remoteComments.object_uri, input.object_uri)
+      )
+    )
+    .get();
+
+  if (existing) {
+    logger.debug("federation", `Remote comment already exists: ${input.object_uri}`);
+    return existing;
+  }
+
+  return database
+    .insert(remoteComments)
+    .values({
+      post_id: input.post_id,
+      activity_uri: input.activity_uri,
+      object_uri: input.object_uri,
+      actor_uri: input.actor_uri,
+      actor_name: input.actor_name ?? null,
+      actor_url: input.actor_url ?? null,
+      content_html: input.content_html,
+      content_text: input.content_text,
+      in_reply_to_uri: input.in_reply_to_uri,
+      moderation_status: input.moderation_status ?? REMOTE_COMMENT_PENDING_STATUS,
+      raw_source: input.raw_source,
+      published_at: input.published_at ?? null,
+      received_at: new Date(),
+    })
+    .returning()
+    .get();
+}
+
+export function getRemoteCommentsForPost(
+  postId: number,
+  database: RepliesDatabase = db
+): RemoteComment[] {
+  return database.select().from(remoteComments).where(eq(remoteComments.post_id, postId)).all();
+}
+
+export function getRemoteCommentCountForPost(
+  postId: number,
+  database: RepliesDatabase = db
+): number {
+  const result = database
+    .select({ count: count() })
+    .from(remoteComments)
+    .where(eq(remoteComments.post_id, postId))
+    .get();
+  return result?.count ?? 0;
+}
+
+export function deleteRemoteCommentByActivityUri(
+  activityUri: string,
+  database: RepliesDatabase = db
+): boolean {
+  const deleted = database
+    .delete(remoteComments)
+    .where(eq(remoteComments.activity_uri, activityUri))
+    .returning()
+    .get();
+  return Boolean(deleted);
+}
+
+export async function handleCreateActivity(create: Create): Promise<void> {
+  const activityId = create.id;
+  const actorId = create.actorId;
+
+  if (!activityId || !actorId) {
+    logger.warn("federation", "Create activity missing id or actor");
+    return;
+  }
+
+  const object = await create.getObject({ suppressError: true });
+  if (!(object instanceof Note)) {
+    logger.debug("federation", `Ignoring Create with unsupported object type: ${activityId.href}`);
+    return;
+  }
+
+  const replyTargetId = object.replyTargetId;
+  const objectId = object.id;
+  if (!replyTargetId || !objectId) {
+    logger.debug(
+      "federation",
+      `Ignoring Create without reply target or object id: ${activityId.href}`
+    );
+    return;
+  }
+
+  const post = resolveLocalPublishedPostFromReplyTargetUri(replyTargetId.href);
+  if (!post) {
+    logger.debug(
+      "federation",
+      `Ignoring Create reply for unknown or non-local object: ${replyTargetId.href}`
+    );
+    return;
+  }
+
+  const content = stringValue(object.content);
+  const sanitized = sanitizeRemoteReplyContent(content);
+  const actor = await create.getActor({ suppressError: true });
+  const rawSource = await serializeRawSource(object);
+  const stored = addRemoteComment({
+    post_id: post.id,
+    activity_uri: activityId.href,
+    object_uri: objectId.href,
+    actor_uri: actorId.href,
+    actor_name: actor && isActor(actor) ? stringValue(actor.name) : null,
+    actor_url: actor && isActor(actor) ? urlValue(actor.url) : null,
+    content_html: sanitized.html,
+    content_text: sanitized.text,
+    in_reply_to_uri: replyTargetId.href,
+    raw_source: rawSource,
+    published_at: object.published ? new Date(object.published.epochMilliseconds) : null,
+  });
+
+  if (stored) {
+    logger.info("federation", `Stored Create reply ${activityId.href} for post ${post.slug}`);
+  }
+}
+
+function stringValue(value: string | { toString(): string } | null): string {
+  return typeof value === "string" ? value : (value?.toString() ?? "");
+}
+
+function urlValue(value: URL | Link | null): string | null {
+  if (value instanceof URL) {
+    return value.href;
+  }
+
+  return value?.href?.href ?? null;
+}
+
+async function serializeRawSource(object: Note): Promise<string> {
+  try {
+    return JSON.stringify(await object.toJsonLd({ format: "compact" }));
+  } catch (error) {
+    logger.debug("federation", "Failed to serialize remote reply source", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return JSON.stringify({ id: object.id?.href ?? null, type: "Note" });
+  }
+}

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -4,6 +4,7 @@ import {
   Undo,
   Like,
   Announce,
+  Create,
   Accept,
   isActor,
   InProcessMessageQueue,
@@ -17,6 +18,7 @@ import { logger } from "@/utils/logger";
 import { buildActorProfile } from "./actor-profile";
 import { handleLikeActivity } from "./likes";
 import { handleAnnounceActivity } from "./boosts";
+import { handleCreateActivity } from "./replies";
 
 // Context type for federation - we use void since we don't need request-specific data
 export type FederationContext = void;
@@ -177,6 +179,9 @@ export function createFedifyFederation() {
     })
     .on(Announce, async (_ctx, announce) => {
       await handleAnnounceActivity(announce);
+    })
+    .on(Create, async (_ctx, create) => {
+      await handleCreateActivity(create);
     });
 
   // Set up outbox dispatcher - lists activities sent by this actor


### PR DESCRIPTION
## Summary
- add a remote_comments table and generated Drizzle migration
- store valid inbound Create(Note) replies to local published posts as pending remote comments
- sanitize remote reply content before storing display-safe fields
- keep duplicate delivery idempotent by activity/object URI
- add Create inbox handling without disrupting existing Follow, Undo, Like, or Announce handlers

## Verification
- bun test src/federation/__tests__/replies.test.ts src/federation/__tests__/boosts.test.ts src/federation/__tests__/likes.test.ts src/federation/__tests__/following.test.ts
- npm run typecheck
- make check
- make dev-tail grep for errors/warnings
- pre-push checks passed