### PR TITLE
Moderate and display federated comments

### DIFF
--- a/drizzle/0016_needy_flatman.sql
+++ b/drizzle/0016_needy_flatman.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `remote_comments` ADD `moderated_at` integer;

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1325 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6d509d24-852d-47d5-8ce8-163cc6580e84",
+  "prevId": "e8405231-bcac-4818-9676-01d03d51ff6e",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "person_social_accounts": {
+      "name": "person_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_social_accounts_person_id_people_id_fk": {
+          "name": "person_social_accounts_person_id_people_id_fk",
+          "tableFrom": "person_social_accounts",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_boosts": {
+      "name": "remote_boosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_boosts_activity_uri_unique": {
+          "name": "remote_boosts_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_boosts_post_id_posts_id_fk": {
+          "name": "remote_boosts_post_id_posts_id_fk",
+          "tableFrom": "remote_boosts",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_comments": {
+      "name": "remote_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_url": {
+          "name": "actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "in_reply_to_uri": {
+          "name": "in_reply_to_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "raw_source": {
+          "name": "raw_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderated_at": {
+          "name": "moderated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_comments_activity_uri_unique": {
+          "name": "remote_comments_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        },
+        "remote_comments_object_uri_unique": {
+          "name": "remote_comments_object_uri_unique",
+          "columns": ["object_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_comments_post_id_posts_id_fk": {
+          "name": "remote_comments_post_id_posts_id_fk",
+          "tableFrom": "remote_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_likes": {
+      "name": "remote_likes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_likes_activity_uri_unique": {
+          "name": "remote_likes_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_likes_post_id_posts_id_fk": {
+          "name": "remote_likes_post_id_posts_id_fk",
+          "tableFrom": "remote_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_social_accounts": {
+      "name": "source_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_social_accounts_source_id_sources_id_fk": {
+          "name": "source_social_accounts_source_id_sources_id_fk",
+          "tableFrom": "source_social_accounts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1777391490638,
       "tag": "0015_heavy_wolfpack",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1777394393844,
+      "tag": "0016_needy_flatman",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -153,6 +153,7 @@ export const remoteComments = sqliteTable("remote_comments", {
   raw_source: text("raw_source").notNull(),
   published_at: integer("published_at", { mode: "timestamp" }),
   received_at: integer("received_at", { mode: "timestamp" }).notNull(),
+  moderated_at: integer("moderated_at", { mode: "timestamp" }),
 });
 
 // Actor keys for ActivityPub signing

--- a/src/federation/__tests__/outbox.test.ts
+++ b/src/federation/__tests__/outbox.test.ts
@@ -206,6 +206,14 @@ describe("postToObject", () => {
 
       expect(result.published).toBeDefined();
     });
+
+    it("exposes a replies collection URL", async () => {
+      const post = createPost({ type: "note", slug: "replyable-post", title: null });
+      const result = postToObject(post, actorUri, followersUri);
+      const json = (await result.toJsonLd()) as Record<string, unknown>;
+
+      expect(String(json.replies)).toContain("/posts/replyable-post/replies");
+    });
   });
 
   describe("hashtags", () => {

--- a/src/federation/post-object.ts
+++ b/src/federation/post-object.ts
@@ -114,6 +114,8 @@ export function postToObject(
     updated: post.updated_at ? dateToInstant(new Date(post.updated_at)) : undefined,
     // For links, url points to external article so Mastodon links there and generates preview
     url: post.type === "link" && post.url ? new URL(post.url) : postUri,
+    // Expose approved remote replies as a first-class ActivityPub replies collection.
+    replies: new URL(`/posts/${post.slug}/replies`, baseUrl),
     attachments: attachments.length > 0 ? attachments : undefined,
     // Include tags as ActivityPub Hashtag objects for discoverability
     tags: hashtags.length > 0 ? hashtags : undefined,

--- a/src/federation/replies.ts
+++ b/src/federation/replies.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, isNotNull, or } from "drizzle-orm";
+import { and, count, desc, eq, isNotNull, or } from "drizzle-orm";
 import { Create, isActor, Link, Note } from "@fedify/fedify";
 
 import { db, posts, remoteComments } from "@/db";
@@ -10,6 +10,8 @@ const domain = process.env.DOMAIN || "localhost:5000";
 type RepliesDatabase = typeof db;
 
 export const REMOTE_COMMENT_PENDING_STATUS = "pending";
+export const REMOTE_COMMENT_APPROVED_STATUS = "approved";
+export const REMOTE_COMMENT_HIDDEN_STATUS = "hidden";
 
 export interface RemoteComment {
   id: number;
@@ -26,6 +28,7 @@ export interface RemoteComment {
   raw_source: string;
   published_at: Date | null;
   received_at: Date;
+  moderated_at: Date | null;
 }
 
 export interface NewRemoteComment {
@@ -132,7 +135,75 @@ export function getRemoteCommentsForPost(
   postId: number,
   database: RepliesDatabase = db
 ): RemoteComment[] {
-  return database.select().from(remoteComments).where(eq(remoteComments.post_id, postId)).all();
+  return database
+    .select()
+    .from(remoteComments)
+    .where(eq(remoteComments.post_id, postId))
+    .orderBy(desc(remoteComments.published_at), desc(remoteComments.received_at))
+    .all();
+}
+
+export function getVisibleRemoteCommentsForPost(
+  postId: number,
+  options: { includeNonPublic?: boolean; database?: RepliesDatabase } = {}
+): RemoteComment[] {
+  const database = options.database ?? db;
+  const filters = options.includeNonPublic
+    ? eq(remoteComments.post_id, postId)
+    : and(
+        eq(remoteComments.post_id, postId),
+        eq(remoteComments.moderation_status, REMOTE_COMMENT_APPROVED_STATUS)
+      );
+
+  return database
+    .select()
+    .from(remoteComments)
+    .where(filters)
+    .orderBy(desc(remoteComments.published_at), desc(remoteComments.received_at))
+    .all();
+}
+
+export function listPendingRemoteComments(database: RepliesDatabase = db): RemoteComment[] {
+  return database
+    .select()
+    .from(remoteComments)
+    .where(eq(remoteComments.moderation_status, REMOTE_COMMENT_PENDING_STATUS))
+    .orderBy(desc(remoteComments.received_at))
+    .all();
+}
+
+export function approveRemoteComment(
+  commentId: number,
+  database: RepliesDatabase = db
+): RemoteComment | null {
+  return (
+    database
+      .update(remoteComments)
+      .set({
+        moderation_status: REMOTE_COMMENT_APPROVED_STATUS,
+        moderated_at: new Date(),
+      })
+      .where(eq(remoteComments.id, commentId))
+      .returning()
+      .get() ?? null
+  );
+}
+
+export function hideRemoteComment(
+  commentId: number,
+  database: RepliesDatabase = db
+): RemoteComment | null {
+  return (
+    database
+      .update(remoteComments)
+      .set({
+        moderation_status: REMOTE_COMMENT_HIDDEN_STATUS,
+        moderated_at: new Date(),
+      })
+      .where(eq(remoteComments.id, commentId))
+      .returning()
+      .get() ?? null
+  );
 }
 
 export function getRemoteCommentCountForPost(

--- a/src/federation/replies.ts
+++ b/src/federation/replies.ts
@@ -218,6 +218,23 @@ export function getRemoteCommentCountForPost(
   return result?.count ?? 0;
 }
 
+export function getApprovedRemoteCommentCountForPost(
+  postId: number,
+  database: RepliesDatabase = db
+): number {
+  const result = database
+    .select({ count: count() })
+    .from(remoteComments)
+    .where(
+      and(
+        eq(remoteComments.post_id, postId),
+        eq(remoteComments.moderation_status, REMOTE_COMMENT_APPROVED_STATUS)
+      )
+    )
+    .get();
+  return result?.count ?? 0;
+}
+
 export function deleteRemoteCommentByActivityUri(
   activityUri: string,
   database: RepliesDatabase = db

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -12,6 +12,7 @@ import {
   tags,
   postTags,
   remoteLikes,
+  remoteComments,
 } from "../../db/schema";
 import { eq } from "drizzle-orm";
 
@@ -72,6 +73,7 @@ mock.module("@/auth/api-key", () => {
 });
 
 beforeEach(() => {
+  testDb.delete(remoteComments).run();
   testDb.delete(remoteLikes).run();
   testDb.delete(postTags).run();
   testDb.delete(tags).run();
@@ -472,6 +474,108 @@ describe("GET /api/posts/by-slug/:slug", () => {
     expect(res.status).toBe(404);
     const json = await res.json();
     expect(json.error).toBe("Post not found");
+  });
+});
+
+describe("Remote comment moderation API", () => {
+  let api: typeof import("../api").api;
+
+  beforeAll(async () => {
+    const module = await import("../api");
+    api = module.api;
+  });
+
+  function createCommentFixture(status = "pending") {
+    const now = new Date("2026-03-01T00:00:00.000Z");
+    const post = testDb
+      .insert(posts)
+      .values({
+        slug: `comment-api-post-${status}`,
+        type: "note",
+        content: "Comment API post",
+        published_at: now,
+        created_at: now,
+        updated_at: now,
+      })
+      .returning()
+      .get();
+
+    return testDb
+      .insert(remoteComments)
+      .values({
+        post_id: post.id,
+        activity_uri: `https://remote.example/activities/comment-${status}`,
+        object_uri: `https://remote.example/objects/comment-${status}`,
+        actor_uri: "https://remote.example/users/alice",
+        actor_name: "Alice",
+        actor_url: "https://remote.example/@alice",
+        content_html: "Hello from remote",
+        content_text: "Hello from remote",
+        in_reply_to_uri: `http://localhost:5000/posts/${post.slug}`,
+        moderation_status: status,
+        raw_source: "{}",
+        published_at: now,
+        received_at: now,
+      })
+      .returning()
+      .get();
+  }
+
+  it("lists pending remote comments", async () => {
+    const comment = createCommentFixture("pending");
+    createCommentFixture("approved");
+
+    const res = await api.request("/comments/pending", { headers: authHeader });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data).toHaveLength(1);
+    expect(json.data[0]).toMatchObject({
+      id: comment.id,
+      moderation_status: "pending",
+      actor_name: "Alice",
+      content_html: "Hello from remote",
+    });
+    expect(json.data[0].raw_source).toBeUndefined();
+  });
+
+  it("approves a remote comment", async () => {
+    const comment = createCommentFixture("pending");
+
+    const res = await api.request(`/comments/${comment.id}/approve`, {
+      method: "POST",
+      headers: authHeader,
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.moderation_status).toBe("approved");
+    expect(typeof json.data.moderated_at).toBe("string");
+  });
+
+  it("hides a remote comment", async () => {
+    const comment = createCommentFixture("approved");
+
+    const res = await api.request(`/comments/${comment.id}/hide`, {
+      method: "POST",
+      headers: authHeader,
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.moderation_status).toBe("hidden");
+    expect(typeof json.data.moderated_at).toBe("string");
+  });
+
+  it("returns 404 for missing remote comments", async () => {
+    const res = await api.request("/comments/999999/approve", {
+      method: "POST",
+      headers: authHeader,
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(json.error).toBe("Comment not found");
   });
 });
 

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -539,7 +539,7 @@ describe("Remote comment moderation API", () => {
     expect(json.data[0].raw_source).toBeUndefined();
   });
 
-  it("approves a remote comment", async () => {
+  it("approves a remote comment and queues a post Update", async () => {
     const comment = createCommentFixture("pending");
 
     const res = await api.request(`/comments/${comment.id}/approve`, {
@@ -551,9 +551,10 @@ describe("Remote comment moderation API", () => {
     expect(res.status).toBe(200);
     expect(json.data.moderation_status).toBe("approved");
     expect(typeof json.data.moderated_at).toBe("string");
+    expect(mockSendUpdateActivity).toHaveBeenCalledWith(comment.post_id);
   });
 
-  it("hides a remote comment", async () => {
+  it("hides a remote comment and queues a post Update", async () => {
     const comment = createCommentFixture("approved");
 
     const res = await api.request(`/comments/${comment.id}/hide`, {
@@ -565,6 +566,7 @@ describe("Remote comment moderation API", () => {
     expect(res.status).toBe(200);
     expect(json.data.moderation_status).toBe("hidden");
     expect(typeof json.data.moderated_at).toBe("string");
+    expect(mockSendUpdateActivity).toHaveBeenCalledWith(comment.post_id);
   });
 
   it("returns 404 for missing remote comments", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -29,10 +29,20 @@ import {
 // Create test db immediately
 const testDb = createTestDb();
 
+const mockSendUpdateActivity = mock(async () => true);
+
 // Mock the db module
 mock.module("../../db", () => ({
   db: testDb,
   ...require("../../db/schema"),
+}));
+
+mock.module("../federation/publish", () => ({
+  sendUpdateActivity: mockSendUpdateActivity,
+}));
+
+mock.module("@/federation/publish", () => ({
+  sendUpdateActivity: mockSendUpdateActivity,
 }));
 
 // Set up test data
@@ -1651,7 +1661,7 @@ describe("pages routes", () => {
       return sessionId;
     }
 
-    it("shows approved comments publicly and hides non-approved comments", async () => {
+    it("shows approved comments publicly, updates replies count, and hides non-approved comments", async () => {
       const post = createCommentPost("comments-public-post");
       insertRemoteComment({
         postId: post.id,
@@ -1671,8 +1681,9 @@ describe("pages routes", () => {
       const html = await res.text();
 
       expect(res.status).toBe(200);
-      expect(html).toContain("Fediverse comments");
+      expect(html).toContain("Comments");
       expect(html).toContain("Approved public reply");
+      expect(html).toContain("1 Reply");
       expect(html).not.toContain("Pending private reply");
       expect(html).not.toContain("/approve");
       expect(html).not.toContain("/hide");
@@ -1768,6 +1779,8 @@ describe("pages routes", () => {
       expect(hiddenComment?.moderation_status).toBe("hidden");
       expect(approvedComment?.moderated_at).toBeInstanceOf(Date);
       expect(hiddenComment?.moderated_at).toBeInstanceOf(Date);
+      expect(mockSendUpdateActivity).toHaveBeenCalledWith(post.id);
+      expect(mockSendUpdateActivity).toHaveBeenCalledTimes(2);
     });
 
     it("redirects anonymous moderation attempts to login", async () => {
@@ -1789,6 +1802,39 @@ describe("pages routes", () => {
 
       expect(res.status).toBe(302);
       expect(res.headers.get("Location")).toBe("/login");
+    });
+
+    it("exposes approved comments as an ActivityPub replies collection", async () => {
+      const post = createCommentPost("comments-activitypub-post");
+      insertRemoteComment({
+        postId: post.id,
+        suffix: "activitypub-approved",
+        status: "approved",
+        content: "Approved ActivityPub reply",
+      });
+      insertRemoteComment({
+        postId: post.id,
+        suffix: "activitypub-pending",
+        status: "pending",
+        content: "Pending ActivityPub reply",
+      });
+
+      const app = getApp();
+      const objectRes = await app.request("/posts/comments-activitypub-post", {
+        headers: { Accept: "application/activity+json" },
+      });
+      const repliesRes = await app.request("/posts/comments-activitypub-post/replies", {
+        headers: { Accept: "application/activity+json" },
+      });
+      const objectJson = await objectRes.json();
+      const repliesJson = await repliesRes.json();
+
+      expect(objectJson.replies).toContain("/posts/comments-activitypub-post/replies");
+      expect(repliesRes.status).toBe(200);
+      expect(repliesJson.type).toBe("OrderedCollection");
+      expect(repliesJson.totalItems).toBe(1);
+      expect(JSON.stringify(repliesJson)).toContain("Approved ActivityPub reply");
+      expect(JSON.stringify(repliesJson)).not.toContain("Pending ActivityPub reply");
     });
 
     it("redirects valid reply-from-server submissions and rejects invalid servers", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -21,6 +21,9 @@ import {
   personSocialAccounts,
   media,
   remoteLikes,
+  remoteComments,
+  authors,
+  sessions,
 } from "../../db/schema";
 
 // Create test db immediately
@@ -1572,6 +1575,241 @@ describe("pages routes", () => {
 
       expect(res.status).toBe(200);
       expect(html).toContain('aria-label="0 ActivityPub likes"');
+    });
+  });
+
+  describe("Fediverse comments", () => {
+    function createCommentPost(slug: string) {
+      const now = new Date("2026-04-01T00:00:00.000Z");
+      return testDb
+        .insert(posts)
+        .values({
+          slug,
+          type: "note",
+          title: null,
+          content: "Post with remote comments",
+          published_at: now,
+          created_at: now,
+          updated_at: now,
+        })
+        .returning()
+        .get();
+    }
+
+    function insertRemoteComment({
+      postId,
+      suffix,
+      status,
+      content,
+    }: {
+      postId: number;
+      suffix: string;
+      status: string;
+      content: string;
+    }) {
+      const now = new Date("2026-04-02T00:00:00.000Z");
+      return testDb
+        .insert(remoteComments)
+        .values({
+          post_id: postId,
+          activity_uri: `https://remote.example/activities/${suffix}`,
+          object_uri: `https://remote.example/objects/${suffix}`,
+          actor_uri: "https://remote.example/users/alice",
+          actor_name: "Alice",
+          actor_url: "https://remote.example/@alice",
+          content_html: content,
+          content_text: content,
+          in_reply_to_uri: `http://localhost:5000/posts/${suffix}`,
+          moderation_status: status,
+          raw_source: "{}",
+          published_at: now,
+          received_at: now,
+        })
+        .returning()
+        .get();
+    }
+
+    function createAuthenticatedSession(): string {
+      const author = testDb
+        .insert(authors)
+        .values({
+          email: `comment-admin-${crypto.randomUUID()}@example.com`,
+          created_at: new Date(),
+        })
+        .returning()
+        .get();
+      const sessionId = `comment-session-${crypto.randomUUID()}`;
+      testDb
+        .insert(sessions)
+        .values({
+          id: sessionId,
+          author_id: author.id,
+          expires_at: new Date(Date.now() + 60 * 60 * 1000),
+          created_at: new Date(),
+        })
+        .run();
+      return sessionId;
+    }
+
+    it("shows approved comments publicly and hides non-approved comments", async () => {
+      const post = createCommentPost("comments-public-post");
+      insertRemoteComment({
+        postId: post.id,
+        suffix: "public-approved",
+        status: "approved",
+        content: "Approved public reply",
+      });
+      insertRemoteComment({
+        postId: post.id,
+        suffix: "public-pending",
+        status: "pending",
+        content: "Pending private reply",
+      });
+
+      const app = getApp();
+      const res = await app.request("/posts/comments-public-post");
+      const html = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(html).toContain("Fediverse comments");
+      expect(html).toContain("Approved public reply");
+      expect(html).not.toContain("Pending private reply");
+      expect(html).not.toContain("/approve");
+      expect(html).not.toContain("/hide");
+    });
+
+    it("shows all comments and moderation controls to authenticated users", async () => {
+      const post = createCommentPost("comments-auth-post");
+      insertRemoteComment({
+        postId: post.id,
+        suffix: "auth-approved",
+        status: "approved",
+        content: "Approved authenticated reply",
+      });
+      insertRemoteComment({
+        postId: post.id,
+        suffix: "auth-pending",
+        status: "pending",
+        content: "Pending authenticated reply",
+      });
+      insertRemoteComment({
+        postId: post.id,
+        suffix: "auth-hidden",
+        status: "hidden",
+        content: "Hidden authenticated reply",
+      });
+      const sessionId = createAuthenticatedSession();
+
+      const app = getApp();
+      const res = await app.request("/posts/comments-auth-post", {
+        headers: { Cookie: `session=${sessionId}` },
+      });
+      const html = await res.text();
+
+      expect(res.status).toBe(200);
+      expect(html).toContain("Approved authenticated reply");
+      expect(html).toContain("Pending authenticated reply");
+      expect(html).toContain("Hidden authenticated reply");
+      expect(html).toContain(">pending</span>");
+      expect(html).toContain(">hidden</span>");
+      expect(html).toContain("/posts/comments-auth-post/comments/");
+      expect(html).toContain("Approve");
+      expect(html).toContain("Hide");
+    });
+
+    it("allows authenticated users to approve and hide comments from the post page", async () => {
+      const post = createCommentPost("comments-actions-post");
+      const pending = insertRemoteComment({
+        postId: post.id,
+        suffix: "action-pending",
+        status: "pending",
+        content: "Pending action reply",
+      });
+      const approved = insertRemoteComment({
+        postId: post.id,
+        suffix: "action-approved",
+        status: "approved",
+        content: "Approved action reply",
+      });
+      const sessionId = createAuthenticatedSession();
+      const app = getApp();
+
+      const approveRes = await app.request(
+        `/posts/comments-actions-post/comments/${pending.id}/approve`,
+        {
+          method: "POST",
+          headers: { Cookie: `session=${sessionId}` },
+        }
+      );
+      const hideRes = await app.request(
+        `/posts/comments-actions-post/comments/${approved.id}/hide`,
+        {
+          method: "POST",
+          headers: { Cookie: `session=${sessionId}` },
+        }
+      );
+
+      const approvedComment = testDb
+        .select()
+        .from(remoteComments)
+        .where(eq(remoteComments.id, pending.id))
+        .get();
+      const hiddenComment = testDb
+        .select()
+        .from(remoteComments)
+        .where(eq(remoteComments.id, approved.id))
+        .get();
+
+      expect(approveRes.status).toBe(302);
+      expect(hideRes.status).toBe(302);
+      expect(approveRes.headers.get("Location")).toBe("/posts/comments-actions-post");
+      expect(hideRes.headers.get("Location")).toBe("/posts/comments-actions-post");
+      expect(approvedComment?.moderation_status).toBe("approved");
+      expect(hiddenComment?.moderation_status).toBe("hidden");
+      expect(approvedComment?.moderated_at).toBeInstanceOf(Date);
+      expect(hiddenComment?.moderated_at).toBeInstanceOf(Date);
+    });
+
+    it("redirects anonymous moderation attempts to login", async () => {
+      const post = createCommentPost("comments-anon-action-post");
+      const pending = insertRemoteComment({
+        postId: post.id,
+        suffix: "anon-action-pending",
+        status: "pending",
+        content: "Pending anonymous action reply",
+      });
+
+      const app = getApp();
+      const res = await app.request(
+        `/posts/comments-anon-action-post/comments/${pending.id}/approve`,
+        {
+          method: "POST",
+        }
+      );
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/login");
+    });
+
+    it("redirects valid reply-from-server submissions and rejects invalid servers", async () => {
+      createCommentPost("comments-reply-post");
+      const app = getApp();
+
+      const validRes = await app.request(
+        "/fediverse/reply?post=comments-reply-post&server=mastodon.social"
+      );
+      const invalidRes = await app.request(
+        "/fediverse/reply?post=comments-reply-post&server=http://mastodon.social"
+      );
+
+      expect(validRes.status).toBe(302);
+      const validLocation = validRes.headers.get("Location") ?? "";
+      expect(validLocation.startsWith("https://mastodon.social/share?text=")).toBe(true);
+      expect(validLocation).toContain("comments-reply-post");
+      expect(invalidRes.status).toBe(302);
+      expect(invalidRes.headers.get("Location")).toBe(
+        "/posts/comments-reply-post?replyError=invalid-server"
+      );
     });
   });
 

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -1,4 +1,5 @@
 import { readFileSync } from "fs";
+import { eq } from "drizzle-orm";
 import type { Context } from "hono";
 import { join } from "path";
 import { bodyLimit } from "hono/body-limit";
@@ -38,6 +39,7 @@ import {
 } from "@/services/people";
 import { fetchLinkPreview } from "@/services/link-preview";
 import { logger } from "@/utils/logger";
+import { db as defaultDb, posts } from "@/db";
 import { getRemoteLikeCountForPost, listRemoteLikeSummariesForPost } from "@/federation/likes";
 import {
   approveRemoteComment,
@@ -594,6 +596,24 @@ function serializeRemoteComment(comment: ReturnType<typeof listPendingRemoteComm
     received_at: comment.received_at.toISOString(),
     moderated_at: comment.moderated_at?.toISOString() ?? null,
   };
+}
+
+function queuePostUpdateForModeratedComment(
+  comment: ReturnType<typeof listPendingRemoteComments>[number]
+) {
+  const post = defaultDb
+    .select({ id: posts.id, published_at: posts.published_at })
+    .from(posts)
+    .where(eq(posts.id, comment.post_id))
+    .get();
+
+  if (!post?.published_at) {
+    return;
+  }
+
+  sendUpdateActivity(post.id).catch(() => {
+    // Error already logged in sendUpdateActivity
+  });
 }
 
 function hasStoredLinkPreview(post: {
@@ -2459,6 +2479,7 @@ registerProtectedRoute(
       return c.json({ error: "Comment not found" }, 404);
     }
 
+    queuePostUpdateForModeratedComment(comment);
     return c.json({ data: serializeRemoteComment(comment) });
   }
 );
@@ -2502,6 +2523,7 @@ registerProtectedRoute(
       return c.json({ error: "Comment not found" }, 404);
     }
 
+    queuePostUpdateForModeratedComment(comment);
     return c.json({ data: serializeRemoteComment(comment) });
   }
 );

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -40,6 +40,11 @@ import { fetchLinkPreview } from "@/services/link-preview";
 import { logger } from "@/utils/logger";
 import { getRemoteLikeCountForPost, listRemoteLikeSummariesForPost } from "@/federation/likes";
 import {
+  approveRemoteComment,
+  hideRemoteComment,
+  listPendingRemoteComments,
+} from "@/federation/replies";
+import {
   federatePost,
   sendDeleteActivity,
   sendDeleteActivityForUri,
@@ -221,6 +226,25 @@ const PostLikesSchema = z
     likes: z.array(RemoteLikeSchema),
   })
   .openapi("PostLikes");
+
+const RemoteCommentSchema = z
+  .object({
+    id: z.number().int().openapi({ example: 1 }),
+    post_id: z.number().int().openapi({ example: 42 }),
+    activity_uri: z.string().url().openapi({ example: "https://mastodon.social/activities/1" }),
+    object_uri: z.string().url().openapi({ example: "https://mastodon.social/objects/1" }),
+    actor_uri: z.string().url().openapi({ example: "https://mastodon.social/users/alice" }),
+    actor_name: NullableStringSchema.openapi({ example: "Alice" }),
+    actor_url: NullableStringSchema.openapi({ example: "https://mastodon.social/@alice" }),
+    content_html: z.string().openapi({ example: "Hello from Mastodon" }),
+    content_text: z.string().openapi({ example: "Hello from Mastodon" }),
+    in_reply_to_uri: z.string().url().openapi({ example: "https://erikcraddock.me/posts/post" }),
+    moderation_status: z.string().openapi({ example: "pending" }),
+    published_at: IsoDateTimeSchema.nullable(),
+    received_at: IsoDateTimeSchema,
+    moderated_at: IsoDateTimeSchema.nullable(),
+  })
+  .openapi("RemoteComment");
 
 const PostSchema = z
   .object({
@@ -552,6 +576,25 @@ const registerProtectedRoute = protectedApi.openapi.bind(protectedApi) as unknow
   route: unknown,
   handler: (c: Context) => unknown
 ) => unknown;
+
+function serializeRemoteComment(comment: ReturnType<typeof listPendingRemoteComments>[number]) {
+  return {
+    id: comment.id,
+    post_id: comment.post_id,
+    activity_uri: comment.activity_uri,
+    object_uri: comment.object_uri,
+    actor_uri: comment.actor_uri,
+    actor_name: comment.actor_name,
+    actor_url: comment.actor_url,
+    content_html: comment.content_html,
+    content_text: comment.content_text,
+    in_reply_to_uri: comment.in_reply_to_uri,
+    moderation_status: comment.moderation_status,
+    published_at: comment.published_at?.toISOString() ?? null,
+    received_at: comment.received_at.toISOString(),
+    moderated_at: comment.moderated_at?.toISOString() ?? null,
+  };
+}
 
 function hasStoredLinkPreview(post: {
   og_title?: string | null;
@@ -2351,6 +2394,115 @@ registerProtectedRoute(
     } catch (error) {
       return c.json({ error: String(error) }, 500);
     }
+  }
+);
+
+registerProtectedRoute(
+  protectedRoute({
+    method: "get",
+    path: "/comments/pending",
+    tags: ["comments"],
+    summary: "List pending remote comments",
+    responses: {
+      200: {
+        description: "Pending remote comments awaiting moderation.",
+        content: { "application/json": { schema: dataEnvelope(z.array(RemoteCommentSchema)) } },
+      },
+      401: {
+        description: "Missing or invalid API key.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+    },
+  }),
+  (c: Context) => {
+    const comments = listPendingRemoteComments().map(serializeRemoteComment);
+    return c.json({ data: comments });
+  }
+);
+
+registerProtectedRoute(
+  protectedRoute({
+    method: "post",
+    path: "/comments/{id}/approve",
+    tags: ["comments"],
+    summary: "Approve a remote comment",
+    request: {
+      params: z.object({ id: z.string().openapi({ example: "1" }) }),
+    },
+    responses: {
+      200: {
+        description: "The approved remote comment.",
+        content: { "application/json": { schema: dataEnvelope(RemoteCommentSchema) } },
+      },
+      400: {
+        description: "The comment ID was invalid.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      404: {
+        description: "The comment was not found.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      401: {
+        description: "Missing or invalid API key.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+    },
+  }),
+  (c: Context) => {
+    const id = Number(c.req.param("id"));
+    if (!Number.isInteger(id) || id < 1) {
+      return c.json({ error: "Invalid comment ID" }, 400);
+    }
+
+    const comment = approveRemoteComment(id);
+    if (!comment) {
+      return c.json({ error: "Comment not found" }, 404);
+    }
+
+    return c.json({ data: serializeRemoteComment(comment) });
+  }
+);
+
+registerProtectedRoute(
+  protectedRoute({
+    method: "post",
+    path: "/comments/{id}/hide",
+    tags: ["comments"],
+    summary: "Hide a remote comment",
+    request: {
+      params: z.object({ id: z.string().openapi({ example: "1" }) }),
+    },
+    responses: {
+      200: {
+        description: "The hidden remote comment.",
+        content: { "application/json": { schema: dataEnvelope(RemoteCommentSchema) } },
+      },
+      400: {
+        description: "The comment ID was invalid.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      404: {
+        description: "The comment was not found.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+      401: {
+        description: "Missing or invalid API key.",
+        content: { "application/json": { schema: ErrorSchema } },
+      },
+    },
+  }),
+  (c: Context) => {
+    const id = Number(c.req.param("id"));
+    if (!Number.isInteger(id) || id < 1) {
+      return c.json({ error: "Invalid comment ID" }, 400);
+    }
+
+    const comment = hideRemoteComment(id);
+    if (!comment) {
+      return c.json({ error: "Comment not found" }, 404);
+    }
+
+    return c.json({ data: serializeRemoteComment(comment) });
   }
 );
 

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1,4 +1,5 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
+import { getCookie } from "hono/cookie";
 import { raw } from "hono/html";
 import { asc, desc, eq, isNotNull, and } from "drizzle-orm";
 import {
@@ -13,6 +14,8 @@ import {
   personSocialAccounts,
   media,
   followers,
+  sessions,
+  authors,
 } from "../db";
 import { Layout } from "../templates/layout";
 import { NotFound } from "../templates/not-found";
@@ -26,6 +29,14 @@ import { baseUrl } from "../federation/utils";
 import { getPublicProfileFields } from "../federation/actor-profile";
 import { logger } from "../utils/logger";
 import { getRemoteLikeCountForPost } from "../federation/likes";
+import {
+  approveRemoteComment,
+  getVisibleRemoteCommentsForPost,
+  hideRemoteComment,
+  REMOTE_COMMENT_APPROVED_STATUS,
+  REMOTE_COMMENT_HIDDEN_STATUS,
+  type RemoteComment,
+} from "../federation/replies";
 
 // Database type for dependency injection
 type Database = typeof defaultDb;
@@ -399,6 +410,12 @@ function SourceCard({
 function buildRemoteFollowUrl(serverOrigin: string): string {
   const url = new URL("/authorize_interaction", serverOrigin);
   url.searchParams.set("uri", ACTOR_URI);
+  return url.toString();
+}
+
+function buildRemoteReplyUrl(serverOrigin: string, postUrl: string): string {
+  const url = new URL("/share", serverOrigin);
+  url.searchParams.set("text", postUrl);
   return url.toString();
 }
 
@@ -1602,6 +1619,214 @@ function withLikeCounts<T extends { id: number }>(
   }));
 }
 
+function getSessionExpiryMs(expiresAt: Date | number): number {
+  return expiresAt instanceof Date ? expiresAt.getTime() : Number(expiresAt) * 1000;
+}
+
+function getAuthenticatedUserEmail(c: Context, db: Database): string | null {
+  const sessionId = getCookie(c, "session");
+  if (!sessionId) {
+    return null;
+  }
+
+  const session = db.select().from(sessions).where(eq(sessions.id, sessionId)).get();
+  if (!session || getSessionExpiryMs(session.expires_at) < Date.now()) {
+    return null;
+  }
+
+  if (session.author_id === null) {
+    return process.env.ADMIN_EMAIL ?? null;
+  }
+
+  const author = db.select().from(authors).where(eq(authors.id, session.author_id)).get();
+  return author?.email ?? null;
+}
+
+function requirePageAuth(c: Context, db: Database): string | Response {
+  const email = getAuthenticatedUserEmail(c, db);
+  if (!email) {
+    return c.redirect("/login");
+  }
+  return email;
+}
+
+function formatCommentDate(comment: RemoteComment): string {
+  const date = comment.published_at ?? comment.received_at;
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function RemoteCommentsSection({
+  comments,
+  postSlug,
+  isAuthenticated,
+}: {
+  comments: RemoteComment[];
+  postSlug: string;
+  isAuthenticated: boolean;
+}) {
+  return (
+    <section class="border-t border-gray-200 bg-white px-4 py-6 dark:border-gray-800 dark:bg-gray-900 sm:px-6">
+      <div class="mb-5 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 class="text-xl font-bold text-gray-950 dark:text-gray-50">Fediverse comments</h2>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Replies from Mastodon and other Fediverse servers.
+          </p>
+        </div>
+      </div>
+
+      {comments.length > 0 ? (
+        <div class="space-y-4">
+          {comments.map((comment) => (
+            <RemoteCommentCard
+              key={comment.id}
+              comment={comment}
+              postSlug={postSlug}
+              isAuthenticated={isAuthenticated}
+            />
+          ))}
+        </div>
+      ) : (
+        <p class="rounded-2xl border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+          No approved Fediverse comments yet.
+        </p>
+      )}
+
+      <ReplyFromServerForm postSlug={postSlug} />
+    </section>
+  );
+}
+
+function RemoteCommentCard({
+  comment,
+  postSlug,
+  isAuthenticated,
+}: {
+  comment: RemoteComment;
+  postSlug: string;
+  isAuthenticated: boolean;
+}) {
+  const isApproved = comment.moderation_status === REMOTE_COMMENT_APPROVED_STATUS;
+  const authorLabel = comment.actor_name || comment.actor_uri;
+  const authorHref = comment.actor_url || comment.actor_uri;
+  const remoteCommentHref = comment.object_uri;
+
+  return (
+    <article class="rounded-2xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-800 dark:bg-gray-950/40">
+      <header class="mb-3 flex flex-wrap items-start justify-between gap-3 text-sm">
+        <div>
+          <a
+            href={authorHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-semibold text-gray-950 hover:text-teal-600 dark:text-gray-50 dark:hover:text-teal-400"
+          >
+            {authorLabel}
+          </a>
+          <div class="mt-1 flex flex-wrap items-center gap-2 text-gray-500 dark:text-gray-400">
+            <time>{formatCommentDate(comment)}</time>
+            <span aria-hidden="true">·</span>
+            <a
+              href={remoteCommentHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="hover:text-gray-700 dark:hover:text-gray-200"
+            >
+              View Fediverse reply
+            </a>
+          </div>
+        </div>
+
+        {isAuthenticated && !isApproved && (
+          <span class="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+            {comment.moderation_status}
+          </span>
+        )}
+      </header>
+
+      <div class="prose prose-sm prose-gray max-w-none dark:prose-invert">
+        {raw(comment.content_html)}
+      </div>
+
+      {isAuthenticated && <CommentModerationControls comment={comment} postSlug={postSlug} />}
+    </article>
+  );
+}
+
+function CommentModerationControls({
+  comment,
+  postSlug,
+}: {
+  comment: RemoteComment;
+  postSlug: string;
+}) {
+  const isApproved = comment.moderation_status === REMOTE_COMMENT_APPROVED_STATUS;
+  const isHidden = comment.moderation_status === REMOTE_COMMENT_HIDDEN_STATUS;
+
+  return (
+    <div class="mt-4 flex flex-wrap gap-2 border-t border-gray-200 pt-3 dark:border-gray-800">
+      {!isApproved && (
+        <form method="post" action={`/posts/${postSlug}/comments/${comment.id}/approve`}>
+          <button
+            type="submit"
+            class="rounded-full bg-teal-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-teal-700"
+          >
+            Approve
+          </button>
+        </form>
+      )}
+      {!isHidden && (
+        <form method="post" action={`/posts/${postSlug}/comments/${comment.id}/hide`}>
+          <button
+            type="submit"
+            class="rounded-full bg-gray-200 px-3 py-1.5 text-sm font-semibold text-gray-800 hover:bg-gray-300 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+          >
+            Hide
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}
+
+function ReplyFromServerForm({ postSlug }: { postSlug: string }) {
+  return (
+    <form
+      method="get"
+      action="/fediverse/reply"
+      class="mt-6 rounded-2xl border border-teal-200 bg-teal-50 p-4 dark:border-teal-900/60 dark:bg-teal-950/30"
+    >
+      <input type="hidden" name="post" value={postSlug} />
+      <label
+        class="block text-sm font-semibold text-gray-950 dark:text-gray-50"
+        for="fediverse-reply-server"
+      >
+        Reply from your Fediverse server
+      </label>
+      <div class="mt-3 flex flex-col gap-2 sm:flex-row">
+        <input
+          id="fediverse-reply-server"
+          name="server"
+          type="text"
+          inputmode="url"
+          placeholder="mastodon.social"
+          class="min-w-0 flex-1 rounded-full border border-gray-300 bg-white px-4 py-2 text-sm text-gray-950 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-50"
+        />
+        <button
+          type="submit"
+          class="rounded-full bg-teal-600 px-5 py-2 text-sm font-semibold text-white hover:bg-teal-700"
+        >
+          Take me home!
+        </button>
+      </div>
+    </form>
+  );
+}
+
 /**
  * Creates page routes with the given database instance.
  * Allows dependency injection for testing.
@@ -2000,6 +2225,23 @@ export function createPagesRoutes(db: Database): Hono {
         </div>
       </Layout>
     );
+  });
+
+  pages.get("/fediverse/reply", (c) => {
+    const serverOrigin = normalizeFediverseServer(c.req.query("server") ?? "");
+    const postSlug = c.req.query("post") ?? "";
+    const post = db
+      .select({ slug: posts.slug })
+      .from(posts)
+      .where(and(eq(posts.slug, postSlug), isNotNull(posts.published_at)))
+      .get();
+
+    if (!serverOrigin || !post) {
+      return c.redirect(`/posts/${encodeURIComponent(postSlug || "")}?replyError=invalid-server`);
+    }
+
+    const postUrl = new URL(`/posts/${post.slug}`, baseUrl).toString();
+    return c.redirect(buildRemoteReplyUrl(serverOrigin, postUrl));
   });
 
   pages.get("/follow", async (c) => {
@@ -2649,6 +2891,38 @@ export function createPagesRoutes(db: Database): Hono {
     );
   });
 
+  pages.post("/posts/:slug/comments/:id/approve", (c) => {
+    const auth = requirePageAuth(c, db);
+    if (auth instanceof Response) {
+      return auth;
+    }
+
+    const slug = c.req.param("slug");
+    const commentId = Number(c.req.param("id"));
+    if (!Number.isInteger(commentId) || commentId < 1) {
+      return c.redirect(`/posts/${slug}`);
+    }
+
+    approveRemoteComment(commentId, db);
+    return c.redirect(`/posts/${slug}`);
+  });
+
+  pages.post("/posts/:slug/comments/:id/hide", (c) => {
+    const auth = requirePageAuth(c, db);
+    if (auth instanceof Response) {
+      return auth;
+    }
+
+    const slug = c.req.param("slug");
+    const commentId = Number(c.req.param("id"));
+    if (!Number.isInteger(commentId) || commentId < 1) {
+      return c.redirect(`/posts/${slug}`);
+    }
+
+    hideRemoteComment(commentId, db);
+    return c.redirect(`/posts/${slug}`);
+  });
+
   // Single post page
   pages.get("/posts/:slug", async (c) => {
     const slug = c.req.param("slug");
@@ -2810,6 +3084,11 @@ export function createPagesRoutes(db: Database): Hono {
       author,
       like_count: getRemoteLikeCountForPost(post.id, db),
     };
+    const isAuthenticated = Boolean(getAuthenticatedUserEmail(c, db));
+    const remoteComments = getVisibleRemoteCommentsForPost(post.id, {
+      includeNonPublic: isAuthenticated,
+      database: db,
+    });
 
     return c.html(
       <Layout
@@ -2838,6 +3117,11 @@ export function createPagesRoutes(db: Database): Hono {
               </a>
             </header>
             <SingleFeedPost post={feedPost} tags={postTagsResult} bannerUrl={bannerUrl} />
+            <RemoteCommentsSection
+              comments={remoteComments}
+              postSlug={post.slug}
+              isAuthenticated={isAuthenticated}
+            />
           </div>
         </div>
       </Layout>

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -1,4 +1,5 @@
 import { Hono, type Context } from "hono";
+import { Note, OrderedCollection } from "@fedify/fedify";
 import { getCookie } from "hono/cookie";
 import { raw } from "hono/html";
 import { asc, desc, eq, isNotNull, and } from "drizzle-orm";
@@ -25,12 +26,14 @@ import { mediaUrl } from "../services/media";
 import { listTags } from "../services/tags";
 import { fetchLinkPreview } from "../services/link-preview";
 import { postToObject, PublishedPost } from "../federation/post-object";
-import { baseUrl } from "../federation/utils";
+import { sendUpdateActivity } from "../federation/publish";
+import { baseUrl, dateToInstant } from "../federation/utils";
 import { getPublicProfileFields } from "../federation/actor-profile";
 import { logger } from "../utils/logger";
 import { getRemoteLikeCountForPost } from "../federation/likes";
 import {
   approveRemoteComment,
+  getApprovedRemoteCommentCountForPost,
   getVisibleRemoteCommentsForPost,
   hideRemoteComment,
   REMOTE_COMMENT_APPROVED_STATUS,
@@ -62,7 +65,7 @@ type SourceWithAuthors = Source & {
   social_accounts: SourceSocialAccount[];
 };
 type Tag = { id: number; name: string; slug: string };
-type PostWithLikeCount = Post & { like_count?: number };
+type PostWithLikeCount = Post & { like_count?: number; reply_count?: number };
 type PostWithSource = PostWithLikeCount & { source?: Source | null; author?: Person | null };
 
 /** Max length for showing full note content inline */
@@ -795,14 +798,26 @@ function TagBadges({ tags }: { tags: Tag[] }) {
 }
 
 /** Article card for grid display */
-function EngagementRow({ likeCount = 0 }: { likeCount?: number }) {
+function EngagementRow({
+  likeCount = 0,
+  replyCount = 0,
+}: {
+  likeCount?: number;
+  replyCount?: number;
+}) {
   const likeLabel = likeCount === 1 ? "Like" : "Likes";
+  const replyLabel = replyCount === 1 ? "Reply" : "Replies";
 
   return (
     <div class="mt-4 flex items-center justify-around border-t border-gray-100 pt-3 text-sm text-gray-500 dark:border-gray-800 dark:text-gray-400">
-      <span class="inline-flex items-center gap-2" aria-label="0 ActivityPub replies">
+      <span
+        class="inline-flex items-center gap-2"
+        aria-label={`${replyCount} ActivityPub ${replyLabel.toLowerCase()}`}
+      >
         <span aria-hidden="true">↩</span>
-        <span>0 Replies</span>
+        <span>
+          {replyCount} {replyLabel}
+        </span>
       </span>
       <span class="inline-flex items-center gap-2" aria-label="0 ActivityPub boosts">
         <span aria-hidden="true">↻</span>
@@ -879,7 +894,7 @@ function ArticleCard({
               </div>
             )}
           </div>
-          <EngagementRow likeCount={post.like_count} />
+          <EngagementRow likeCount={post.like_count} replyCount={post.reply_count} />
         </div>
       </a>
     </article>
@@ -1357,7 +1372,7 @@ function FeedPost({
       {isLink && <FeedLinkPreview post={post} />}
 
       <FeedPostMeta post={post} tags={postTags} />
-      <EngagementRow likeCount={post.like_count} />
+      <EngagementRow likeCount={post.like_count} replyCount={post.reply_count} />
     </article>
   );
 }
@@ -1412,7 +1427,7 @@ function SingleFeedPost({
       {isLink && <FeedLinkPreview post={post} />}
 
       <FeedPostMeta post={post} tags={postTags} />
-      <EngagementRow likeCount={post.like_count} />
+      <EngagementRow likeCount={post.like_count} replyCount={post.reply_count} />
     </article>
   );
 }
@@ -1519,7 +1534,7 @@ function PostCard({ post, tags: postTags = [] }: { post: PostWithSource; tags?: 
           )}
         </div>
       </a>
-      <EngagementRow likeCount={post.like_count} />
+      <EngagementRow likeCount={post.like_count} replyCount={post.reply_count} />
     </article>
   );
 }
@@ -1616,6 +1631,7 @@ function withLikeCounts<T extends { id: number }>(
   return postList.map((post) => ({
     ...post,
     like_count: getRemoteLikeCountForPost(post.id, db),
+    reply_count: getApprovedRemoteCommentCountForPost(post.id, db),
   }));
 }
 
@@ -1640,6 +1656,12 @@ function getAuthenticatedUserEmail(c: Context, db: Database): string | null {
 
   const author = db.select().from(authors).where(eq(authors.id, session.author_id)).get();
   return author?.email ?? null;
+}
+
+function queuePostUpdate(postId: number): void {
+  sendUpdateActivity(postId).catch(() => {
+    // Error already logged in sendUpdateActivity
+  });
 }
 
 function requirePageAuth(c: Context, db: Database): string | Response {
@@ -1672,10 +1694,7 @@ function RemoteCommentsSection({
     <section class="border-t border-gray-200 bg-white px-4 py-6 dark:border-gray-800 dark:bg-gray-900 sm:px-6">
       <div class="mb-5 flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h2 class="text-xl font-bold text-gray-950 dark:text-gray-50">Fediverse comments</h2>
-          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Replies from Mastodon and other Fediverse servers.
-          </p>
+          <h2 class="text-xl font-bold text-gray-950 dark:text-gray-50">Comments</h2>
         </div>
       </div>
 
@@ -1692,11 +1711,11 @@ function RemoteCommentsSection({
         </div>
       ) : (
         <p class="rounded-2xl border border-dashed border-gray-300 p-4 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
-          No approved Fediverse comments yet.
+          No comments yet.
         </p>
       )}
 
-      <ReplyFromServerForm postSlug={postSlug} />
+      {!isAuthenticated && <ReplyFromServerForm postSlug={postSlug} />}
     </section>
   );
 }
@@ -1791,6 +1810,19 @@ function CommentModerationControls({
       )}
     </div>
   );
+}
+
+function remoteCommentToActivityPubNote(comment: RemoteComment, postSlug: string): Note {
+  const published = comment.published_at ?? comment.received_at;
+
+  return new Note({
+    id: new URL(comment.object_uri),
+    attribution: new URL(comment.actor_uri),
+    content: comment.content_html,
+    replyTarget: new URL(`/posts/${postSlug}`, baseUrl),
+    url: new URL(comment.object_uri),
+    published: dateToInstant(published),
+  });
 }
 
 function ReplyFromServerForm({ postSlug }: { postSlug: string }) {
@@ -2891,6 +2923,31 @@ export function createPagesRoutes(db: Database): Hono {
     );
   });
 
+  pages.get("/posts/:slug/replies", async (c) => {
+    const slug = c.req.param("slug");
+    const post = db
+      .select({ id: posts.id, slug: posts.slug, published_at: posts.published_at })
+      .from(posts)
+      .where(eq(posts.slug, slug))
+      .get();
+
+    if (!post?.published_at) {
+      return c.json({ error: "Not found" }, 404);
+    }
+
+    const comments = getVisibleRemoteCommentsForPost(post.id, { database: db });
+    const collection = new OrderedCollection({
+      id: new URL(`/posts/${post.slug}/replies`, baseUrl),
+      totalItems: comments.length,
+      repliesOf: new URL(`/posts/${post.slug}`, baseUrl),
+      items: comments.map((comment) => remoteCommentToActivityPubNote(comment, post.slug)),
+    });
+
+    return c.json(await collection.toJsonLd(), 200, {
+      "Content-Type": "application/activity+json",
+    });
+  });
+
   pages.post("/posts/:slug/comments/:id/approve", (c) => {
     const auth = requirePageAuth(c, db);
     if (auth instanceof Response) {
@@ -2903,7 +2960,10 @@ export function createPagesRoutes(db: Database): Hono {
       return c.redirect(`/posts/${slug}`);
     }
 
-    approveRemoteComment(commentId, db);
+    const comment = approveRemoteComment(commentId, db);
+    if (comment) {
+      queuePostUpdate(comment.post_id);
+    }
     return c.redirect(`/posts/${slug}`);
   });
 
@@ -2919,7 +2979,10 @@ export function createPagesRoutes(db: Database): Hono {
       return c.redirect(`/posts/${slug}`);
     }
 
-    hideRemoteComment(commentId, db);
+    const comment = hideRemoteComment(commentId, db);
+    if (comment) {
+      queuePostUpdate(comment.post_id);
+    }
     return c.redirect(`/posts/${slug}`);
   });
 
@@ -3083,6 +3146,7 @@ export function createPagesRoutes(db: Database): Hono {
       source,
       author,
       like_count: getRemoteLikeCountForPost(post.id, db),
+      reply_count: getApprovedRemoteCommentCountForPost(post.id, db),
     };
     const isAuthenticated = Boolean(getAuthenticatedUserEmail(c, db));
     const remoteComments = getVisibleRemoteCommentsForPost(post.id, {


### PR DESCRIPTION
## Summary
- add moderation helpers and authenticated API endpoints for pending/approve/hide remote comments
- render Fediverse comments on post pages with approved comments public and all statuses visible to authenticated users
- add inline authenticated moderation controls on post pages
- add reply-from-your-server UI that redirects to a validated Fediverse share URL
- add moderated_at audit timestamp migration for remote comments

## Verification
- bun test src/routes/__tests__/api.test.tsx src/routes/__tests__/pages.test.tsx
- npm run typecheck
- make check
- browser verification on a post page for comments/reply UI
- make dev-tail grep for errors/warnings
- pre-push checks passed