### PR TITLE
Add follower admin page

### DIFF
--- a/src/routes/__tests__/admin.test.tsx
+++ b/src/routes/__tests__/admin.test.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mock } from "bun:test";
+
+import { createTestDb } from "../../db/test-utils";
+import { followers, sessions } from "../../db/schema";
+
+const testDb = createTestDb();
+const adminEmail = "admin-test@example.com";
+
+process.env.ADMIN_EMAIL = adminEmail;
+
+mock.module("../../db", () => ({
+  db: testDb,
+  ...require("../../db/schema"),
+}));
+
+mock.module("@/db", () => ({
+  db: testDb,
+  ...require("../../db/schema"),
+}));
+
+function createAdminSession(): string {
+  const sessionId = crypto.randomUUID();
+  testDb
+    .insert(sessions)
+    .values({
+      id: sessionId,
+      author_id: null,
+      expires_at: new Date(Date.now() + 60 * 60 * 1000),
+      created_at: new Date(),
+    })
+    .run();
+  return sessionId;
+}
+
+function authenticatedRequest(path: string): Request {
+  const sessionId = createAdminSession();
+  return new Request(`http://localhost${path}`, {
+    headers: { Cookie: `session=${sessionId}` },
+  });
+}
+
+beforeEach(() => {
+  testDb.delete(followers).run();
+  testDb.delete(sessions).run();
+});
+
+describe("admin follower page", () => {
+  it("redirects unauthenticated users to login", async () => {
+    const { admin } = await import("../admin");
+
+    const res = await admin.request("/followers");
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/login");
+  });
+
+  it("shows an empty state and follower count when there are no followers", async () => {
+    const { admin } = await import("../admin");
+
+    const res = await admin.request(authenticatedRequest("/followers"));
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("ActivityPub Followers");
+    expect(html).toContain("Stored followers");
+    expect(html).toContain("No ActivityPub followers yet");
+    expect(html).toContain("When remote Fediverse accounts follow this site");
+  });
+
+  it("lists stored followers with inbox metadata and followed date", async () => {
+    testDb
+      .insert(followers)
+      .values({
+        actor_uri: "https://remote.example/users/alice",
+        inbox_uri: "https://remote.example/users/alice/inbox",
+        shared_inbox_uri: "https://remote.example/inbox",
+        followed_at: new Date("2026-04-20T12:34:00.000Z"),
+      })
+      .run();
+
+    const { admin } = await import("../admin");
+
+    const res = await admin.request(authenticatedRequest("/followers"));
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("https://remote.example/users/alice");
+    expect(html).toContain("https://remote.example/users/alice/inbox");
+    expect(html).toContain("https://remote.example/inbox");
+    expect(html).toContain("2026");
+  });
+
+  it("links to the follower page from the admin dashboard", async () => {
+    const { admin } = await import("../admin");
+
+    const res = await admin.request(authenticatedRequest("/"));
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain('href="/admin/followers"');
+    expect(html).toContain("ActivityPub Followers");
+  });
+
+  it("does not render follower mutation actions", async () => {
+    testDb
+      .insert(followers)
+      .values({
+        actor_uri: "https://remote.example/users/bob",
+        inbox_uri: "https://remote.example/users/bob/inbox",
+        shared_inbox_uri: null,
+        followed_at: new Date("2026-04-21T12:34:00.000Z"),
+      })
+      .run();
+
+    const { admin } = await import("../admin");
+
+    const res = await admin.request(authenticatedRequest("/followers"));
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).not.toContain(">Approve<");
+    expect(html).not.toContain(">Reject<");
+    expect(html).not.toContain(">Remove<");
+    expect(html).not.toContain(">Delete<");
+  });
+});

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
+import { desc } from "drizzle-orm";
 import { Layout } from "@/templates/layout";
 import { requireAuth, requireAdmin } from "@/auth/middleware";
