### PR TITLE
Fix profile card following count

### DIFF
--- a/src/routes/__tests__/pages.test.tsx
+++ b/src/routes/__tests__/pages.test.tsx
@@ -608,6 +608,35 @@ describe("pages routes", () => {
       expect(html).toContain("rounded-full");
     });
 
+    it("shows accepted remote follow count in the profile card", async () => {
+      testDb.delete(remoteFollows).run();
+      const now = new Date();
+      testDb
+        .insert(remoteFollows)
+        .values({
+          actor_uri: "https://example.social/users/followed",
+          handle: "@followed@example.social",
+          preferred_username: "followed",
+          display_name: "Followed Person",
+          profile_url: "https://example.social/@followed",
+          inbox_uri: "https://example.social/users/followed/inbox",
+          shared_inbox_uri: "https://example.social/inbox",
+          follow_activity_uri: "http://localhost:5000/activities/follow/followed",
+          status: "accepted",
+          followed_at: now,
+          accepted_at: now,
+          created_at: now,
+          updated_at: now,
+        })
+        .run();
+
+      const app = getApp();
+      const res = await app.request("/feed");
+      const html = await res.text();
+
+      expect(html).toMatch(/<dt[^>]*>Following<\/dt>\s*<dd[^>]*>1<\/dd>/);
+    });
+
     it("links the actor card follow button to the Fediverse follow flow", async () => {
       const app = getApp();
       const res = await app.request("/feed");

--- a/src/routes/pages.tsx
+++ b/src/routes/pages.tsx
@@ -39,6 +39,7 @@ import {
   createOrRetryRemoteFollow,
   getRemoteFollowForPerson,
   getRemoteFollowStatusLabel,
+  listAcceptedRemoteFollows,
   resolveRemoteActor,
   unfollowRemoteFollow,
 } from "../federation/following";
@@ -2184,7 +2185,7 @@ export function createPagesRoutes(db: Database): Hono {
     const totalPosts = countResult.length;
     const totalPages = Math.ceil(totalPosts / FEED_POSTS_PER_PAGE);
     const followerCount = db.select().from(followers).all().length;
-    const followingCount = 0;
+    const followingCount = listAcceptedRemoteFollows(db).length;
 
     // Handle no posts
     if (totalPosts === 0) {
@@ -3297,7 +3298,7 @@ export function createPagesRoutes(db: Database): Hono {
       .where(isNotNull(posts.published_at))
       .all().length;
     const followerCount = db.select().from(followers).all().length;
-    const followingCount = 0;
+    const followingCount = listAcceptedRemoteFollows(db).length;
     const feedPost: PostWithSource = {
       ...post,
       source,


### PR DESCRIPTION
## Summary
- read the profile card Following count from accepted remote follows instead of hardcoding zero
- apply the count on feed and post-page sidebars
- add page coverage for accepted remote follow count rendering

## Tests
- npm run typecheck
- bun test src/routes/__tests__/pages.test.tsx
- make check

Task: task-8bbab1a1