### PR TITLE
Send ActivityPub follows

### DIFF
--- a/drizzle/0017_hot_landau.sql
+++ b/drizzle/0017_hot_landau.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `remote_follows` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`person_id` integer,
+	`actor_uri` text NOT NULL,
+	`handle` text,
+	`preferred_username` text,
+	`display_name` text,
+	`profile_url` text,
+	`inbox_uri` text NOT NULL,
+	`shared_inbox_uri` text,
+	`avatar_url` text,
+	`follow_activity_uri` text NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`last_error` text,
+	`followed_at` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`person_id`) REFERENCES `people`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_follows_actor_uri_unique` ON `remote_follows` (`actor_uri`);--> statement-breakpoint
+CREATE UNIQUE INDEX `remote_follows_follow_activity_uri_unique` ON `remote_follows` (`follow_activity_uri`);

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1469 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6942c6a4-12ff-4a1e-89c5-9b1db6d04d84",
+  "prevId": "6d509d24-852d-47d5-8ce8-163cc6580e84",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "person_social_accounts": {
+      "name": "person_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_social_accounts_person_id_people_id_fk": {
+          "name": "person_social_accounts_person_id_people_id_fk",
+          "tableFrom": "person_social_accounts",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_boosts": {
+      "name": "remote_boosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_boosts_activity_uri_unique": {
+          "name": "remote_boosts_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_boosts_post_id_posts_id_fk": {
+          "name": "remote_boosts_post_id_posts_id_fk",
+          "tableFrom": "remote_boosts",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_comments": {
+      "name": "remote_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_url": {
+          "name": "actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "in_reply_to_uri": {
+          "name": "in_reply_to_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "raw_source": {
+          "name": "raw_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderated_at": {
+          "name": "moderated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_comments_activity_uri_unique": {
+          "name": "remote_comments_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        },
+        "remote_comments_object_uri_unique": {
+          "name": "remote_comments_object_uri_unique",
+          "columns": ["object_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_comments_post_id_posts_id_fk": {
+          "name": "remote_comments_post_id_posts_id_fk",
+          "tableFrom": "remote_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_follows": {
+      "name": "remote_follows",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_username": {
+          "name": "preferred_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "follow_activity_uri": {
+          "name": "follow_activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_follows_actor_uri_unique": {
+          "name": "remote_follows_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        },
+        "remote_follows_follow_activity_uri_unique": {
+          "name": "remote_follows_follow_activity_uri_unique",
+          "columns": ["follow_activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_follows_person_id_people_id_fk": {
+          "name": "remote_follows_person_id_people_id_fk",
+          "tableFrom": "remote_follows",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_likes": {
+      "name": "remote_likes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_likes_activity_uri_unique": {
+          "name": "remote_likes_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_likes_post_id_posts_id_fk": {
+          "name": "remote_likes_post_id_posts_id_fk",
+          "tableFrom": "remote_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_social_accounts": {
+      "name": "source_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_social_accounts_source_id_sources_id_fk": {
+          "name": "source_social_accounts_source_id_sources_id_fk",
+          "tableFrom": "source_social_accounts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1777394393844,
       "tag": "0016_needy_flatman",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1777405864318,
+      "tag": "0017_hot_landau",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -107,6 +107,26 @@ export const followers = sqliteTable("followers", {
   followed_at: integer("followed_at", { mode: "timestamp" }).notNull(),
 });
 
+// ActivityPub accounts followed by the local site actor
+export const remoteFollows = sqliteTable("remote_follows", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  person_id: integer("person_id").references(() => people.id, { onDelete: "set null" }),
+  actor_uri: text("actor_uri").notNull().unique(),
+  handle: text("handle"),
+  preferred_username: text("preferred_username"),
+  display_name: text("display_name"),
+  profile_url: text("profile_url"),
+  inbox_uri: text("inbox_uri").notNull(),
+  shared_inbox_uri: text("shared_inbox_uri"),
+  avatar_url: text("avatar_url"),
+  follow_activity_uri: text("follow_activity_uri").notNull().unique(),
+  status: text("status").notNull().default("pending"),
+  last_error: text("last_error"),
+  followed_at: integer("followed_at", { mode: "timestamp" }).notNull(),
+  created_at: integer("created_at", { mode: "timestamp" }).notNull(),
+  updated_at: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
 // ActivityPub likes received from remote actors
 export const remoteLikes = sqliteTable("remote_likes", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/src/federation/__tests__/following-send.test.ts
+++ b/src/federation/__tests__/following-send.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from "bun:test";
 import { createTestDb } from "../../db/test-utils";
 import { people, personSocialAccounts, remoteFollows } from "../../db/schema";
 import {
+  cancelPendingRemoteFollow,
   createOrRetryRemoteFollow,
   parseFediverseHandle,
   resolveRemoteActor,
   isSafeRemoteUrl,
+  REMOTE_FOLLOW_CANCELLED_STATUS,
   REMOTE_FOLLOW_PENDING_STATUS,
   type ResolvedRemoteActor,
 } from "../following";
@@ -141,6 +143,29 @@ describe("ActivityPub following send workflow", () => {
 
     expect(first.id).toBe(second.id);
     expect(first.person_id).toBe(existingPerson.id);
+    expect(testDb.select().from(people).all()).toHaveLength(1);
+    expect(testDb.select().from(remoteFollows).all()).toHaveLength(1);
+  });
+
+  it("cancels pending follows without creating new people", async () => {
+    const testDb = createTestDb();
+    const follow = await createOrRetryRemoteFollow({
+      actor: actor(),
+      database: testDb,
+      deliver: async () => {},
+    });
+    const delivered: string[] = [];
+
+    const cancelled = await cancelPendingRemoteFollow({
+      followId: follow.id,
+      database: testDb,
+      deliver: async (storedFollow) => {
+        delivered.push(storedFollow.follow_activity_uri);
+      },
+    });
+
+    expect(cancelled?.status).toBe(REMOTE_FOLLOW_CANCELLED_STATUS);
+    expect(delivered).toEqual([follow.follow_activity_uri]);
     expect(testDb.select().from(people).all()).toHaveLength(1);
     expect(testDb.select().from(remoteFollows).all()).toHaveLength(1);
   });

--- a/src/federation/__tests__/following-send.test.ts
+++ b/src/federation/__tests__/following-send.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "bun:test";
+import { createTestDb } from "../../db/test-utils";
+import { people, personSocialAccounts, remoteFollows } from "../../db/schema";
+import {
+  createOrRetryRemoteFollow,
+  parseFediverseHandle,
+  resolveRemoteActor,
+  isSafeRemoteUrl,
+  REMOTE_FOLLOW_PENDING_STATUS,
+  type ResolvedRemoteActor,
+} from "../following";
+
+function actor(overrides: Partial<ResolvedRemoteActor> = {}): ResolvedRemoteActor {
+  return {
+    actorUri: "https://example.social/users/alice",
+    handle: "@alice@example.social",
+    preferredUsername: "alice",
+    displayName: "Alice",
+    profileUrl: "https://example.social/@alice",
+    inboxUri: "https://example.social/users/alice/inbox",
+    sharedInboxUri: "https://example.social/inbox",
+    avatarUrl: "https://example.social/avatar.png",
+    ...overrides,
+  };
+}
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("ActivityPub following send workflow", () => {
+  it("parses Fediverse handles", () => {
+    expect(parseFediverseHandle("@alice@example.social")).toEqual({
+      username: "alice",
+      host: "example.social",
+    });
+    expect(parseFediverseHandle("alice@example.social")).toEqual({
+      username: "alice",
+      host: "example.social",
+    });
+    expect(parseFediverseHandle("https://example.social/@alice")).toBeNull();
+  });
+
+  it("rejects unsafe remote URLs", () => {
+    expect(isSafeRemoteUrl(new URL("https://example.social/users/alice"))).toBe(true);
+    expect(isSafeRemoteUrl(new URL("http://example.social/users/alice"))).toBe(false);
+    expect(isSafeRemoteUrl(new URL("https://localhost/users/alice"))).toBe(false);
+    expect(isSafeRemoteUrl(new URL("https://192.168.1.5/users/alice"))).toBe(false);
+  });
+
+  it("resolves a remote actor via WebFinger", async () => {
+    const fetcher = async (input: URL | RequestInfo) => {
+      const url = input instanceof URL ? input.href : String(input);
+      if (url.startsWith("https://example.social/.well-known/webfinger")) {
+        return jsonResponse({
+          links: [
+            {
+              rel: "self",
+              type: "application/activity+json",
+              href: "https://example.social/users/alice",
+            },
+          ],
+        });
+      }
+
+      return jsonResponse({
+        id: "https://example.social/users/alice",
+        preferredUsername: "alice",
+        name: "Alice Example",
+        url: "https://example.social/@alice",
+        inbox: "https://example.social/users/alice/inbox",
+        endpoints: { sharedInbox: "https://example.social/inbox" },
+        icon: { url: "https://example.social/avatar.png" },
+      });
+    };
+
+    const resolved = await resolveRemoteActor("@alice@example.social", fetcher as typeof fetch);
+
+    expect(resolved.actorUri).toBe("https://example.social/users/alice");
+    expect(resolved.handle).toBe("@alice@example.social");
+    expect(resolved.displayName).toBe("Alice Example");
+    expect(resolved.inboxUri).toBe("https://example.social/users/alice/inbox");
+  });
+
+  it("stores pending follows and creates a linked person/social account", async () => {
+    const testDb = createTestDb();
+    const delivered: string[] = [];
+
+    const follow = await createOrRetryRemoteFollow({
+      actor: actor(),
+      database: testDb,
+      deliver: async (storedFollow) => {
+        delivered.push(storedFollow.actor_uri);
+      },
+    });
+
+    const storedPeople = testDb.select().from(people).all();
+    const socialAccounts = testDb.select().from(personSocialAccounts).all();
+
+    expect(follow.status).toBe(REMOTE_FOLLOW_PENDING_STATUS);
+    expect(follow.person_id).toBe(storedPeople[0]?.id);
+    expect(follow.follow_activity_uri).toContain("/activities/follow/");
+    expect(delivered).toEqual(["https://example.social/users/alice"]);
+    expect(storedPeople).toHaveLength(1);
+    expect(socialAccounts).toHaveLength(1);
+    expect(socialAccounts[0]?.is_activitypub).toBe(true);
+  });
+
+  it("is idempotent and reuses existing people", async () => {
+    const testDb = createTestDb();
+    const existingPerson = testDb
+      .insert(people)
+      .values({ name: "Alice", url: "https://example.social/@alice" })
+      .returning()
+      .get();
+    testDb
+      .insert(personSocialAccounts)
+      .values({
+        person_id: existingPerson.id,
+        label: "Mastodon",
+        url: "https://example.social/@alice",
+        is_activitypub: true,
+        is_default: true,
+        sort_order: 0,
+      })
+      .run();
+
+    const first = await createOrRetryRemoteFollow({
+      actor: actor(),
+      database: testDb,
+      deliver: async () => {},
+    });
+    const second = await createOrRetryRemoteFollow({
+      actor: actor(),
+      database: testDb,
+      deliver: async () => {},
+    });
+
+    expect(first.id).toBe(second.id);
+    expect(first.person_id).toBe(existingPerson.id);
+    expect(testDb.select().from(people).all()).toHaveLength(1);
+    expect(testDb.select().from(remoteFollows).all()).toHaveLength(1);
+  });
+});

--- a/src/federation/following.ts
+++ b/src/federation/following.ts
@@ -3,7 +3,6 @@ import { Follow, type Recipient } from "@fedify/fedify";
 
 import { db, people, personSocialAccounts, remoteFollows } from "@/db";
 import { logger } from "@/utils/logger";
-import { federation } from "./setup";
 import { baseUrl, dateToInstant } from "./utils";
 
 export const REMOTE_FOLLOW_PENDING_STATUS = "pending";
@@ -327,6 +326,7 @@ function followActivityUri(actorUri: string): string {
 }
 
 export async function sendFollowActivity(follow: RemoteFollow): Promise<void> {
+  const { federation } = await import("./setup");
   const ctx = federation.createContext(new URL(baseUrl), undefined);
   const actorUri = ctx.getActorUri("erik");
   const activity = new Follow({

--- a/src/federation/following.ts
+++ b/src/federation/following.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, inArray } from "drizzle-orm";
 import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
-import { Follow, type Recipient } from "@fedify/fedify";
+import { Follow, Undo, type Recipient } from "@fedify/fedify";
 
 import * as schema from "@/db/schema";
 import { people, personSocialAccounts, remoteFollows } from "@/db/schema";
@@ -334,6 +334,19 @@ function followActivityUri(actorUri: string): string {
   return new URL(`/activities/follow/${encoded}`, baseUrl).href;
 }
 
+function undoFollowActivityUri(actorUri: string): string {
+  const encoded = encodeURIComponent(actorUri).replace(/%/g, "~");
+  return new URL(`/activities/undo-follow/${encoded}`, baseUrl).href;
+}
+
+function remoteFollowRecipient(follow: RemoteFollow): Recipient {
+  return {
+    id: new URL(follow.actor_uri),
+    inboxId: new URL(follow.inbox_uri),
+    endpoints: follow.shared_inbox_uri ? { sharedInbox: new URL(follow.shared_inbox_uri) } : null,
+  };
+}
+
 export async function sendFollowActivity(follow: RemoteFollow): Promise<void> {
   const { federation } = await import("./setup");
   const ctx = federation.createContext(new URL(baseUrl), undefined);
@@ -345,13 +358,26 @@ export async function sendFollowActivity(follow: RemoteFollow): Promise<void> {
     to: new URL(follow.actor_uri),
     published: dateToInstant(follow.followed_at),
   });
-  const recipient: Recipient = {
-    id: new URL(follow.actor_uri),
-    inboxId: new URL(follow.inbox_uri),
-    endpoints: follow.shared_inbox_uri ? { sharedInbox: new URL(follow.shared_inbox_uri) } : null,
-  };
+  await ctx.sendActivity({ identifier: "erik" }, remoteFollowRecipient(follow), activity, {
+    preferSharedInbox: true,
+  });
+}
 
-  await ctx.sendActivity({ identifier: "erik" }, recipient, activity, { preferSharedInbox: true });
+export async function sendUndoFollowActivity(follow: RemoteFollow): Promise<void> {
+  const { federation } = await import("./setup");
+  const ctx = federation.createContext(new URL(baseUrl), undefined);
+  const actorUri = ctx.getActorUri("erik");
+  const activity = new Undo({
+    id: new URL(undoFollowActivityUri(follow.actor_uri)),
+    actor: actorUri,
+    object: new URL(follow.follow_activity_uri),
+    to: new URL(follow.actor_uri),
+    published: dateToInstant(new Date()),
+  });
+
+  await ctx.sendActivity({ identifier: "erik" }, remoteFollowRecipient(follow), activity, {
+    preferSharedInbox: true,
+  });
 }
 
 export async function createOrRetryRemoteFollow({
@@ -412,6 +438,41 @@ export async function createOrRetryRemoteFollow({
   }
 }
 
+export async function cancelPendingRemoteFollow({
+  followId,
+  database = getDefaultDatabase(),
+  deliver = sendUndoFollowActivity,
+}: {
+  followId: number;
+  database?: FollowingDatabase;
+  deliver?: (follow: RemoteFollow) => Promise<void>;
+}): Promise<RemoteFollow | null> {
+  const follow = database.select().from(remoteFollows).where(eq(remoteFollows.id, followId)).get();
+  if (!follow) return null;
+  if (follow.status !== REMOTE_FOLLOW_PENDING_STATUS) {
+    throw new Error("Only pending follow requests can be cancelled");
+  }
+
+  try {
+    await deliver(follow);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    database
+      .update(remoteFollows)
+      .set({ status: REMOTE_FOLLOW_FAILED_STATUS, last_error: message, updated_at: new Date() })
+      .where(eq(remoteFollows.id, follow.id))
+      .run();
+    throw error;
+  }
+
+  return database
+    .update(remoteFollows)
+    .set({ status: REMOTE_FOLLOW_CANCELLED_STATUS, last_error: null, updated_at: new Date() })
+    .where(eq(remoteFollows.id, follow.id))
+    .returning()
+    .get();
+}
+
 export function listRemoteFollows(
   database: FollowingDatabase = getDefaultDatabase()
 ): RemoteFollow[] {
@@ -438,4 +499,11 @@ export function getRemoteFollowForPerson(
   return (
     database.select().from(remoteFollows).where(eq(remoteFollows.person_id, personId)).get() ?? null
   );
+}
+
+export function getRemoteFollowForId(
+  followId: number,
+  database: FollowingDatabase = getDefaultDatabase()
+): RemoteFollow | null {
+  return database.select().from(remoteFollows).where(eq(remoteFollows.id, followId)).get() ?? null;
 }

--- a/src/federation/following.ts
+++ b/src/federation/following.ts
@@ -1,0 +1,430 @@
+import { and, asc, eq, inArray } from "drizzle-orm";
+import { Follow, type Recipient } from "@fedify/fedify";
+
+import { db, people, personSocialAccounts, remoteFollows } from "@/db";
+import { logger } from "@/utils/logger";
+import { federation } from "./setup";
+import { baseUrl, dateToInstant } from "./utils";
+
+export const REMOTE_FOLLOW_PENDING_STATUS = "pending";
+export const REMOTE_FOLLOW_ACCEPTED_STATUS = "accepted";
+export const REMOTE_FOLLOW_REJECTED_STATUS = "rejected";
+export const REMOTE_FOLLOW_FAILED_STATUS = "failed";
+export const REMOTE_FOLLOW_CANCELLED_STATUS = "cancelled";
+
+export type RemoteFollowStatus =
+  | typeof REMOTE_FOLLOW_PENDING_STATUS
+  | typeof REMOTE_FOLLOW_ACCEPTED_STATUS
+  | typeof REMOTE_FOLLOW_REJECTED_STATUS
+  | typeof REMOTE_FOLLOW_FAILED_STATUS
+  | typeof REMOTE_FOLLOW_CANCELLED_STATUS;
+
+type FollowingDatabase = typeof db;
+export type RemoteFollow = typeof remoteFollows.$inferSelect;
+
+type FetchLike = typeof fetch;
+
+export interface ResolvedRemoteActor {
+  actorUri: string;
+  handle: string | null;
+  preferredUsername: string | null;
+  displayName: string | null;
+  profileUrl: string | null;
+  inboxUri: string;
+  sharedInboxUri: string | null;
+  avatarUrl: string | null;
+}
+
+interface WebFingerLink {
+  rel?: string;
+  type?: string;
+  href?: string;
+}
+
+interface WebFingerResponse {
+  subject?: string;
+  aliases?: string[];
+  links?: WebFingerLink[];
+}
+
+interface ActorDocument {
+  id?: string;
+  preferredUsername?: string;
+  name?: string;
+  url?: string | { href?: string } | Array<string | { href?: string }>;
+  inbox?: string;
+  endpoints?: { sharedInbox?: string };
+  icon?: { url?: string } | string | Array<{ url?: string } | string>;
+}
+
+export function parseFediverseHandle(input: string): { username: string; host: string } | null {
+  const normalized = input.trim().replace(/^@/, "");
+  if (!normalized || normalized.includes("://")) return null;
+
+  const [username, host, extra] = normalized.split("@");
+  if (!username || !host || extra) return null;
+  if (!/^[A-Za-z0-9._-]+$/.test(username)) return null;
+
+  try {
+    const url = new URL(`https://${host}`);
+    if (!isSafeRemoteUrl(url)) return null;
+    return { username, host: url.hostname.toLowerCase() };
+  } catch {
+    return null;
+  }
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const parts = hostname.split(".").map((part) => Number(part));
+  if (
+    parts.length !== 4 ||
+    parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+  ) {
+    return false;
+  }
+
+  const [a, b] = parts;
+  return (
+    a === 10 ||
+    a === 127 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 169 && b === 254) ||
+    a === 0
+  );
+}
+
+export function isSafeRemoteUrl(url: URL): boolean {
+  if (url.protocol !== "https:") return false;
+
+  const hostname = url.hostname.toLowerCase();
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "0.0.0.0" ||
+    hostname === "::1" ||
+    hostname.startsWith("127.") ||
+    hostname.startsWith("[::1]") ||
+    isPrivateIpv4(hostname)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+async function fetchJson<T>(url: URL, fetcher: FetchLike): Promise<T> {
+  if (!isSafeRemoteUrl(url)) {
+    throw new Error(`Unsafe remote URL: ${url.href}`);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const response = await fetcher(url, {
+      headers: { Accept: "application/activity+json, application/ld+json, application/json" },
+      redirect: "error",
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`Fetch failed for ${url.href}: ${response.status}`);
+    }
+
+    const text = await response.text();
+    if (text.length > 1_000_000) {
+      throw new Error(`Response too large for ${url.href}`);
+    }
+
+    return JSON.parse(text) as T;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function firstUrl(value: ActorDocument["url"]): string | null {
+  if (!value) return null;
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const candidate = typeof item === "string" ? item : item.href;
+      if (candidate) return candidate;
+    }
+    return null;
+  }
+  return value.href ?? null;
+}
+
+function firstIconUrl(value: ActorDocument["icon"]): string | null {
+  if (!value) return null;
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const candidate = typeof item === "string" ? item : item.url;
+      if (candidate) return candidate;
+    }
+    return null;
+  }
+  return value.url ?? null;
+}
+
+function validateRemoteUrl(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return isSafeRemoteUrl(url) ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveRemoteActor(
+  input: string,
+  fetcher: FetchLike = fetch
+): Promise<ResolvedRemoteActor> {
+  let directActorUrl: URL | null = null;
+  if (input.trim().includes("://")) {
+    try {
+      directActorUrl = new URL(input.trim());
+    } catch {
+      throw new Error("Actor URL is invalid");
+    }
+  }
+  const parsed = directActorUrl ? null : parseFediverseHandle(input);
+  if (!parsed && !directActorUrl) {
+    throw new Error("Enter a Fediverse handle like @alice@example.social");
+  }
+
+  let actorUrl: URL;
+  let handle: string | null = null;
+  let fallbackUsername: string | null = null;
+
+  if (directActorUrl) {
+    if (!isSafeRemoteUrl(directActorUrl)) {
+      throw new Error("Actor URL is not safe to fetch");
+    }
+    actorUrl = directActorUrl;
+  } else {
+    const resource = `acct:${parsed!.username}@${parsed!.host}`;
+    const webFingerUrl = new URL(`https://${parsed!.host}/.well-known/webfinger`);
+    webFingerUrl.searchParams.set("resource", resource);
+
+    const webFinger = await fetchJson<WebFingerResponse>(webFingerUrl, fetcher);
+    const selfLink = webFinger.links?.find(
+      (link) =>
+        link.rel === "self" &&
+        link.href &&
+        (!link.type || link.type.includes("activity") || link.type.includes("ld+json"))
+    );
+
+    if (!selfLink?.href) {
+      throw new Error("Could not find an ActivityPub actor for that handle");
+    }
+
+    actorUrl = new URL(selfLink.href);
+    handle = `@${parsed!.username}@${parsed!.host}`;
+    fallbackUsername = parsed!.username;
+  }
+
+  if (!isSafeRemoteUrl(actorUrl)) {
+    throw new Error("Resolved actor URL is not safe to fetch");
+  }
+
+  const actor = await fetchJson<ActorDocument>(actorUrl, fetcher);
+  const actorUri = validateRemoteUrl(actor.id ?? actorUrl.href);
+  const inboxUri = validateRemoteUrl(actor.inbox ?? null);
+  if (!actorUri || !inboxUri) {
+    throw new Error("Resolved actor is missing a safe id or inbox");
+  }
+
+  const profileUrl = validateRemoteUrl(firstUrl(actor.url)) ?? actorUri;
+  const avatarUrl = validateRemoteUrl(firstIconUrl(actor.icon));
+  const preferredUsername = actor.preferredUsername ?? fallbackUsername;
+
+  return {
+    actorUri,
+    handle,
+    preferredUsername,
+    displayName: actor.name ?? preferredUsername,
+    profileUrl,
+    inboxUri,
+    sharedInboxUri: validateRemoteUrl(actor.endpoints?.sharedInbox ?? null),
+    avatarUrl,
+  };
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case REMOTE_FOLLOW_ACCEPTED_STATUS:
+      return "Following";
+    case REMOTE_FOLLOW_REJECTED_STATUS:
+      return "Rejected";
+    case REMOTE_FOLLOW_FAILED_STATUS:
+      return "Failed";
+    case REMOTE_FOLLOW_CANCELLED_STATUS:
+      return "Cancelled";
+    default:
+      return "Pending";
+  }
+}
+
+export function getRemoteFollowStatusLabel(status: string): string {
+  return statusLabel(status);
+}
+
+function findPersonIdForActor(
+  actor: ResolvedRemoteActor,
+  database: FollowingDatabase
+): number | null {
+  const candidates = [actor.actorUri, actor.profileUrl, actor.handle].filter(
+    (value): value is string => Boolean(value)
+  );
+  if (candidates.length === 0) return null;
+
+  const match = database
+    .select({ personId: personSocialAccounts.person_id })
+    .from(personSocialAccounts)
+    .where(
+      and(
+        eq(personSocialAccounts.is_activitypub, true),
+        inArray(personSocialAccounts.url, candidates)
+      )
+    )
+    .get();
+
+  return match?.personId ?? null;
+}
+
+function ensurePersonForActor(actor: ResolvedRemoteActor, database: FollowingDatabase): number {
+  const existingPersonId = findPersonIdForActor(actor, database);
+  if (existingPersonId) return existingPersonId;
+
+  const name = actor.displayName ?? actor.preferredUsername ?? actor.handle ?? actor.actorUri;
+  const person = database
+    .insert(people)
+    .values({ name, url: actor.profileUrl ?? actor.actorUri })
+    .returning()
+    .get();
+
+  database
+    .insert(personSocialAccounts)
+    .values({
+      person_id: person.id,
+      label: actor.handle ?? "Fediverse",
+      url: actor.profileUrl ?? actor.actorUri,
+      avatar_url: actor.avatarUrl,
+      is_activitypub: true,
+      is_default: true,
+      sort_order: 0,
+    })
+    .run();
+
+  return person.id;
+}
+
+function followActivityUri(actorUri: string): string {
+  const encoded = encodeURIComponent(actorUri).replace(/%/g, "~");
+  return new URL(`/activities/follow/${encoded}`, baseUrl).href;
+}
+
+export async function sendFollowActivity(follow: RemoteFollow): Promise<void> {
+  const ctx = federation.createContext(new URL(baseUrl), undefined);
+  const actorUri = ctx.getActorUri("erik");
+  const activity = new Follow({
+    id: new URL(follow.follow_activity_uri),
+    actor: actorUri,
+    object: new URL(follow.actor_uri),
+    to: new URL(follow.actor_uri),
+    published: dateToInstant(follow.followed_at),
+  });
+  const recipient: Recipient = {
+    id: new URL(follow.actor_uri),
+    inboxId: new URL(follow.inbox_uri),
+    endpoints: follow.shared_inbox_uri ? { sharedInbox: new URL(follow.shared_inbox_uri) } : null,
+  };
+
+  await ctx.sendActivity({ identifier: "erik" }, recipient, activity, { preferSharedInbox: true });
+}
+
+export async function createOrRetryRemoteFollow({
+  actor,
+  database = db,
+  deliver = sendFollowActivity,
+}: {
+  actor: ResolvedRemoteActor;
+  database?: FollowingDatabase;
+  deliver?: (follow: RemoteFollow) => Promise<void>;
+}): Promise<RemoteFollow> {
+  const existing = database
+    .select()
+    .from(remoteFollows)
+    .where(eq(remoteFollows.actor_uri, actor.actorUri))
+    .get();
+
+  if (existing) {
+    logger.debug("federation", `Remote follow already exists: ${actor.actorUri}`);
+    return existing;
+  }
+
+  const now = new Date();
+  const personId = ensurePersonForActor(actor, database);
+  const follow = database
+    .insert(remoteFollows)
+    .values({
+      person_id: personId,
+      actor_uri: actor.actorUri,
+      handle: actor.handle,
+      preferred_username: actor.preferredUsername,
+      display_name: actor.displayName,
+      profile_url: actor.profileUrl,
+      inbox_uri: actor.inboxUri,
+      shared_inbox_uri: actor.sharedInboxUri,
+      avatar_url: actor.avatarUrl,
+      follow_activity_uri: followActivityUri(actor.actorUri),
+      status: REMOTE_FOLLOW_PENDING_STATUS,
+      last_error: null,
+      followed_at: now,
+      created_at: now,
+      updated_at: now,
+    })
+    .returning()
+    .get();
+
+  try {
+    await deliver(follow);
+    return follow;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    database
+      .update(remoteFollows)
+      .set({ status: REMOTE_FOLLOW_FAILED_STATUS, last_error: message, updated_at: new Date() })
+      .where(eq(remoteFollows.id, follow.id))
+      .run();
+    throw error;
+  }
+}
+
+export function listRemoteFollows(database: FollowingDatabase = db): RemoteFollow[] {
+  return database
+    .select()
+    .from(remoteFollows)
+    .orderBy(asc(remoteFollows.display_name), asc(remoteFollows.id))
+    .all();
+}
+
+export function getRemoteFollowForActor(
+  actorUri: string,
+  database: FollowingDatabase = db
+): RemoteFollow | null {
+  return (
+    database.select().from(remoteFollows).where(eq(remoteFollows.actor_uri, actorUri)).get() ?? null
+  );
+}
+
+export function getRemoteFollowForPerson(
+  personId: number,
+  database: FollowingDatabase = db
+): RemoteFollow | null {
+  return (
+    database.select().from(remoteFollows).where(eq(remoteFollows.person_id, personId)).get() ?? null
+  );
+}