+import { db, followers } from "@/db";
 import { listApiKeys, createApiKey, revokeApiKey, getAuthorByEmail } from "@/auth/api-key";
 import { listAuthors, addAuthor, deleteAuthor } from "@/auth/authors";
 import {
@@ -40,6 +42,11 @@ function AdminNav({ isAdmin }: { isAdmin: boolean }) {
         <li>
           <a href="/admin/passkeys" class="text-blue-600 dark:text-blue-400 hover:underline">
             Passkeys
+          </a>
+        </li>
+        <li>
+          <a href="/admin/followers" class="text-blue-600 dark:text-blue-400 hover:underline">
+            Followers
           </a>
         </li>
         {isAdmin && (
@@ -87,6 +94,23 @@ function formatDate(date: Date | null): string {
 }
 
 /**
+ * Format date and time for ActivityPub admin records.
+ */
+function formatDateTime(date: Date): string {
+  return date.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function MissingValue() {
+  return <span class="text-gray-400 dark:text-gray-500">Not provided</span>;
+}
+
+/**
  * GET /admin - Admin dashboard
  */
 admin.get("/", (c) => {
@@ -97,14 +121,115 @@ admin.get("/", (c) => {
       <div class="max-w-4xl mx-auto">
         <AdminHeader title="Admin Dashboard" isAdmin={auth.isAdmin} />
 
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-          <h2 class="text-lg font-semibold mb-4">Welcome</h2>
-          <p class="text-gray-600 dark:text-gray-300 mb-2">
-            Logged in as <span class="font-medium text-gray-900 dark:text-white">{auth.email}</span>
-          </p>
-          <p class="text-sm text-gray-500 dark:text-gray-400">
-            Role: {auth.isAdmin ? "Admin" : "Author"}
-          </p>
+        <div class="grid gap-6 md:grid-cols-2">
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+            <h2 class="text-lg font-semibold mb-4">Welcome</h2>
+            <p class="text-gray-600 dark:text-gray-300 mb-2">
+              Logged in as{" "}
+              <span class="font-medium text-gray-900 dark:text-white">{auth.email}</span>
+            </p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              Role: {auth.isAdmin ? "Admin" : "Author"}
+            </p>
+          </div>
+
+          <a
+            href="/admin/followers"
+            class="block bg-white dark:bg-gray-800 rounded-lg shadow p-6 hover:ring-2 hover:ring-blue-500"
+          >
+            <h2 class="text-lg font-semibold mb-2">ActivityPub Followers</h2>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              Inspect remote Fediverse accounts that follow this site.
+            </p>
+          </a>
+        </div>
+      </div>
+    </Layout>
+  );
+});
+
+/**
+ * GET /admin/followers - ActivityPub follower inspection
+ */
+admin.get("/followers", (c) => {
+  const auth = c.get("auth");
+  const storedFollowers = db.select().from(followers).orderBy(desc(followers.followed_at)).all();
+  const followerCount = storedFollowers.length;
+
+  return c.html(
+    <Layout title="Followers | Admin">
+      <div class="max-w-5xl mx-auto">
+        <AdminHeader title="ActivityPub Followers" isAdmin={auth.isAdmin} />
+
+        <div class="mb-6 grid gap-4 sm:grid-cols-2">
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Stored followers</p>
+            <p class="mt-2 text-3xl font-bold text-gray-950 dark:text-white">{followerCount}</p>
+          </div>
+          <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Page status</p>
+            <p class="mt-2 text-lg font-semibold text-gray-950 dark:text-white">Read-only</p>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Approval, rejection, and removal are handled by separate tasks.
+            </p>
+          </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+          {storedFollowers.length === 0 ? (
+            <div class="p-6 text-gray-600 dark:text-gray-300">
+              <h2 class="text-lg font-semibold text-gray-950 dark:text-white mb-2">
+                No ActivityPub followers yet
+              </h2>
+              <p>When remote Fediverse accounts follow this site, they will appear here.</p>
+            </div>
+          ) : (
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                  <tr>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Actor
+                    </th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Inbox
+                    </th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Shared inbox
+                    </th>
+                    <th class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Followed
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                  {storedFollowers.map((follower) => (
+                    <tr>
+                      <td class="px-4 py-3 align-top text-sm">
+                        <a
+                          href={follower.actor_uri}
+                          class="break-all text-blue-600 hover:underline dark:text-blue-400"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          {follower.actor_uri}
+                        </a>
+                      </td>
+                      <td class="px-4 py-3 align-top text-sm text-gray-700 dark:text-gray-300 break-all">
+                        {follower.inbox_uri}
+                      </td>
+                      <td class="px-4 py-3 align-top text-sm text-gray-700 dark:text-gray-300 break-all">
+                        {follower.shared_inbox_uri ?? <MissingValue />}
+                      </td>
+                      <td class="px-4 py-3 align-top text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                        {formatDateTime(follower.followed_at)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
## Summary
- Add authenticated read-only ActivityPub follower admin page at /admin/followers
- Add dashboard/admin navigation to follower inspection
- Show stored follower count, empty state, and follower actor/inbox/shared inbox/followed date metadata
- Add admin route tests for auth, listing, counts, empty state, and read-only behavior

## Verification
- bun test src/routes/__tests__/admin.test.tsx
- npm run typecheck
- npm run lint
- make check
- Browser check on /admin/followers
- make dev-tail grep for errors/warnings

Task: #task-bea99555