### PR TITLE
Accept followed ActivityPub accounts

### DIFF
--- a/drizzle/0018_special_nuke.sql
+++ b/drizzle/0018_special_nuke.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `remote_follows` ADD `accepted_at` integer;--> statement-breakpoint
+ALTER TABLE `remote_follows` ADD `rejected_at` integer;

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1483 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3f56495e-92a5-496d-a867-ebc9eb3f923e",
+  "prevId": "6942c6a4-12ff-4a1e-89c5-9b1db6d04d84",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "person_social_accounts": {
+      "name": "person_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_social_accounts_person_id_people_id_fk": {
+          "name": "person_social_accounts_person_id_people_id_fk",
+          "tableFrom": "person_social_accounts",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_boosts": {
+      "name": "remote_boosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_boosts_activity_uri_unique": {
+          "name": "remote_boosts_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_boosts_post_id_posts_id_fk": {
+          "name": "remote_boosts_post_id_posts_id_fk",
+          "tableFrom": "remote_boosts",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_comments": {
+      "name": "remote_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_url": {
+          "name": "actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "in_reply_to_uri": {
+          "name": "in_reply_to_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "raw_source": {
+          "name": "raw_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderated_at": {
+          "name": "moderated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_comments_activity_uri_unique": {
+          "name": "remote_comments_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        },
+        "remote_comments_object_uri_unique": {
+          "name": "remote_comments_object_uri_unique",
+          "columns": ["object_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_comments_post_id_posts_id_fk": {
+          "name": "remote_comments_post_id_posts_id_fk",
+          "tableFrom": "remote_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_follows": {
+      "name": "remote_follows",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_username": {
+          "name": "preferred_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "follow_activity_uri": {
+          "name": "follow_activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_follows_actor_uri_unique": {
+          "name": "remote_follows_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        },
+        "remote_follows_follow_activity_uri_unique": {
+          "name": "remote_follows_follow_activity_uri_unique",
+          "columns": ["follow_activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_follows_person_id_people_id_fk": {
+          "name": "remote_follows_person_id_people_id_fk",
+          "tableFrom": "remote_follows",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_likes": {
+      "name": "remote_likes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_likes_activity_uri_unique": {
+          "name": "remote_likes_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_likes_post_id_posts_id_fk": {
+          "name": "remote_likes_post_id_posts_id_fk",
+          "tableFrom": "remote_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_social_accounts": {
+      "name": "source_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_social_accounts_source_id_sources_id_fk": {
+          "name": "source_social_accounts_source_id_sources_id_fk",
+          "tableFrom": "source_social_accounts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1777405864318,
       "tag": "0017_hot_landau",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1777408864092,
+      "tag": "0018_special_nuke",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -123,6 +123,8 @@ export const remoteFollows = sqliteTable("remote_follows", {
   status: text("status").notNull().default("pending"),
   last_error: text("last_error"),
   followed_at: integer("followed_at", { mode: "timestamp" }).notNull(),
+  accepted_at: integer("accepted_at", { mode: "timestamp" }),
+  rejected_at: integer("rejected_at", { mode: "timestamp" }),
   created_at: integer("created_at", { mode: "timestamp" }).notNull(),
   updated_at: integer("updated_at", { mode: "timestamp" }).notNull(),
 });

--- a/src/federation/__tests__/following-send.test.ts
+++ b/src/federation/__tests__/following-send.test.ts
@@ -1,3 +1,4 @@
+import { Accept, Follow, Reject } from "@fedify/fedify";
 import { describe, it, expect } from "bun:test";
 import { createTestDb } from "../../db/test-utils";
 import { people, personSocialAccounts, remoteFollows } from "../../db/schema";
@@ -7,8 +8,12 @@ import {
   parseFediverseHandle,
   resolveRemoteActor,
   isSafeRemoteUrl,
+  REMOTE_FOLLOW_ACCEPTED_STATUS,
   REMOTE_FOLLOW_CANCELLED_STATUS,
   REMOTE_FOLLOW_PENDING_STATUS,
+  REMOTE_FOLLOW_REJECTED_STATUS,
+  handleAcceptActivity,
+  handleRejectActivity,
   type ResolvedRemoteActor,
 } from "../following";
 
@@ -168,5 +173,81 @@ describe("ActivityPub following send workflow", () => {
     expect(delivered).toEqual([follow.follow_activity_uri]);
     expect(testDb.select().from(people).all()).toHaveLength(1);
     expect(testDb.select().from(remoteFollows).all()).toHaveLength(1);
+  });
+
+  it("marks pending follows accepted from valid Accept activities", async () => {
+    const testDb = createTestDb();
+    const follow = await createOrRetryRemoteFollow({
+      actor: actor(),
+      database: testDb,
+      deliver: async () => {},
+    });
+
+    const localActor = new URL("/users/erik", new URL(follow.follow_activity_uri).origin);
+    const updated = await handleAcceptActivity(
+      new Accept({
+        actor: new URL(follow.actor_uri),
+        object: new Follow({
+          id: new URL(follow.follow_activity_uri),
+          actor: localActor,
+          object: new URL(follow.actor_uri),
+        }),
+      }),
+      testDb
+    );
+
+    expect(updated?.status).toBe(REMOTE_FOLLOW_ACCEPTED_STATUS);
+    expect(updated?.accepted_at).toBeInstanceOf(Date);
+    expect(testDb.select().from(remoteFollows).get()?.status).toBe(REMOTE_FOLLOW_ACCEPTED_STATUS);
+  });
+
+  it("marks pending follows rejected from valid Reject activities", async () => {
+    const testDb = createTestDb();
+    const follow = await createOrRetryRemoteFollow({
+      actor: actor(),
+      database: testDb,
+      deliver: async () => {},
+    });
+
+    const localActor = new URL("/users/erik", new URL(follow.follow_activity_uri).origin);
+    const updated = await handleRejectActivity(
+      new Reject({
+        actor: new URL(follow.actor_uri),
+        object: new Follow({
+          id: new URL(follow.follow_activity_uri),
+          actor: localActor,
+          object: new URL(follow.actor_uri),
+        }),
+      }),
+      testDb
+    );
+
+    expect(updated?.status).toBe(REMOTE_FOLLOW_REJECTED_STATUS);
+    expect(updated?.rejected_at).toBeInstanceOf(Date);
+    expect(testDb.select().from(remoteFollows).get()?.status).toBe(REMOTE_FOLLOW_REJECTED_STATUS);
+  });
+
+  it("ignores mismatched Accept activities", async () => {
+    const testDb = createTestDb();
+    const follow = await createOrRetryRemoteFollow({
+      actor: actor(),
+      database: testDb,
+      deliver: async () => {},
+    });
+
+    const updated = await handleAcceptActivity(
+      new Accept({
+        actor: new URL("https://other.example/users/mallory"),
+        object: new Follow({
+          id: new URL(follow.follow_activity_uri),
+          actor: new URL("http://localhost:5000/users/erik"),
+          object: new URL(follow.actor_uri),
+        }),
+      }),
+      testDb
+    );
+
+    expect(updated).toBeNull();
+    expect(testDb.select().from(remoteFollows).get()?.status).toBe(REMOTE_FOLLOW_PENDING_STATUS);
   });
 });

--- a/src/federation/__tests__/following.test.ts
+++ b/src/federation/__tests__/following.test.ts
@@ -25,7 +25,62 @@ function loadPayload(): FollowingEndpointPayload {
   }
 
   const script = String.raw`
+    import { db, remoteFollows } from "./src/db";
     import { federation } from "./src/federation/setup";
+
+    const now = new Date("2026-04-20T12:00:00.000Z");
+    db.insert(remoteFollows).values([
+      {
+        actor_uri: "https://example.social/users/accepted",
+        handle: "@accepted@example.social",
+        display_name: "Accepted Account",
+        profile_url: "https://example.social/@accepted",
+        inbox_uri: "https://example.social/users/accepted/inbox",
+        follow_activity_uri: "http://localhost:5000/activities/follow/accepted",
+        status: "accepted",
+        followed_at: now,
+        accepted_at: now,
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        actor_uri: "https://example.social/users/pending",
+        handle: "@pending@example.social",
+        display_name: "Pending Account",
+        profile_url: "https://example.social/@pending",
+        inbox_uri: "https://example.social/users/pending/inbox",
+        follow_activity_uri: "http://localhost:5000/activities/follow/pending",
+        status: "pending",
+        followed_at: now,
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        actor_uri: "https://example.social/users/rejected",
+        handle: "@rejected@example.social",
+        display_name: "Rejected Account",
+        profile_url: "https://example.social/@rejected",
+        inbox_uri: "https://example.social/users/rejected/inbox",
+        follow_activity_uri: "http://localhost:5000/activities/follow/rejected",
+        status: "rejected",
+        followed_at: now,
+        rejected_at: now,
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        actor_uri: "https://example.social/users/cancelled",
+        handle: "@cancelled@example.social",
+        display_name: "Cancelled Account",
+        profile_url: "https://example.social/@cancelled",
+        inbox_uri: "https://example.social/users/cancelled/inbox",
+        follow_activity_uri: "http://localhost:5000/activities/follow/cancelled",
+        status: "cancelled",
+        followed_at: now,
+        created_at: now,
+        updated_at: now,
+      },
+    ]).run();
 
     function activityRequest(path) {
       return new Request("http://localhost:5000" + path, {
@@ -92,17 +147,26 @@ describe("ActivityPub following collection", () => {
     expect(result.actor.outbox).toBe("http://localhost:5000/users/erik/outbox");
   });
 
-  it("returns an empty following collection for erik", () => {
+  it("returns accepted follows for erik", () => {
     const result = loadPayload();
 
     expect(result.followingStatus).toBe(200);
     expect(result.following).toMatchObject({
       id: "http://localhost:5000/users/erik/following",
       type: "OrderedCollection",
-      totalItems: 0,
+      totalItems: 1,
     });
-    expect(result.following.items).toBeUndefined();
-    expect(result.following.orderedItems).toBeUndefined();
+    expect(result.following.orderedItems ?? result.following.items).toEqual([
+      "https://example.social/users/accepted",
+    ]);
+  });
+
+  it("excludes non-accepted follows from erik's following collection", () => {
+    const result = loadPayload();
+
+    expect(JSON.stringify(result.following)).not.toContain("pending");
+    expect(JSON.stringify(result.following)).not.toContain("rejected");
+    expect(JSON.stringify(result.following)).not.toContain("cancelled");
   });
 
   it("returns not found for non-erik following collections", () => {

--- a/src/federation/following.ts
+++ b/src/federation/following.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, inArray } from "drizzle-orm";
 import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
-import { Follow, Undo, type Recipient } from "@fedify/fedify";
+import { Accept, Follow, Reject, Undo, type Recipient } from "@fedify/fedify";
 
 import * as schema from "@/db/schema";
 import { people, personSocialAccounts, remoteFollows } from "@/db/schema";
@@ -438,6 +438,106 @@ export async function createOrRetryRemoteFollow({
   }
 }
 
+function localActorUri(): string {
+  return new URL("/users/erik", baseUrl).href;
+}
+
+function getFollowActivityIdFromResponse(
+  activity: Accept | Reject,
+  object: unknown
+): string | null {
+  if (object instanceof Follow && object.id) return object.id.href;
+  return activity.objectId?.href ?? null;
+}
+
+function isLocalFollowObject(object: unknown): boolean {
+  if (!(object instanceof Follow)) return true;
+  return object.actorId?.href === localActorUri();
+}
+
+async function applyRemoteFollowResponse({
+  activity,
+  status,
+  timestampField,
+  database,
+}: {
+  activity: Accept | Reject;
+  status: typeof REMOTE_FOLLOW_ACCEPTED_STATUS | typeof REMOTE_FOLLOW_REJECTED_STATUS;
+  timestampField: "accepted_at" | "rejected_at";
+  database: FollowingDatabase;
+}): Promise<RemoteFollow | null> {
+  const object = await activity.getObject({ suppressError: true });
+  const followActivityUri = getFollowActivityIdFromResponse(activity, object);
+  if (!followActivityUri) {
+    logger.warn("federation", "Follow response missing follow object id");
+    return null;
+  }
+
+  if (!isLocalFollowObject(object)) {
+    logger.warn("federation", `Follow response does not target local actor: ${followActivityUri}`);
+    return null;
+  }
+
+  const follow = database
+    .select()
+    .from(remoteFollows)
+    .where(eq(remoteFollows.follow_activity_uri, followActivityUri))
+    .get();
+  if (!follow) {
+    logger.warn(
+      "federation",
+      `Follow response did not match a stored follow: ${followActivityUri}`
+    );
+    return null;
+  }
+
+  const responseActorUri = activity.actorId?.href;
+  if (responseActorUri && responseActorUri !== follow.actor_uri) {
+    logger.warn("federation", `Follow response actor mismatch: ${responseActorUri}`);
+    return null;
+  }
+
+  if (follow.status !== REMOTE_FOLLOW_PENDING_STATUS) {
+    logger.debug(
+      "federation",
+      `Ignoring follow response for ${follow.status} follow: ${follow.id}`
+    );
+    return follow;
+  }
+
+  const now = new Date();
+  return database
+    .update(remoteFollows)
+    .set({ status, [timestampField]: now, last_error: null, updated_at: now })
+    .where(eq(remoteFollows.id, follow.id))
+    .returning()
+    .get();
+}
+
+export function handleAcceptActivity(
+  activity: Accept,
+  database: FollowingDatabase = getDefaultDatabase()
+): Promise<RemoteFollow | null> {
+  return applyRemoteFollowResponse({
+    activity,
+    status: REMOTE_FOLLOW_ACCEPTED_STATUS,
+    timestampField: "accepted_at",
+    database,
+  });
+}
+
+export function handleRejectActivity(
+  activity: Reject,
+  database: FollowingDatabase = getDefaultDatabase()
+): Promise<RemoteFollow | null> {
+  return applyRemoteFollowResponse({
+    activity,
+    status: REMOTE_FOLLOW_REJECTED_STATUS,
+    timestampField: "rejected_at",
+    database,
+  });
+}
+
 export async function cancelPendingRemoteFollow({
   followId,
   database = getDefaultDatabase(),
@@ -479,6 +579,17 @@ export function listRemoteFollows(
   return database
     .select()
     .from(remoteFollows)
+    .orderBy(asc(remoteFollows.display_name), asc(remoteFollows.id))
+    .all();
+}
+
+export function listAcceptedRemoteFollows(
+  database: FollowingDatabase = getDefaultDatabase()
+): RemoteFollow[] {
+  return database
+    .select()
+    .from(remoteFollows)
+    .where(eq(remoteFollows.status, REMOTE_FOLLOW_ACCEPTED_STATUS))
     .orderBy(asc(remoteFollows.display_name), asc(remoteFollows.id))
     .all();
 }

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -6,6 +6,7 @@ import {
   Announce,
   Create,
   Accept,
+  Reject,
   isActor,
   InProcessMessageQueue,
   type KvStore,
@@ -19,6 +20,7 @@ import { buildActorProfile } from "./actor-profile";
 import { handleLikeActivity } from "./likes";
 import { handleAnnounceActivity } from "./boosts";
 import { handleCreateActivity } from "./replies";
+import { handleAcceptActivity, handleRejectActivity, listAcceptedRemoteFollows } from "./following";
 
 // Context type for federation - we use void since we don't need request-specific data
 export type FederationContext = void;
@@ -182,6 +184,12 @@ export function createFedifyFederation() {
     })
     .on(Create, async (_ctx, create) => {
       await handleCreateActivity(create);
+    })
+    .on(Accept, async (_ctx, accept) => {
+      await handleAcceptActivity(accept);
+    })
+    .on(Reject, async (_ctx, reject) => {
+      await handleRejectActivity(reject);
     });
 
   // Set up outbox dispatcher - lists activities sent by this actor
@@ -224,16 +232,18 @@ export function createFedifyFederation() {
       return "0";
     });
 
-  // Set up following collection dispatcher - this single-user site does not follow actors yet
+  // Set up following collection dispatcher - returns accepted remote follows
   federation
     .setFollowingDispatcher("/users/{identifier}/following", async (_ctx, identifier) => {
       if (identifier !== "erik") {
         return null;
       }
 
-      return { items: [] };
+      return { items: listAcceptedRemoteFollows().map((follow) => new URL(follow.actor_uri)) };
     })
-    .setCounter((_ctx, identifier) => (identifier === "erik" ? 0 : null));
+    .setCounter((_ctx, identifier) =>
+      identifier === "erik" ? listAcceptedRemoteFollows().length : null
+    );
 
   // Set up followers collection dispatcher - returns list of followers
   federation

--- a/src/routes/__tests__/admin.test.tsx
+++ b/src/routes/__tests__/admin.test.tsx
@@ -208,8 +208,52 @@ describe("admin following page", () => {
     expect(html).toContain(">Follow<");
   });
 
-  it("lets admins cancel pending follow requests", async () => {
+  it("shows accepted and rejected timestamps", async () => {
+    const now = new Date("2026-04-20T12:34:00.000Z");
     testDb
+      .insert(remoteFollows)
+      .values([
+        {
+          actor_uri: "https://example.social/users/accepted",
+          handle: "@accepted@example.social",
+          display_name: "Accepted Example",
+          profile_url: "https://example.social/@accepted",
+          inbox_uri: "https://example.social/users/accepted/inbox",
+          follow_activity_uri: "http://localhost:5000/activities/follow/accepted",
+          status: "accepted",
+          followed_at: now,
+          accepted_at: now,
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          actor_uri: "https://example.social/users/rejected",
+          handle: "@rejected@example.social",
+          display_name: "Rejected Example",
+          profile_url: "https://example.social/@rejected",
+          inbox_uri: "https://example.social/users/rejected/inbox",
+          follow_activity_uri: "http://localhost:5000/activities/follow/rejected",
+          status: "rejected",
+          followed_at: now,
+          rejected_at: now,
+          created_at: now,
+          updated_at: now,
+        },
+      ])
+      .run();
+
+    const { admin } = await import("../admin");
+
+    const res = await admin.request(authenticatedRequest("/following"));
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("Accepted Apr 20, 2026");
+    expect(html).toContain("Rejected Apr 20, 2026");
+  });
+
+  it("lets admins cancel pending follow requests", async () => {
+    const follow = testDb
       .insert(remoteFollows)
       .values({
         actor_uri: "https://example.social/users/alice",
@@ -223,16 +267,17 @@ describe("admin following page", () => {
         created_at: new Date(),
         updated_at: new Date(),
       })
-      .run();
+      .returning()
+      .get();
 
     const { admin } = await import("../admin");
 
     const pageRes = await admin.request(authenticatedRequest("/following"));
     const html = await pageRes.text();
-    expect(html).toContain('action="/admin/following/1/cancel"');
+    expect(html).toContain(`action="/admin/following/${follow.id}/cancel"`);
     expect(html).toContain("Cancel request");
 
-    const cancelRes = await admin.request(authenticatedRequest("/following/1/cancel"), {
+    const cancelRes = await admin.request(authenticatedRequest(`/following/${follow.id}/cancel`), {
       method: "POST",
     });
 

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -1105,6 +1105,62 @@ describe("pages routes", () => {
       expect(mockContextSendActivity).toHaveBeenCalledTimes(1);
     });
 
+    it("renders authenticated person card status labels consistently", async () => {
+      const author = testDb
+        .insert(authors)
+        .values({
+          email: `person-status-${crypto.randomUUID()}@example.com`,
+          created_at: new Date(),
+        })
+        .returning()
+        .get();
+      const sessionId = `person-status-session-${crypto.randomUUID()}`;
+      testDb
+        .insert(sessions)
+        .values({
+          id: sessionId,
+          author_id: author.id,
+          expires_at: new Date(Date.now() + 60 * 60 * 1000),
+          created_at: new Date(),
+        })
+        .run();
+
+      const app = getApp();
+      const statuses = [
+        ["accepted", "Following"],
+        ["rejected", "Rejected"],
+        ["failed", "Failed"],
+        ["cancelled", "Cancelled"],
+      ] as const;
+
+      for (const [status, label] of statuses) {
+        testDb.delete(remoteFollows).run();
+        testDb
+          .insert(remoteFollows)
+          .values({
+            person_id: 1,
+            actor_uri: `https://mastodon.social/users/testauthor-${status}`,
+            handle: `@testauthor-${status}@mastodon.social`,
+            preferred_username: `testauthor-${status}`,
+            display_name: "Test Author",
+            profile_url: `https://mastodon.social/@testauthor-${status}`,
+            inbox_uri: `https://mastodon.social/users/testauthor-${status}/inbox`,
+            follow_activity_uri: `http://localhost:5000/activities/follow/testauthor-${status}`,
+            status,
+            followed_at: new Date(),
+            created_at: new Date(),
+            updated_at: new Date(),
+          })
+          .run();
+
+        const res = await app.request("/people/1", {
+          headers: { Cookie: `session=${sessionId}` },
+        });
+        const html = await res.text();
+        expect(html).toContain(`>${label}</span>`);
+      }
+    });
+
     it("shows links from the selected person with full shared link content", async () => {
       const app = getApp();
       const res = await app.request("/people/1");

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -357,6 +357,7 @@ admin.get("/following", async (c) => {
                     <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Status</th>
                     <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Person</th>
                     <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Followed</th>
+                    <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Resolved</th>
                     <th class="px-3 py-2 text-left text-xs uppercase text-gray-500">Actions</th>
                   </tr>
                 </thead>
@@ -388,6 +389,15 @@ admin.get("/following", async (c) => {
                         )}
                       </td>
                       <td class="px-3 py-2 text-sm">{formatDateTime(follow.followed_at)}</td>
+                      <td class="px-3 py-2 text-sm">
+                        {follow.accepted_at ? (
+                          <span>Accepted {formatDateTime(follow.accepted_at)}</span>
+                        ) : follow.rejected_at ? (
+                          <span>Rejected {formatDateTime(follow.rejected_at)}</span>
+                        ) : (
+                          <MissingValue />
+                        )}
+                      </td>
                       <td class="px-3 py-2 text-sm">
                         {follow.status === REMOTE_FOLLOW_PENDING_STATUS ? (
                           <form method="post" action={`/admin/following/${follow.id}/cancel`}>

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -2544,6 +2544,8 @@ protectedApi.get("/following", (c) => {
     profile_url: follow.profile_url,
     status: follow.status,
     followed_at: follow.followed_at.toISOString(),
+    accepted_at: follow.accepted_at?.toISOString() ?? null,
+    rejected_at: follow.rejected_at?.toISOString() ?? null,
   }));
   return c.json({ data: follows });
 });


### PR DESCRIPTION
## Summary
- Handle incoming ActivityPub `Accept` and `Reject` activities for previously sent follows.
- Store `accepted_at` / `rejected_at` timestamps on `remote_follows` and surface them in the admin/API views.
- Populate `/users/erik/following` with accepted remote follows only.
- Add coverage for valid/mismatched follow responses, following collection filtering, admin timestamps, and person-card status labels.

## Verification
- `bun test src/federation/__tests__/following-send.test.ts src/federation/__tests__/following.test.ts src/routes/__tests__/admin.test.tsx src/routes/__tests__/api.test.tsx src/routes/__tests__/pages.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `make check`
- `npm run build`
- Browser: opened `http://localhost:5000/admin/following` and verified the Following admin page renders with the Resolved column.
- `make dev-tail 2>&1 | grep -E "(ERROR|WARN|error|Error)" || true` returned no output.

Task: #task-6ab71b89