--- a/src/federation/following.ts
+++ b/src/federation/following.ts
@@ -1,7 +1,9 @@
 import { and, asc, eq, inArray } from "drizzle-orm";
+import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
 import { Follow, type Recipient } from "@fedify/fedify";
 
-import { db, people, personSocialAccounts, remoteFollows } from "@/db";
+import * as schema from "@/db/schema";
+import { people, personSocialAccounts, remoteFollows } from "@/db/schema";
 import { logger } from "@/utils/logger";
 import { baseUrl, dateToInstant } from "./utils";
 
@@ -18,8 +20,15 @@ export type RemoteFollowStatus =
   | typeof REMOTE_FOLLOW_FAILED_STATUS
   | typeof REMOTE_FOLLOW_CANCELLED_STATUS;
 
-type FollowingDatabase = typeof db;
+type FollowingDatabase = BunSQLiteDatabase<typeof schema>;
 export type RemoteFollow = typeof remoteFollows.$inferSelect;
+
+function getDefaultDatabase(): FollowingDatabase {
+  // Keep the production database import lazy so tests that inject an in-memory DB
+  // do not open ./data/site.db at module load time.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require("@/db").db as FollowingDatabase;
+}
 
 type FetchLike = typeof fetch;
 
@@ -347,7 +356,7 @@ export async function sendFollowActivity(follow: RemoteFollow): Promise<void> {
 
 export async function createOrRetryRemoteFollow({
   actor,
-  database = db,
+  database = getDefaultDatabase(),
   deliver = sendFollowActivity,
 }: {
   actor: ResolvedRemoteActor;
@@ -403,7 +412,9 @@ export async function createOrRetryRemoteFollow({
   }
 }
 
-export function listRemoteFollows(database: FollowingDatabase = db): RemoteFollow[] {
+export function listRemoteFollows(
+  database: FollowingDatabase = getDefaultDatabase()
+): RemoteFollow[] {
   return database
     .select()
     .from(remoteFollows)
@@ -413,7 +424,7 @@ export function listRemoteFollows(database: FollowingDatabase = db): RemoteFollo
 
 export function getRemoteFollowForActor(
   actorUri: string,
-  database: FollowingDatabase = db
+  database: FollowingDatabase = getDefaultDatabase()
 ): RemoteFollow | null {
   return (
     database.select().from(remoteFollows).where(eq(remoteFollows.actor_uri, actorUri)).get() ?? null
@@ -422,7 +433,7 @@ export function getRemoteFollowForActor(
 
 export function getRemoteFollowForPerson(
   personId: number,
-  database: FollowingDatabase = db
+  database: FollowingDatabase = getDefaultDatabase()
 ): RemoteFollow | null {
   return (
     database.select().from(remoteFollows).where(eq(remoteFollows.person_id, personId)).get() ?? null

--- a/src/routes/__tests__/admin.test.tsx
+++ b/src/routes/__tests__/admin.test.tsx
@@ -3,7 +3,9 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { mock } from "bun:test";
 
 import { createTestDb } from "../../db/test-utils";
-import { followers, sessions } from "../../db/schema";
+import { followers, remoteFollows, sessions } from "../../db/schema";
+
+const originalFetch = global.fetch;
 
 const testDb = createTestDb();
 const adminEmail = "admin-test@example.com";
@@ -42,8 +44,10 @@ function authenticatedRequest(path: string): Request {
 }
 
 beforeEach(() => {
+  testDb.delete(remoteFollows).run();
   testDb.delete(followers).run();
   testDb.delete(sessions).run();
+  global.fetch = originalFetch;
 });
 
 describe("admin follower page", () => {
@@ -124,5 +128,71 @@ describe("admin follower page", () => {
     expect(html).not.toContain(">Reject<");
     expect(html).not.toContain(">Remove<");
     expect(html).not.toContain(">Delete<");
+  });
+});
+
+describe("admin following page", () => {
+  it("redirects unauthenticated users to login", async () => {
+    const { admin } = await import("../admin");
+
+    const res = await admin.request("/following");
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/login");
+  });
+
+  it("shows the following form and empty state", async () => {
+    const { admin } = await import("../admin");
+
+    const res = await admin.request(authenticatedRequest("/following"));
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("Follow a Fediverse account");
+    expect(html).toContain("@alice@example.social");
+    expect(html).toContain("No followed accounts yet.");
+  });
+
+  it("resolves a Fediverse account preview", async () => {
+    global.fetch = mock(async (input: URL | RequestInfo) => {
+      const url = input instanceof URL ? input.href : String(input);
+      if (url.startsWith("https://example.social/.well-known/webfinger")) {
+        return new Response(
+          JSON.stringify({
+            links: [
+              {
+                rel: "self",
+                type: "application/activity+json",
+                href: "https://example.social/users/alice",
+              },
+            ],
+          })
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          id: "https://example.social/users/alice",
+          preferredUsername: "alice",
+          name: "Alice Example",
+          url: "https://example.social/@alice",
+          inbox: "https://example.social/users/alice/inbox",
+          endpoints: { sharedInbox: "https://example.social/inbox" },
+        })
+      );
+    }) as unknown as typeof fetch;
+
+    const { admin } = await import("../admin");
+
+    const res = await admin.request(
+      authenticatedRequest("/following?handle=%40alice%40example.social")
+    );
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("Resolved account");
+    expect(html).toContain("Alice Example");
+    expect(html).toContain("https://example.social/users/alice");
+    expect(html).toContain(">Follow<");
   });
 });

--- a/src/routes/__tests__/admin.test.tsx
+++ b/src/routes/__tests__/admin.test.tsx
@@ -22,6 +22,17 @@ mock.module("@/db", () => ({
   ...require("../../db/schema"),
 }));
 
+const mockContextSendActivity = mock(async () => {});
+
+mock.module("@/federation/setup", () => ({
+  federation: {
+    createContext: mock(() => ({
+      getActorUri: () => new URL("http://localhost:5000/users/erik"),
+      sendActivity: mockContextSendActivity,
+    })),
+  },
+}));
+
 function createAdminSession(): string {
   const sessionId = crypto.randomUUID();
   testDb
@@ -48,6 +59,7 @@ beforeEach(() => {
   testDb.delete(followers).run();
   testDb.delete(sessions).run();
   global.fetch = originalFetch;
+  mockContextSendActivity.mockClear();
 });
 
 describe("admin follower page", () => {
@@ -194,5 +206,39 @@ describe("admin following page", () => {
     expect(html).toContain("Alice Example");
     expect(html).toContain("https://example.social/users/alice");
     expect(html).toContain(">Follow<");
+  });
+
+  it("lets admins cancel pending follow requests", async () => {
+    testDb
+      .insert(remoteFollows)
+      .values({
+        actor_uri: "https://example.social/users/alice",
+        handle: "@alice@example.social",
+        display_name: "Alice Example",
+        profile_url: "https://example.social/@alice",
+        inbox_uri: "https://example.social/users/alice/inbox",
+        follow_activity_uri: "http://localhost:5000/activities/follow/alice",
+        status: "pending",
+        followed_at: new Date(),
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .run();
+
+    const { admin } = await import("../admin");
+
+    const pageRes = await admin.request(authenticatedRequest("/following"));
+    const html = await pageRes.text();
+    expect(html).toContain('action="/admin/following/1/cancel"');
+    expect(html).toContain("Cancel request");
+
+    const cancelRes = await admin.request(authenticatedRequest("/following/1/cancel"), {
+      method: "POST",
+    });
+
+    const stored = testDb.select().from(remoteFollows).get();
+    expect(cancelRes.status).toBe(302);
+    expect(stored?.status).toBe("cancelled");
+    expect(mockContextSendActivity).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -1857,6 +1857,38 @@ describe("Remote following API", () => {
     expect(listBody.data[0].actor_uri).toBe("https://example.social/users/alice");
   });
 
+  it("cancels pending follows", async () => {
+    const follow = testDb
+      .insert(remoteFollows)
+      .values({
+        actor_uri: "https://example.social/users/alice",
+        handle: "@alice@example.social",
+        display_name: "Alice Example",
+        profile_url: "https://example.social/@alice",
+        inbox_uri: "https://example.social/users/alice/inbox",
+        follow_activity_uri: "http://localhost:5000/activities/follow/alice",
+        status: "pending",
+        followed_at: new Date(),
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .returning()
+      .get();
+    const { api } = await import("../api");
+
+    const res = await api.request("/following/cancel", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ id: follow.id }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.status).toBe("cancelled");
+    expect(testDb.select().from(remoteFollows).get()?.status).toBe("cancelled");
+    expect(mockContextSendActivity).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects unsafe handles without creating follows", async () => {
     const { api } = await import("../api");
 

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -13,6 +13,7 @@ import {
   postTags,
   remoteLikes,
   remoteComments,
+  remoteFollows,
 } from "../../db/schema";
 import { eq } from "drizzle-orm";
 
@@ -31,9 +32,14 @@ mock.module("@/db", () => ({
   ...require("../../db/schema"),
 }));
 
+const mockContextSendActivity = mock(async () => {});
+
 mock.module("@/federation/setup", () => ({
   federation: {
-    createContext: mock(() => {}),
+    createContext: mock(() => ({
+      getActorUri: () => new URL("http://localhost:5000/users/erik"),
+      sendActivity: mockContextSendActivity,
+    })),
     sendActivity: mock(() => {}),
   },
   createFedifyFederation: mock(() => {}),
@@ -73,6 +79,7 @@ mock.module("@/auth/api-key", () => {
 });
 
 beforeEach(() => {
+  testDb.delete(remoteFollows).run();
   testDb.delete(remoteComments).run();
   testDb.delete(remoteLikes).run();
   testDb.delete(postTags).run();
@@ -89,6 +96,7 @@ beforeEach(() => {
   mockSendDeleteActivityForUri.mockClear();
   mockSendUpdateActivity.mockClear();
   mockSendActorUpdateActivity.mockClear();
+  mockContextSendActivity.mockClear();
 });
 
 const authHeader = { Authorization: "Bearer ek_test" };
@@ -1779,5 +1787,86 @@ describe("/api/people", () => {
     expect(res.status).toBe(404);
     const json = await res.json();
     expect(json.error).toBe("Person not found");
+  });
+});
+
+describe("Remote following API", () => {
+  function mockRemoteActorFetch(): void {
+    global.fetch = mock(async (input: URL | RequestInfo) => {
+      const url = input instanceof URL ? input.href : String(input);
+      if (url.startsWith("https://example.social/.well-known/webfinger")) {
+        return new Response(
+          JSON.stringify({
+            links: [
+              {
+                rel: "self",
+                type: "application/activity+json",
+                href: "https://example.social/users/alice",
+              },
+            ],
+          })
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          id: "https://example.social/users/alice",
+          preferredUsername: "alice",
+          name: "Alice Example",
+          url: "https://example.social/@alice",
+          inbox: "https://example.social/users/alice/inbox",
+          endpoints: { sharedInbox: "https://example.social/inbox" },
+        })
+      );
+    }) as unknown as typeof fetch;
+  }
+
+  it("resolves a remote actor without creating a follow", async () => {
+    mockRemoteActorFetch();
+    const { api } = await import("../api");
+
+    const res = await api.request("/following/resolve", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ handle: "@alice@example.social" }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.actorUri).toBe("https://example.social/users/alice");
+    expect(testDb.select().from(remoteFollows).all()).toHaveLength(0);
+  });
+
+  it("creates a pending follow and lists stored follows", async () => {
+    mockRemoteActorFetch();
+    const { api } = await import("../api");
+
+    const createRes = await api.request("/following", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ handle: "@alice@example.social" }),
+    });
+    const createBody = await createRes.json();
+
+    const listRes = await api.request("/following", { headers: authHeader });
+    const listBody = await listRes.json();
+
+    expect(createRes.status).toBe(200);
+    expect(createBody.data.status).toBe("pending");
+    expect(listBody.data).toHaveLength(1);
+    expect(listBody.data[0].actor_uri).toBe("https://example.social/users/alice");
+  });
+
+  it("rejects unsafe handles without creating follows", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/following/resolve", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ handle: "@alice@localhost" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(testDb.select().from(remoteFollows).all()).toHaveLength(0);
   });
 });

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -31,7 +31,11 @@ import {
 // Create test db immediately
 const testDb = createTestDb();
 
+const mockFederatePost = mock(async () => true);
+const mockSendDeleteActivity = mock(async () => true);
+const mockSendDeleteActivityForUri = mock(async () => true);
 const mockSendUpdateActivity = mock(async () => true);
+const mockSendActorUpdateActivity = mock(async () => true);
 
 // Mock the db module
 mock.module("../../db", () => ({
@@ -40,11 +44,19 @@ mock.module("../../db", () => ({
 }));
 
 mock.module("../federation/publish", () => ({
+  federatePost: mockFederatePost,
+  sendDeleteActivity: mockSendDeleteActivity,
+  sendDeleteActivityForUri: mockSendDeleteActivityForUri,
   sendUpdateActivity: mockSendUpdateActivity,
+  sendActorUpdateActivity: mockSendActorUpdateActivity,
 }));
 
 mock.module("@/federation/publish", () => ({
+  federatePost: mockFederatePost,
+  sendDeleteActivity: mockSendDeleteActivity,
+  sendDeleteActivityForUri: mockSendDeleteActivityForUri,
   sendUpdateActivity: mockSendUpdateActivity,
+  sendActorUpdateActivity: mockSendActorUpdateActivity,
 }));
 
 // Set up test data

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -36,6 +36,7 @@ const mockSendDeleteActivity = mock(async () => true);
 const mockSendDeleteActivityForUri = mock(async () => true);
 const mockSendUpdateActivity = mock(async () => true);
 const mockSendActorUpdateActivity = mock(async () => true);
+const mockContextSendActivity = mock(async () => {});
 
 // Mock the db module
 mock.module("../../db", () => ({
@@ -57,6 +58,15 @@ mock.module("@/federation/publish", () => ({
   sendDeleteActivityForUri: mockSendDeleteActivityForUri,
   sendUpdateActivity: mockSendUpdateActivity,
   sendActorUpdateActivity: mockSendActorUpdateActivity,
+}));
+
+mock.module("@/federation/setup", () => ({
+  federation: {
+    createContext: mock(() => ({
+      getActorUri: () => new URL("http://localhost:5000/users/erik"),
+      sendActivity: mockContextSendActivity,
+    })),
+  },
 }));
 
 // Set up test data
@@ -1079,7 +1089,20 @@ describe("pages routes", () => {
       const followedHtml = await followedRes.text();
 
       expect(followedHtml).toContain(">Pending</span>");
+      expect(followedHtml).toContain('action="/people/1/follow/cancel"');
       expect(followedHtml).not.toContain('action="/people/1/follow"');
+
+      mockContextSendActivity.mockClear();
+      const cancelRes = await app.request("/people/1/follow/cancel", {
+        method: "POST",
+        headers: { Cookie: `session=${sessionId}` },
+      });
+
+      expect(cancelRes.status).toBe(302);
+      expect(
+        testDb.select().from(remoteFollows).where(eq(remoteFollows.person_id, 1)).get()?.status
+      ).toBe("cancelled");
+      expect(mockContextSendActivity).toHaveBeenCalledTimes(1);
     });
 
     it("shows links from the selected person with full shared link content", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -23,6 +23,7 @@ import {
   remoteLikes,
   remoteBoosts,
   remoteComments,
+  remoteFollows,
   authors,
   sessions,
 } from "../../db/schema";
@@ -1011,6 +1012,62 @@ describe("pages routes", () => {
       expect(html).toContain('src="https://mastodon.social/avatar.jpg"');
       expect(html).toContain('href="https://mastodon.social/@testauthor"');
       expect(html).toContain(">Follow</a>");
+    });
+
+    it("shows local follow actions and status for authenticated person cards", async () => {
+      const author = testDb
+        .insert(authors)
+        .values({
+          email: `person-follow-${crypto.randomUUID()}@example.com`,
+          created_at: new Date(),
+        })
+        .returning()
+        .get();
+      const sessionId = `person-follow-session-${crypto.randomUUID()}`;
+      testDb
+        .insert(sessions)
+        .values({
+          id: sessionId,
+          author_id: author.id,
+          expires_at: new Date(Date.now() + 60 * 60 * 1000),
+          created_at: new Date(),
+        })
+        .run();
+
+      const app = getApp();
+      const initialRes = await app.request("/people/1", {
+        headers: { Cookie: `session=${sessionId}` },
+      });
+      const initialHtml = await initialRes.text();
+
+      expect(initialHtml).toContain('action="/people/1/follow"');
+      expect(initialHtml).toContain(">Follow</button>");
+
+      testDb
+        .insert(remoteFollows)
+        .values({
+          person_id: 1,
+          actor_uri: "https://mastodon.social/users/testauthor",
+          handle: "@testauthor@mastodon.social",
+          preferred_username: "testauthor",
+          display_name: "Test Author",
+          profile_url: "https://mastodon.social/@testauthor",
+          inbox_uri: "https://mastodon.social/users/testauthor/inbox",
+          follow_activity_uri: "http://localhost:5000/activities/follow/testauthor",
+          status: "pending",
+          followed_at: new Date(),
+          created_at: new Date(),
+          updated_at: new Date(),
+        })
+        .run();
+
+      const followedRes = await app.request("/people/1", {
+        headers: { Cookie: `session=${sessionId}` },
+      });
+      const followedHtml = await followedRes.text();
+
+      expect(followedHtml).toContain(">Pending</span>");
+      expect(followedHtml).not.toContain('action="/people/1/follow"');
     });
 
     it("shows links from the selected person with full shared link content", async () => {

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -11,6 +11,13 @@ import {
   verifyAndStorePasskey,
   deletePasskey,
 } from "@/auth/passkey";
+import {
+  createOrRetryRemoteFollow,
+  getRemoteFollowStatusLabel,
+  listRemoteFollows,
+  resolveRemoteActor,
+  type ResolvedRemoteActor,
+} from "@/federation/following";
 
 export const admin = new Hono();
 
@@ -47,6 +54,11 @@ function AdminNav({ isAdmin }: { isAdmin: boolean }) {
         <li>
           <a href="/admin/followers" class="text-blue-600 dark:text-blue-400 hover:underline">
             Followers
+          </a>
+        </li>
+        <li>
+          <a href="/admin/following" class="text-blue-600 dark:text-blue-400 hover:underline">
+            Following
           </a>
         </li>
         {isAdmin && (
@@ -110,6 +122,32 @@ function MissingValue() {
   return <span class="text-gray-400 dark:text-gray-500">Not provided</span>;
 }
 
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span class="inline-flex rounded-full bg-yellow-100 px-2 py-1 text-xs font-semibold text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200">
+      {getRemoteFollowStatusLabel(status)}
+    </span>
+  );
+}
+
+function ResolvedActorPreview({ actor }: { actor: ResolvedRemoteActor }) {
+  return (
+    <div class="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+      <h2 class="mb-2 text-lg font-semibold text-blue-950 dark:text-blue-100">Resolved account</h2>
+      <p class="text-sm text-blue-900 dark:text-blue-200">
+        {actor.displayName ?? actor.preferredUsername ?? actor.handle ?? actor.actorUri}
+      </p>
+      <p class="break-all text-xs text-blue-700 dark:text-blue-300">{actor.actorUri}</p>
+      <form method="post" action="/admin/following" class="mt-4">
+        <input type="hidden" name="actor" value={actor.actorUri} />
+        <button class="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700" type="submit">
+          Follow
+        </button>
+      </form>
+    </div>
+  );
+}
+
 /**
  * GET /admin - Admin dashboard
  */
@@ -140,6 +178,16 @@ admin.get("/", (c) => {
             <h2 class="text-lg font-semibold mb-2">ActivityPub Followers</h2>
             <p class="text-sm text-gray-500 dark:text-gray-400">
               Inspect remote Fediverse accounts that follow this site.
+            </p>
+          </a>
+
+          <a
+            href="/admin/following"
+            class="block bg-white dark:bg-gray-800 rounded-lg shadow p-6 hover:ring-2 hover:ring-blue-500"
+          >
+            <h2 class="text-lg font-semibold mb-2">Following</h2>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              Follow Fediverse accounts from this site actor.
             </p>
           </a>
         </div>
@@ -234,6 +282,138 @@ admin.get("/followers", (c) => {
       </div>
     </Layout>
   );
+});
+
+/**
+ * GET /admin/following - ActivityPub following management
+ */
+admin.get("/following", async (c) => {
+  const auth = c.get("auth");
+  const handle = c.req.query("handle")?.trim() ?? "";
+  const success = c.req.query("success");
+  const error = c.req.query("error");
+  let resolvedActor: ResolvedRemoteActor | null = null;
+  let resolveError: string | null = null;
+
+  if (handle) {
+    try {
+      resolvedActor = await resolveRemoteActor(handle);
+    } catch (cause) {
+      resolveError = cause instanceof Error ? cause.message : String(cause);
+    }
+  }
+
+  const follows = listRemoteFollows();
+
+  return c.html(
+    <Layout title="Following | Admin">
+      <div class="mx-auto max-w-5xl">
+        <AdminHeader title="Following" isAdmin={auth.isAdmin} />
+
+        {success && (
+          <div class="mb-6 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800 dark:border-green-800 dark:bg-green-900/20 dark:text-green-200">
+            {success}
+          </div>
+        )}
+        {(error || resolveError) && (
+          <div class="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
+            {error ?? resolveError}
+          </div>
+        )}
+
+        <div class="mb-6 rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+          <h2 class="mb-4 text-lg font-semibold">Follow a Fediverse account</h2>
+          <form method="get" action="/admin/following" class="flex flex-col gap-3 sm:flex-row">
+            <input
+              class="flex-1 rounded border border-gray-300 px-3 py-2 dark:border-gray-700 dark:bg-gray-900"
+              name="handle"
+              placeholder="@alice@example.social"
+              type="text"
+              value={handle}
+            />
+            <button
+              class="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+              type="submit"
+            >
+              Resolve
+            </button>
+          </form>
+        </div>
+
+        {resolvedActor && <ResolvedActorPreview actor={resolvedActor} />}
+
+        <div class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
+          <h2 class="mb-4 text-lg font-semibold">Stored follows</h2>
+          {follows.length === 0 ? (
+            <p class="text-gray-600 dark:text-gray-300">No followed accounts yet.</p>
+          ) : (
+            <div class="overflow-x-auto">
+              <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead>
+                  <tr>
+                    <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Account</th>
+                    <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Status</th>
+                    <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Person</th>
+                    <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Followed</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                  {follows.map((follow) => (
+                    <tr>
+                      <td class="px-3 py-2 text-sm">
+                        <a
+                          class="break-all text-blue-600 hover:underline"
+                          href={follow.profile_url ?? follow.actor_uri}
+                        >
+                          {follow.display_name ?? follow.handle ?? follow.actor_uri}
+                        </a>
+                        <div class="break-all text-xs text-gray-500">{follow.actor_uri}</div>
+                      </td>
+                      <td class="px-3 py-2 text-sm">
+                        <StatusBadge status={follow.status} />
+                      </td>
+                      <td class="px-3 py-2 text-sm">
+                        {follow.person_id ? (
+                          <a
+                            class="text-blue-600 hover:underline"
+                            href={`/people/${follow.person_id}`}
+                          >
+                            Person #{follow.person_id}
+                          </a>
+                        ) : (
+                          <MissingValue />
+                        )}
+                      </td>
+                      <td class="px-3 py-2 text-sm">{formatDateTime(follow.followed_at)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </Layout>
+  );
+});
+
+admin.post("/following", async (c) => {
+  const form = await c.req.formData();
+  const actorInput = String(form.get("actor") ?? "").trim();
+  if (!actorInput) {
+    return c.redirect("/admin/following?error=Fediverse account is required");
+  }
+
+  try {
+    const actor = await resolveRemoteActor(actorInput);
+    const follow = await createOrRetryRemoteFollow({ actor });
+    return c.redirect(
+      `/admin/following?success=${encodeURIComponent(`Follow request sent to ${follow.display_name ?? follow.handle ?? follow.actor_uri}`)}`
+    );
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return c.redirect(`/admin/following?error=${encodeURIComponent(message)}`);
+  }
 });
 
 /**

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -12,6 +12,8 @@ import {
   deletePasskey,
 } from "@/auth/passkey";
 import {
+  REMOTE_FOLLOW_PENDING_STATUS,
+  cancelPendingRemoteFollow,
   createOrRetryRemoteFollow,
   getRemoteFollowStatusLabel,
   listRemoteFollows,
@@ -355,6 +357,7 @@ admin.get("/following", async (c) => {
                     <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Status</th>
                     <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Person</th>
                     <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Followed</th>
+                    <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Actions</th>
                   </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
@@ -385,6 +388,20 @@ admin.get("/following", async (c) => {
                         )}
                       </td>
                       <td class="px-3 py-2 text-sm">{formatDateTime(follow.followed_at)}</td>
+                      <td class="px-3 py-2 text-sm">
+                        {follow.status === REMOTE_FOLLOW_PENDING_STATUS ? (
+                          <form method="post" action={`/admin/following/${follow.id}/cancel`}>
+                            <button
+                              class="rounded bg-gray-200 px-3 py-1 text-sm font-semibold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+                              type="submit"
+                            >
+                              Cancel request
+                            </button>
+                          </form>
+                        ) : (
+                          <MissingValue />
+                        )}
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -395,6 +412,21 @@ admin.get("/following", async (c) => {
       </div>
     </Layout>
   );
+});
+
+admin.post("/following/:id/cancel", async (c) => {
+  const id = Number(c.req.param("id"));
+  if (!Number.isInteger(id) || id < 1) {
+    return c.redirect("/admin/following?error=Invalid follow request");
+  }
+
+  try {
+    await cancelPendingRemoteFollow({ followId: id });
+    return c.redirect("/admin/following?success=Follow request cancelled");
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return c.redirect(`/admin/following?error=${encodeURIComponent(message)}`);
+  }
 });
 
 admin.post("/following", async (c) => {

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -47,6 +47,11 @@ import {
   listPendingRemoteComments,
 } from "@/federation/replies";
 import {
+  createOrRetryRemoteFollow,
+  listRemoteFollows,
+  resolveRemoteActor,
+} from "@/federation/following";
+import {
   federatePost,
   sendDeleteActivity,
   sendDeleteActivityForUri,
@@ -2527,6 +2532,51 @@ registerProtectedRoute(
     return c.json({ data: serializeRemoteComment(comment) });
   }
 );
+
+protectedApi.get("/following", (c) => {
+  const follows = listRemoteFollows().map((follow) => ({
+    id: follow.id,
+    person_id: follow.person_id,
+    actor_uri: follow.actor_uri,
+    handle: follow.handle,
+    display_name: follow.display_name,
+    profile_url: follow.profile_url,
+    status: follow.status,
+    followed_at: follow.followed_at.toISOString(),
+  }));
+  return c.json({ data: follows });
+});
+
+protectedApi.post("/following/resolve", async (c) => {
+  const body = (await c.req.json().catch(() => null)) as { handle?: string } | null;
+  if (!body?.handle) {
+    return c.json({ error: "Handle is required" }, 400);
+  }
+
+  try {
+    const actor = await resolveRemoteActor(body.handle);
+    return c.json({ data: actor });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return c.json({ error: message }, 400);
+  }
+});
+
+protectedApi.post("/following", async (c) => {
+  const body = (await c.req.json().catch(() => null)) as { handle?: string } | null;
+  if (!body?.handle) {
+    return c.json({ error: "Handle is required" }, 400);
+  }
+
+  try {
+    const actor = await resolveRemoteActor(body.handle);
+    const follow = await createOrRetryRemoteFollow({ actor });
+    return c.json({ data: { id: follow.id, actor_uri: follow.actor_uri, status: follow.status } });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return c.json({ error: message }, 400);
+  }
+});
 
 api.route("/", protectedApi);
 

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -47,6 +47,7 @@ import {
   listPendingRemoteComments,
 } from "@/federation/replies";
 import {
+  cancelPendingRemoteFollow,
   createOrRetryRemoteFollow,
   listRemoteFollows,
   resolveRemoteActor,
@@ -2559,6 +2560,25 @@ protectedApi.post("/following/resolve", async (c) => {
   } catch (cause) {
     const message = cause instanceof Error ? cause.message : String(cause);
     return c.json({ error: message }, 400);
+  }
+});
+
+protectedApi.post("/following/cancel", async (c) => {
+  const body = (await c.req.json().catch(() => null)) as { id?: number } | null;
+  const id = Number(body?.id);
+  if (!Number.isInteger(id) || id < 1) {
+    return c.json({ error: "Invalid follow ID" }, 400);
+  }
+
+  try {
+    const follow = await cancelPendingRemoteFollow({ followId: id });
+    if (!follow) {
+      return c.json({ error: "Follow not found" }, 404);
+    }
+    return c.json({ data: { id: follow.id, actor_uri: follow.actor_uri, status: follow.status } });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return c.json({ error: message }, 409);
   }
 });
 

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -33,6 +33,12 @@ import { logger } from "../utils/logger";
 import { getRemoteLikeCountForPost } from "../federation/likes";
 import { getRemoteBoostCountForPost } from "../federation/boosts";
 import {
+  createOrRetryRemoteFollow,
+  getRemoteFollowForPerson,
+  getRemoteFollowStatusLabel,
+  resolveRemoteActor,
+} from "../federation/following";
+import {
   approveRemoteComment,
   getApprovedRemoteCommentCountForPost,
   getVisibleRemoteCommentsForPost,
@@ -199,6 +205,8 @@ function PersonCard({
   socialAccounts = [],
   showSocialAccounts = true,
   showFollowButton = true,
+  authenticated = false,
+  followStatus = null,
 }: {
   person: Person;
   titleLink?: "detail" | "website";
@@ -206,6 +214,8 @@ function PersonCard({
   socialAccounts?: SocialAccount[];
   showSocialAccounts?: boolean;
   showFollowButton?: boolean;
+  authenticated?: boolean;
+  followStatus?: string | null;
 }) {
   const hostname = getLinkPreviewSiteLabel(person.url, null) ?? person.url;
   const initial = person.name.charAt(0).toUpperCase();
@@ -252,14 +262,31 @@ function PersonCard({
           ) : null}
           {showFollowButton && activityPubAccount ? (
             <div class="mt-3 flex justify-end">
-              <a
-                href={activityPubAccount.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="inline-flex rounded-full bg-teal-600 px-3 py-1 text-sm font-semibold text-white transition hover:bg-teal-700 dark:bg-teal-500 dark:text-gray-950 dark:hover:bg-teal-400"
-              >
-                Follow
-              </a>
+              {authenticated ? (
+                followStatus ? (
+                  <span class="inline-flex rounded-full bg-teal-100 px-3 py-1 text-sm font-semibold text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
+                    {getRemoteFollowStatusLabel(followStatus)}
+                  </span>
+                ) : (
+                  <form method="post" action={`/people/${person.id}/follow`}>
+                    <button
+                      type="submit"
+                      class="inline-flex rounded-full bg-teal-600 px-3 py-1 text-sm font-semibold text-white transition hover:bg-teal-700 dark:bg-teal-500 dark:text-gray-950 dark:hover:bg-teal-400"
+                    >
+                      Follow
+                    </button>
+                  </form>
+                )
+              ) : (
+                <a
+                  href={activityPubAccount.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex rounded-full bg-teal-600 px-3 py-1 text-sm font-semibold text-white transition hover:bg-teal-700 dark:bg-teal-500 dark:text-gray-950 dark:hover:bg-teal-400"
+                >
+                  Follow
+                </a>
+              )}
             </div>
           ) : null}
         </div>
@@ -2801,6 +2828,35 @@ export function createPagesRoutes(db: Database): Hono {
     );
   });
 
+  pages.post("/people/:id/follow", async (c) => {
+    if (!getAuthenticatedUserEmail(c, db)) {
+      return c.redirect("/login");
+    }
+
+    const id = Number(c.req.param("id"));
+    if (!Number.isInteger(id) || id < 1) {
+      return c.redirect("/people?error=Invalid person");
+    }
+
+    const activityPubAccount = getPersonSocialAccounts(db, id).find(
+      (account) => account.is_activitypub
+    );
+    if (!activityPubAccount) {
+      return c.redirect(
+        `/people/${id}?error=${encodeURIComponent("No ActivityPub account found")}`
+      );
+    }
+
+    try {
+      const actor = await resolveRemoteActor(activityPubAccount.url);
+      await createOrRetryRemoteFollow({ actor });
+      return c.redirect(`/people/${id}?success=${encodeURIComponent("Follow request sent")}`);
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      return c.redirect(`/people/${id}?error=${encodeURIComponent(message)}`);
+    }
+  });
+
   // Person detail page
   pages.get("/people/:id", (c) => {
     const id = parseInt(c.req.param("id") ?? "", 10);
@@ -2829,6 +2885,8 @@ export function createPagesRoutes(db: Database): Hono {
 
     const authoredSources = getSourcesAuthoredByPerson(db, person.id);
     const socialAccounts = getPersonSocialAccounts(db, person.id);
+    const isAuthenticated = Boolean(getAuthenticatedUserEmail(c, db));
+    const followStatus = getRemoteFollowForPerson(person.id, db)?.status ?? null;
     const personLinks: PostWithSource[] = withEngagementCounts(
       db,
       db
@@ -2855,6 +2913,8 @@ export function createPagesRoutes(db: Database): Hono {
               titleLink="website"
               authoredSources={authoredSources}
               socialAccounts={socialAccounts}
+              authenticated={isAuthenticated}
+              followStatus={followStatus}
             />
           </aside>
           <div class="overflow-hidden border-x border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900 sm:rounded-2xl sm:border">

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -33,6 +33,8 @@ import { logger } from "../utils/logger";
 import { getRemoteLikeCountForPost } from "../federation/likes";
 import { getRemoteBoostCountForPost } from "../federation/boosts";
 import {
+  REMOTE_FOLLOW_PENDING_STATUS,
+  cancelPendingRemoteFollow,
   createOrRetryRemoteFollow,
   getRemoteFollowForPerson,
   getRemoteFollowStatusLabel,
@@ -264,9 +266,21 @@ function PersonCard({
             <div class="mt-3 flex justify-end">
               {authenticated ? (
                 followStatus ? (
-                  <span class="inline-flex rounded-full bg-teal-100 px-3 py-1 text-sm font-semibold text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
-                    {getRemoteFollowStatusLabel(followStatus)}
-                  </span>
+                  <div class="flex items-center gap-2">
+                    <span class="inline-flex rounded-full bg-teal-100 px-3 py-1 text-sm font-semibold text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
+                      {getRemoteFollowStatusLabel(followStatus)}
+                    </span>
+                    {followStatus === REMOTE_FOLLOW_PENDING_STATUS ? (
+                      <form method="post" action={`/people/${person.id}/follow/cancel`}>
+                        <button
+                          type="submit"
+                          class="inline-flex rounded-full bg-gray-200 px-3 py-1 text-sm font-semibold text-gray-800 transition hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+                        >
+                          Cancel
+                        </button>
+                      </form>
+                    ) : null}
+                  </div>
                 ) : (
                   <form method="post" action={`/people/${person.id}/follow`}>
                     <button
@@ -2826,6 +2840,32 @@ export function createPagesRoutes(db: Database): Hono {
         </div>
       </Layout>
     );
+  });
+
+  pages.post("/people/:id/follow/cancel", async (c) => {
+    if (!getAuthenticatedUserEmail(c, db)) {
+      return c.redirect("/login");
+    }
+
+    const id = Number(c.req.param("id"));
+    if (!Number.isInteger(id) || id < 1) {
+      return c.redirect("/people?error=Invalid person");
+    }
+
+    const follow = getRemoteFollowForPerson(id, db);
+    if (!follow) {
+      return c.redirect(
+        `/people/${id}?error=${encodeURIComponent("No pending follow request found")}`
+      );
+    }
+
+    try {
+      await cancelPendingRemoteFollow({ followId: follow.id, database: db });
+      return c.redirect(`/people/${id}?success=${encodeURIComponent("Follow request cancelled")}`);
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      return c.redirect(`/people/${id}?error=${encodeURIComponent(message)}`);
+    }
   });
 
   pages.post("/people/:id/follow", async (c) => {


### PR DESCRIPTION
## Summary
- Add remote following storage and migration
- Resolve Fediverse handles/actor URLs with WebFinger/actor fetch and basic SSRF-safe URL validation
- Send signed ActivityPub Follow activities from the local actor and store follows as pending
- Auto-create/reuse local people and ActivityPub social accounts for followed actors
- Add authenticated following admin UI and protected following API routes
- Add authenticated person-card local follow/status behavior

## Verification
- bun test src/federation/__tests__/following-send.test.ts src/routes/__tests__/admin.test.tsx src/routes/__tests__/api.test.tsx src/routes/__tests__/pages.test.tsx
- npm run lint
- npm run typecheck
- make check
- Browser check on /admin/following
- make dev-tail grep for errors/warnings

Task: #task-ed533753