### PR TITLE
Unfollow Fediverse accounts

### DIFF
--- a/drizzle/0019_windy_shadowcat.sql
+++ b/drizzle/0019_windy_shadowcat.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `remote_follows` ADD `unfollowed_at` integer;

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1490 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8ef7f4d0-f2e8-4ec2-a3ae-4fa4cb6c6e59",
+  "prevId": "3f56495e-92a5-496d-a867-ebc9eb3f923e",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "person_social_accounts": {
+      "name": "person_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_social_accounts_person_id_people_id_fk": {
+          "name": "person_social_accounts_person_id_people_id_fk",
+          "tableFrom": "person_social_accounts",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_boosts": {
+      "name": "remote_boosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_boosts_activity_uri_unique": {
+          "name": "remote_boosts_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_boosts_post_id_posts_id_fk": {
+          "name": "remote_boosts_post_id_posts_id_fk",
+          "tableFrom": "remote_boosts",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_comments": {
+      "name": "remote_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_url": {
+          "name": "actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "in_reply_to_uri": {
+          "name": "in_reply_to_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "raw_source": {
+          "name": "raw_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderated_at": {
+          "name": "moderated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_comments_activity_uri_unique": {
+          "name": "remote_comments_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        },
+        "remote_comments_object_uri_unique": {
+          "name": "remote_comments_object_uri_unique",
+          "columns": ["object_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_comments_post_id_posts_id_fk": {
+          "name": "remote_comments_post_id_posts_id_fk",
+          "tableFrom": "remote_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_follows": {
+      "name": "remote_follows",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_username": {
+          "name": "preferred_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "follow_activity_uri": {
+          "name": "follow_activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unfollowed_at": {
+          "name": "unfollowed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_follows_actor_uri_unique": {
+          "name": "remote_follows_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        },
+        "remote_follows_follow_activity_uri_unique": {
+          "name": "remote_follows_follow_activity_uri_unique",
+          "columns": ["follow_activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_follows_person_id_people_id_fk": {
+          "name": "remote_follows_person_id_people_id_fk",
+          "tableFrom": "remote_follows",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_likes": {
+      "name": "remote_likes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_likes_activity_uri_unique": {
+          "name": "remote_likes_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_likes_post_id_posts_id_fk": {
+          "name": "remote_likes_post_id_posts_id_fk",
+          "tableFrom": "remote_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_social_accounts": {
+      "name": "source_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_social_accounts_source_id_sources_id_fk": {
+          "name": "source_social_accounts_source_id_sources_id_fk",
+          "tableFrom": "source_social_accounts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1777408864092,
       "tag": "0018_special_nuke",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1777409695079,
+      "tag": "0019_windy_shadowcat",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -125,6 +125,7 @@ export const remoteFollows = sqliteTable("remote_follows", {
   followed_at: integer("followed_at", { mode: "timestamp" }).notNull(),
   accepted_at: integer("accepted_at", { mode: "timestamp" }),
   rejected_at: integer("rejected_at", { mode: "timestamp" }),
+  unfollowed_at: integer("unfollowed_at", { mode: "timestamp" }),
   created_at: integer("created_at", { mode: "timestamp" }).notNull(),
   updated_at: integer("updated_at", { mode: "timestamp" }).notNull(),
 });

--- a/src/federation/__tests__/following-send.test.ts
+++ b/src/federation/__tests__/following-send.test.ts
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm";
 import { Accept, Follow, Reject } from "@fedify/fedify";
 import { describe, it, expect } from "bun:test";
 import { createTestDb } from "../../db/test-utils";
@@ -14,6 +15,7 @@ import {
   REMOTE_FOLLOW_REJECTED_STATUS,
   handleAcceptActivity,
   handleRejectActivity,
+  unfollowRemoteFollow,
   type ResolvedRemoteActor,
 } from "../following";
 
@@ -173,6 +175,90 @@ describe("ActivityPub following send workflow", () => {
     expect(delivered).toEqual([follow.follow_activity_uri]);
     expect(testDb.select().from(people).all()).toHaveLength(1);
     expect(testDb.select().from(remoteFollows).all()).toHaveLength(1);
+  });
+
+  it("unfollows accepted follows with the original Follow activity URI", async () => {
+    const testDb = createTestDb();
+    const follow = await createOrRetryRemoteFollow({
+      actor: actor(),
+      database: testDb,
+      deliver: async () => {},
+    });
+    await handleAcceptActivity(
+      new Accept({
+        actor: new URL(follow.actor_uri),
+        object: new Follow({
+          id: new URL(follow.follow_activity_uri),
+          actor: new URL("/users/erik", new URL(follow.follow_activity_uri).origin),
+          object: new URL(follow.actor_uri),
+        }),
+      }),
+      testDb
+    );
+    const delivered: string[] = [];
+
+    const unfollowed = await unfollowRemoteFollow({
+      followId: follow.id,
+      database: testDb,
+      deliver: async (storedFollow) => {
+        delivered.push(storedFollow.follow_activity_uri);
+      },
+    });
+
+    expect(unfollowed?.status).toBe(REMOTE_FOLLOW_CANCELLED_STATUS);
+    expect(unfollowed?.unfollowed_at).toBeInstanceOf(Date);
+    expect(delivered).toEqual([follow.follow_activity_uri]);
+    expect(testDb.select().from(people).all()).toHaveLength(1);
+    expect(testDb.select().from(personSocialAccounts).all()).toHaveLength(1);
+  });
+
+  it("does not resend Undo activities for terminal follows", async () => {
+    const testDb = createTestDb();
+    const follow = await createOrRetryRemoteFollow({
+      actor: actor(),
+      database: testDb,
+      deliver: async () => {},
+    });
+    await cancelPendingRemoteFollow({
+      followId: follow.id,
+      database: testDb,
+      deliver: async () => {},
+    });
+    const delivered: string[] = [];
+
+    const unchanged = await unfollowRemoteFollow({
+      followId: follow.id,
+      database: testDb,
+      deliver: async (storedFollow) => {
+        delivered.push(storedFollow.follow_activity_uri);
+      },
+    });
+
+    expect(unchanged?.status).toBe(REMOTE_FOLLOW_CANCELLED_STATUS);
+    expect(delivered).toEqual([]);
+  });
+
+  it("stores delivery errors without corrupting follow status", async () => {
+    const testDb = createTestDb();
+    const follow = await createOrRetryRemoteFollow({
+      actor: actor(),
+      database: testDb,
+      deliver: async () => {},
+    });
+
+    await expect(
+      unfollowRemoteFollow({
+        followId: follow.id,
+        database: testDb,
+        deliver: async () => {
+          throw new Error("Inbox unavailable");
+        },
+      })
+    ).rejects.toThrow("Inbox unavailable");
+
+    const stored = testDb.select().from(remoteFollows).where(eq(remoteFollows.id, follow.id)).get();
+    expect(stored?.status).toBe(REMOTE_FOLLOW_PENDING_STATUS);
+    expect(stored?.last_error).toBe("Inbox unavailable");
   });
 
   it("marks pending follows accepted from valid Accept activities", async () => {

--- a/src/federation/following.ts
+++ b/src/federation/following.ts
@@ -538,6 +538,51 @@ export function handleRejectActivity(
   });
 }
 
+function canUndoRemoteFollow(status: string): boolean {
+  return status === REMOTE_FOLLOW_PENDING_STATUS || status === REMOTE_FOLLOW_ACCEPTED_STATUS;
+}
+
+export async function unfollowRemoteFollow({
+  followId,
+  database = getDefaultDatabase(),
+  deliver = sendUndoFollowActivity,
+}: {
+  followId: number;
+  database?: FollowingDatabase;
+  deliver?: (follow: RemoteFollow) => Promise<void>;
+}): Promise<RemoteFollow | null> {
+  const follow = database.select().from(remoteFollows).where(eq(remoteFollows.id, followId)).get();
+  if (!follow) return null;
+  if (!canUndoRemoteFollow(follow.status)) {
+    return follow;
+  }
+
+  try {
+    await deliver(follow);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    database
+      .update(remoteFollows)
+      .set({ last_error: message, updated_at: new Date() })
+      .where(eq(remoteFollows.id, follow.id))
+      .run();
+    throw error;
+  }
+
+  const now = new Date();
+  return database
+    .update(remoteFollows)
+    .set({
+      status: REMOTE_FOLLOW_CANCELLED_STATUS,
+      last_error: null,
+      unfollowed_at: now,
+      updated_at: now,
+    })
+    .where(eq(remoteFollows.id, follow.id))
+    .returning()
+    .get();
+}
+
 export async function cancelPendingRemoteFollow({
   followId,
   database = getDefaultDatabase(),
@@ -553,24 +598,7 @@ export async function cancelPendingRemoteFollow({
     throw new Error("Only pending follow requests can be cancelled");
   }
 
-  try {
-    await deliver(follow);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    database
-      .update(remoteFollows)
-      .set({ status: REMOTE_FOLLOW_FAILED_STATUS, last_error: message, updated_at: new Date() })
-      .where(eq(remoteFollows.id, follow.id))
-      .run();
-    throw error;
-  }
-
-  return database
-    .update(remoteFollows)
-    .set({ status: REMOTE_FOLLOW_CANCELLED_STATUS, last_error: null, updated_at: new Date() })
-    .where(eq(remoteFollows.id, follow.id))
-    .returning()
-    .get();
+  return unfollowRemoteFollow({ followId, database, deliver });
 }
 
 export function listRemoteFollows(

--- a/src/routes/__tests__/admin.test.tsx
+++ b/src/routes/__tests__/admin.test.tsx
@@ -252,38 +252,65 @@ describe("admin following page", () => {
     expect(html).toContain("Rejected Apr 20, 2026");
   });
 
-  it("lets admins cancel pending follow requests", async () => {
-    const follow = testDb
+  it("lets admins unfollow pending and accepted follow requests", async () => {
+    const now = new Date();
+    const [pending, accepted] = testDb
       .insert(remoteFollows)
-      .values({
-        actor_uri: "https://example.social/users/alice",
-        handle: "@alice@example.social",
-        display_name: "Alice Example",
-        profile_url: "https://example.social/@alice",
-        inbox_uri: "https://example.social/users/alice/inbox",
-        follow_activity_uri: "http://localhost:5000/activities/follow/alice",
-        status: "pending",
-        followed_at: new Date(),
-        created_at: new Date(),
-        updated_at: new Date(),
-      })
+      .values([
+        {
+          actor_uri: "https://example.social/users/alice",
+          handle: "@alice@example.social",
+          display_name: "Alice Example",
+          profile_url: "https://example.social/@alice",
+          inbox_uri: "https://example.social/users/alice/inbox",
+          follow_activity_uri: "http://localhost:5000/activities/follow/alice",
+          status: "pending",
+          followed_at: now,
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          actor_uri: "https://example.social/users/bob",
+          handle: "@bob@example.social",
+          display_name: "Bob Example",
+          profile_url: "https://example.social/@bob",
+          inbox_uri: "https://example.social/users/bob/inbox",
+          follow_activity_uri: "http://localhost:5000/activities/follow/bob",
+          status: "accepted",
+          followed_at: now,
+          accepted_at: now,
+          created_at: now,
+          updated_at: now,
+        },
+      ])
       .returning()
-      .get();
+      .all();
 
     const { admin } = await import("../admin");
 
     const pageRes = await admin.request(authenticatedRequest("/following"));
     const html = await pageRes.text();
-    expect(html).toContain(`action="/admin/following/${follow.id}/cancel"`);
+    expect(html).toContain(`action="/admin/following/${pending!.id}/unfollow"`);
+    expect(html).toContain(`action="/admin/following/${accepted!.id}/unfollow"`);
     expect(html).toContain("Cancel request");
+    expect(html).toContain("Unfollow");
 
-    const cancelRes = await admin.request(authenticatedRequest(`/following/${follow.id}/cancel`), {
-      method: "POST",
-    });
+    const pendingRes = await admin.request(
+      authenticatedRequest(`/following/${pending!.id}/unfollow`),
+      {
+        method: "POST",
+      }
+    );
+    const acceptedRes = await admin.request(
+      authenticatedRequest(`/following/${accepted!.id}/unfollow`),
+      { method: "POST" }
+    );
 
-    const stored = testDb.select().from(remoteFollows).get();
-    expect(cancelRes.status).toBe(302);
-    expect(stored?.status).toBe("cancelled");
-    expect(mockContextSendActivity).toHaveBeenCalledTimes(1);
+    const stored = testDb.select().from(remoteFollows).all();
+    expect(pendingRes.status).toBe(302);
+    expect(acceptedRes.status).toBe(302);
+    expect(stored.every((follow) => follow.status === "cancelled")).toBe(true);
+    expect(stored.every((follow) => follow.unfollowed_at instanceof Date)).toBe(true);
+    expect(mockContextSendActivity).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/routes/__tests__/api.test.tsx
+++ b/src/routes/__tests__/api.test.tsx
@@ -69,9 +69,16 @@ mock.module("@/auth/api-key", () => {
     validateApiKey: async () => ({ email: "test@example.com" }),
     // Mock middleware to bypass auth
     requireApiKey: async (
-      c: { set: (key: string, value: unknown) => void },
+      c: {
+        req: { header: (name: string) => string | undefined };
+        json: (body: unknown, status: number) => Response;
+        set: (key: string, value: unknown) => void;
+      },
       next: () => Promise<void>
     ) => {
+      if (c.req.header("Authorization") !== "Bearer ek_test") {
+        return c.json({ error: "Invalid or missing API key" }, 401);
+      }
       c.set("apiAuth", { email: "test@example.com" });
       await next();
     },
@@ -1855,6 +1862,109 @@ describe("Remote following API", () => {
     expect(createBody.data.status).toBe("pending");
     expect(listBody.data).toHaveLength(1);
     expect(listBody.data[0].actor_uri).toBe("https://example.social/users/alice");
+  });
+
+  it("unfollows accepted follows and preserves historical rows", async () => {
+    const person = testDb
+      .insert(people)
+      .values({ name: "Alice Example", url: "https://example.social/@alice" })
+      .returning()
+      .get();
+    testDb
+      .insert(personSocialAccounts)
+      .values({
+        person_id: person.id,
+        label: "ActivityPub",
+        url: "https://example.social/@alice",
+        is_activitypub: true,
+        is_default: true,
+        sort_order: 0,
+      })
+      .run();
+    const follow = testDb
+      .insert(remoteFollows)
+      .values({
+        person_id: person.id,
+        actor_uri: "https://example.social/users/alice",
+        handle: "@alice@example.social",
+        display_name: "Alice Example",
+        profile_url: "https://example.social/@alice",
+        inbox_uri: "https://example.social/users/alice/inbox",
+        follow_activity_uri: "http://localhost:5000/activities/follow/alice",
+        status: "accepted",
+        followed_at: new Date(),
+        accepted_at: new Date(),
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .returning()
+      .get();
+    const { api } = await import("../api");
+
+    const res = await api.request("/following/unfollow", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ id: follow.id }),
+    });
+    const body = await res.json();
+    const stored = testDb.select().from(remoteFollows).get();
+
+    expect(res.status).toBe(200);
+    expect(body.data.status).toBe("cancelled");
+    expect(typeof body.data.unfollowed_at).toBe("string");
+    expect(stored?.status).toBe("cancelled");
+    expect(stored?.unfollowed_at).toBeInstanceOf(Date);
+    expect(testDb.select().from(people).all()).toHaveLength(1);
+    expect(testDb.select().from(personSocialAccounts).all()).toHaveLength(1);
+    expect(mockContextSendActivity).toHaveBeenCalledTimes(1);
+    const sentActivity = (mockContextSendActivity.mock.calls[0] as unknown[] | undefined)?.[2] as
+      | { objectId?: URL }
+      | undefined;
+    expect(sentActivity?.objectId?.href).toBe(follow.follow_activity_uri);
+  });
+
+  it("does not send duplicate Undo activities for already cancelled follows", async () => {
+    const follow = testDb
+      .insert(remoteFollows)
+      .values({
+        actor_uri: "https://example.social/users/alice",
+        handle: "@alice@example.social",
+        display_name: "Alice Example",
+        profile_url: "https://example.social/@alice",
+        inbox_uri: "https://example.social/users/alice/inbox",
+        follow_activity_uri: "http://localhost:5000/activities/follow/alice",
+        status: "cancelled",
+        followed_at: new Date(),
+        unfollowed_at: new Date(),
+        created_at: new Date(),
+        updated_at: new Date(),
+      })
+      .returning()
+      .get();
+    const { api } = await import("../api");
+
+    const res = await api.request("/following/unfollow", {
+      method: "POST",
+      headers: { ...authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify({ id: follow.id }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.status).toBe("cancelled");
+    expect(mockContextSendActivity).not.toHaveBeenCalled();
+  });
+
+  it("requires authentication for unfollow API requests", async () => {
+    const { api } = await import("../api");
+
+    const res = await api.request("/following/unfollow", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: 1 }),
+    });
+
+    expect(res.status).toBe(401);
   });
 
   it("cancels pending follows", async () => {

--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -1089,11 +1089,11 @@ describe("pages routes", () => {
       const followedHtml = await followedRes.text();
 
       expect(followedHtml).toContain(">Pending</span>");
-      expect(followedHtml).toContain('action="/people/1/follow/cancel"');
+      expect(followedHtml).toContain('action="/people/1/follow/unfollow"');
       expect(followedHtml).not.toContain('action="/people/1/follow"');
 
       mockContextSendActivity.mockClear();
-      const cancelRes = await app.request("/people/1/follow/cancel", {
+      const cancelRes = await app.request("/people/1/follow/unfollow", {
         method: "POST",
         headers: { Cookie: `session=${sessionId}` },
       });
@@ -1102,6 +1102,79 @@ describe("pages routes", () => {
       expect(
         testDb.select().from(remoteFollows).where(eq(remoteFollows.person_id, 1)).get()?.status
       ).toBe("cancelled");
+      expect(mockContextSendActivity).toHaveBeenCalledTimes(1);
+    });
+
+    it("lets authenticated users unfollow accepted follows from person cards", async () => {
+      testDb.delete(remoteFollows).run();
+      const author = testDb
+        .insert(authors)
+        .values({
+          email: `person-unfollow-${crypto.randomUUID()}@example.com`,
+          created_at: new Date(),
+        })
+        .returning()
+        .get();
+      const sessionId = `person-unfollow-session-${crypto.randomUUID()}`;
+      testDb
+        .insert(sessions)
+        .values({
+          id: sessionId,
+          author_id: author.id,
+          expires_at: new Date(Date.now() + 60 * 60 * 1000),
+          created_at: new Date(),
+        })
+        .run();
+      testDb
+        .insert(remoteFollows)
+        .values({
+          person_id: 1,
+          actor_uri: "https://mastodon.social/users/testauthor",
+          handle: "@testauthor@mastodon.social",
+          preferred_username: "testauthor",
+          display_name: "Test Author",
+          profile_url: "https://mastodon.social/@testauthor",
+          inbox_uri: "https://mastodon.social/users/testauthor/inbox",
+          follow_activity_uri: "http://localhost:5000/activities/follow/testauthor",
+          status: "accepted",
+          followed_at: new Date(),
+          accepted_at: new Date(),
+          created_at: new Date(),
+          updated_at: new Date(),
+        })
+        .run();
+
+      const app = getApp();
+      const pageRes = await app.request("/people/1", {
+        headers: { Cookie: `session=${sessionId}` },
+      });
+      const html = await pageRes.text();
+
+      expect(html).toContain(">Following</span>");
+      expect(html).toContain('action="/people/1/follow/unfollow"');
+
+      mockContextSendActivity.mockClear();
+      const unfollowRes = await app.request("/people/1/follow/unfollow", {
+        method: "POST",
+        headers: { Cookie: `session=${sessionId}` },
+      });
+
+      const stored = testDb
+        .select()
+        .from(remoteFollows)
+        .where(eq(remoteFollows.person_id, 1))
+        .get();
+      expect(unfollowRes.status).toBe(302);
+      expect(stored?.status).toBe("cancelled");
+      expect(stored?.unfollowed_at).toBeInstanceOf(Date);
+      expect(testDb.select().from(people).where(eq(people.id, 1)).get()).toBeTruthy();
+      expect(
+        testDb
+          .select()
+          .from(personSocialAccounts)
+          .where(eq(personSocialAccounts.person_id, 1))
+          .all()
+      ).not.toHaveLength(0);
       expect(mockContextSendActivity).toHaveBeenCalledTimes(1);
     });
 

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -12,12 +12,13 @@ import {
   deletePasskey,
 } from "@/auth/passkey";
 import {
+  REMOTE_FOLLOW_ACCEPTED_STATUS,
   REMOTE_FOLLOW_PENDING_STATUS,
-  cancelPendingRemoteFollow,
   createOrRetryRemoteFollow,
   getRemoteFollowStatusLabel,
   listRemoteFollows,
   resolveRemoteActor,
+  unfollowRemoteFollow,
   type ResolvedRemoteActor,
 } from "@/federation/following";
 
@@ -390,7 +391,9 @@ admin.get("/following", async (c) => {
                       </td>
                       <td class="px-3 py-2 text-sm">{formatDateTime(follow.followed_at)}</td>
                       <td class="px-3 py-2 text-sm">
-                        {follow.accepted_at ? (
+                        {follow.unfollowed_at ? (
+                          <span>Unfollowed {formatDateTime(follow.unfollowed_at)}</span>
+                        ) : follow.accepted_at ? (
                           <span>Accepted {formatDateTime(follow.accepted_at)}</span>
                         ) : follow.rejected_at ? (
                           <span>Rejected {formatDateTime(follow.rejected_at)}</span>
@@ -399,13 +402,16 @@ admin.get("/following", async (c) => {
                         )}
                       </td>
                       <td class="px-3 py-2 text-sm">
-                        {follow.status === REMOTE_FOLLOW_PENDING_STATUS ? (
-                          <form method="post" action={`/admin/following/${follow.id}/cancel`}>
+                        {follow.status === REMOTE_FOLLOW_PENDING_STATUS ||
+                        follow.status === REMOTE_FOLLOW_ACCEPTED_STATUS ? (
+                          <form method="post" action={`/admin/following/${follow.id}/unfollow`}>
                             <button
                               class="rounded bg-gray-200 px-3 py-1 text-sm font-semibold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
                               type="submit"
                             >
-                              Cancel request
+                              {follow.status === REMOTE_FOLLOW_PENDING_STATUS
+                                ? "Cancel request"
+                                : "Unfollow"}
                             </button>
                           </form>
                         ) : (
@@ -424,15 +430,18 @@ admin.get("/following", async (c) => {
   );
 });
 
-admin.post("/following/:id/cancel", async (c) => {
+admin.post("/following/:id/unfollow", async (c) => {
   const id = Number(c.req.param("id"));
   if (!Number.isInteger(id) || id < 1) {
     return c.redirect("/admin/following?error=Invalid follow request");
   }
 
   try {
-    await cancelPendingRemoteFollow({ followId: id });
-    return c.redirect("/admin/following?success=Follow request cancelled");
+    const follow = await unfollowRemoteFollow({ followId: id });
+    if (!follow) {
+      return c.redirect("/admin/following?error=Follow not found");
+    }
+    return c.redirect("/admin/following?success=Account unfollowed");
   } catch (cause) {
     const message = cause instanceof Error ? cause.message : String(cause);
     return c.redirect(`/admin/following?error=${encodeURIComponent(message)}`);

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -51,6 +51,7 @@ import {
   createOrRetryRemoteFollow,
   listRemoteFollows,
   resolveRemoteActor,
+  unfollowRemoteFollow,
 } from "@/federation/following";
 import {
   federatePost,
@@ -2546,6 +2547,7 @@ protectedApi.get("/following", (c) => {
     followed_at: follow.followed_at.toISOString(),
     accepted_at: follow.accepted_at?.toISOString() ?? null,
     rejected_at: follow.rejected_at?.toISOString() ?? null,
+    unfollowed_at: follow.unfollowed_at?.toISOString() ?? null,
   }));
   return c.json({ data: follows });
 });
@@ -2562,6 +2564,32 @@ protectedApi.post("/following/resolve", async (c) => {
   } catch (cause) {
     const message = cause instanceof Error ? cause.message : String(cause);
     return c.json({ error: message }, 400);
+  }
+});
+
+protectedApi.post("/following/unfollow", async (c) => {
+  const body = (await c.req.json().catch(() => null)) as { id?: number } | null;
+  const id = Number(body?.id);
+  if (!Number.isInteger(id) || id < 1) {
+    return c.json({ error: "Invalid follow ID" }, 400);
+  }
+
+  try {
+    const follow = await unfollowRemoteFollow({ followId: id });
+    if (!follow) {
+      return c.json({ error: "Follow not found" }, 404);
+    }
+    return c.json({
+      data: {
+        id: follow.id,
+        actor_uri: follow.actor_uri,
+        status: follow.status,
+        unfollowed_at: follow.unfollowed_at?.toISOString() ?? null,
+      },
+    });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return c.json({ error: message }, 409);
   }
 });
 

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -33,12 +33,14 @@ import { logger } from "../utils/logger";
 import { getRemoteLikeCountForPost } from "../federation/likes";
 import { getRemoteBoostCountForPost } from "../federation/boosts";
 import {
+  REMOTE_FOLLOW_ACCEPTED_STATUS,
   REMOTE_FOLLOW_PENDING_STATUS,
   cancelPendingRemoteFollow,
   createOrRetryRemoteFollow,
   getRemoteFollowForPerson,
   getRemoteFollowStatusLabel,
   resolveRemoteActor,
+  unfollowRemoteFollow,
 } from "../federation/following";
 import {
   approveRemoteComment,
@@ -270,13 +272,14 @@ function PersonCard({
                     <span class="inline-flex rounded-full bg-teal-100 px-3 py-1 text-sm font-semibold text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
                       {getRemoteFollowStatusLabel(followStatus)}
                     </span>
-                    {followStatus === REMOTE_FOLLOW_PENDING_STATUS ? (
-                      <form method="post" action={`/people/${person.id}/follow/cancel`}>
+                    {followStatus === REMOTE_FOLLOW_PENDING_STATUS ||
+                    followStatus === REMOTE_FOLLOW_ACCEPTED_STATUS ? (
+                      <form method="post" action={`/people/${person.id}/follow/unfollow`}>
                         <button
                           type="submit"
                           class="inline-flex rounded-full bg-gray-200 px-3 py-1 text-sm font-semibold text-gray-800 transition hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
                         >
-                          Cancel
+                          {followStatus === REMOTE_FOLLOW_PENDING_STATUS ? "Cancel" : "Unfollow"}
                         </button>
                       </form>
                     ) : null}
@@ -2840,6 +2843,30 @@ export function createPagesRoutes(db: Database): Hono {
         </div>
       </Layout>
     );
+  });
+
+  pages.post("/people/:id/follow/unfollow", async (c) => {
+    if (!getAuthenticatedUserEmail(c, db)) {
+      return c.redirect("/login");
+    }
+
+    const id = Number(c.req.param("id"));
+    if (!Number.isInteger(id) || id < 1) {
+      return c.redirect("/people?error=Invalid person");
+    }
+
+    const follow = getRemoteFollowForPerson(id, db);
+    if (!follow) {
+      return c.redirect(`/people/${id}?error=${encodeURIComponent("No follow record found")}`);
+    }
+
+    try {
+      await unfollowRemoteFollow({ followId: follow.id, database: db });
+      return c.redirect(`/people/${id}?success=${encodeURIComponent("Account unfollowed")}`);
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      return c.redirect(`/people/${id}?error=${encodeURIComponent(message)}`);
+    }
   });
 
   pages.post("/people/:id/follow/cancel", async (c) => {


### PR DESCRIPTION
## Summary
- Add authenticated unfollow support for pending and accepted remote follows.
- Send `Undo(Follow)` using the stored stable Follow activity URI, then mark local follows `cancelled` with `unfollowed_at`.
- Surface unfollow actions in the admin following list, protected following API, and authenticated person cards.
- Preserve historical follow rows and linked people/social-account records.
- Keep terminal follow states idempotent so repeated unfollow attempts do not resend Undo activities.

## Verification
- `bun test src/federation/__tests__/following-send.test.ts src/federation/__tests__/following.test.ts src/routes/__tests__/admin.test.tsx src/routes/__tests__/api.test.tsx src/routes/__tests__/pages.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `make check`
- `npm run build`
- Browser: opened `http://localhost:5000/admin/following` and verified the Following admin page renders after the changes.
- `make dev-tail 2>&1 | grep -E "(ERROR|WARN|error|Error)" || true` returned no output.

Task: #task-9b11bb62
