### PR TITLE
Add ActivityPub featured posts

### DIFF
--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -29,6 +29,7 @@ export interface PostListItem {
   title: string | null;
   excerpt: string | null;
   published_at: string | null;
+  is_featured: boolean;
   source_id: number | null;
   author_id: number | null;
   source: Source | null;
@@ -67,6 +68,7 @@ export interface Post {
   source: Source | null;
   author_id: number | null;
   author: Person | null;
+  is_featured: boolean;
   published_at: string | null;
   created_at: string;
   updated_at: string;

--- a/drizzle/0020_lonely_mariko_yashida.sql
+++ b/drizzle/0020_lonely_mariko_yashida.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `posts` ADD `is_featured` integer DEFAULT false NOT NULL;

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,1498 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "aecc29d4-48d1-4e10-a7de-ea26e236c63b",
+  "prevId": "8ef7f4d0-f2e8-4ec2-a3ae-4fa4cb6c6e59",
+  "tables": {
+    "actor_keys": {
+      "name": "actor_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": ["key_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_keys_author_id_authors_id_fk": {
+          "name": "api_keys_author_id_authors_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_email_unique": {
+          "name": "authors_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "followers": {
+      "name": "followers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "followers_actor_uri_unique": {
+          "name": "followers_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": ["token_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_s3_key_unique": {
+          "name": "media_s3_key_unique",
+          "columns": ["s3_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkeys": {
+      "name": "passkeys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "columns": ["credential_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "passkeys_author_id_authors_id_fk": {
+          "name": "passkeys_author_id_authors_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "person_social_accounts": {
+      "name": "person_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "person_social_accounts_person_id_people_id_fk": {
+          "name": "person_social_accounts_person_id_people_id_fk",
+          "tableFrom": "person_social_accounts",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_post_id_tag_id_pk": {
+          "columns": ["post_id", "tag_id"],
+          "name": "post_tags_post_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_title": {
+          "name": "og_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_site_name": {
+          "name": "og_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_id": {
+          "name": "banner_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "posts_source_id_sources_id_fk": {
+          "name": "posts_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "posts_author_id_people_id_fk": {
+          "name": "posts_author_id_people_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "people",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_banner_image_id_media_id_fk": {
+          "name": "posts_banner_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["banner_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_boosts": {
+      "name": "remote_boosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_boosts_activity_uri_unique": {
+          "name": "remote_boosts_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_boosts_post_id_posts_id_fk": {
+          "name": "remote_boosts_post_id_posts_id_fk",
+          "tableFrom": "remote_boosts",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_comments": {
+      "name": "remote_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_url": {
+          "name": "actor_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_text": {
+          "name": "content_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "in_reply_to_uri": {
+          "name": "in_reply_to_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderation_status": {
+          "name": "moderation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "raw_source": {
+          "name": "raw_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moderated_at": {
+          "name": "moderated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_comments_activity_uri_unique": {
+          "name": "remote_comments_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        },
+        "remote_comments_object_uri_unique": {
+          "name": "remote_comments_object_uri_unique",
+          "columns": ["object_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_comments_post_id_posts_id_fk": {
+          "name": "remote_comments_post_id_posts_id_fk",
+          "tableFrom": "remote_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_follows": {
+      "name": "remote_follows",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_username": {
+          "name": "preferred_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "inbox_uri": {
+          "name": "inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shared_inbox_uri": {
+          "name": "shared_inbox_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "follow_activity_uri": {
+          "name": "follow_activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followed_at": {
+          "name": "followed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unfollowed_at": {
+          "name": "unfollowed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_follows_actor_uri_unique": {
+          "name": "remote_follows_actor_uri_unique",
+          "columns": ["actor_uri"],
+          "isUnique": true
+        },
+        "remote_follows_follow_activity_uri_unique": {
+          "name": "remote_follows_follow_activity_uri_unique",
+          "columns": ["follow_activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_follows_person_id_people_id_fk": {
+          "name": "remote_follows_person_id_people_id_fk",
+          "tableFrom": "remote_follows",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_likes": {
+      "name": "remote_likes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_uri": {
+          "name": "object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_uri": {
+          "name": "activity_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_uri": {
+          "name": "actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_object_uri": {
+          "name": "raw_object_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "remote_likes_activity_uri_unique": {
+          "name": "remote_likes_activity_uri_unique",
+          "columns": ["activity_uri"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "remote_likes_post_id_posts_id_fk": {
+          "name": "remote_likes_post_id_posts_id_fk",
+          "tableFrom": "remote_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_author_id_authors_id_fk": {
+          "name": "sessions_author_id_authors_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_authors": {
+      "name": "source_authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_authors_source_id_sources_id_fk": {
+          "name": "source_authors_source_id_sources_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "source_authors_person_id_people_id_fk": {
+          "name": "source_authors_person_id_people_id_fk",
+          "tableFrom": "source_authors",
+          "tableTo": "people",
+          "columnsFrom": ["person_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_social_accounts": {
+      "name": "source_social_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_activitypub": {
+          "name": "is_activitypub",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "source_social_accounts_source_id_sources_id_fk": {
+          "name": "source_social_accounts_source_id_sources_id_fk",
+          "tableFrom": "source_social_accounts",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_url": {
+          "name": "feed_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_title": {
+          "name": "preview_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_description": {
+          "name": "preview_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_image_url": {
+          "name": "preview_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_site_name": {
+          "name": "preview_site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "tags_slug_unique": {
+          "name": "tags_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1777409695079,
       "tag": "0019_windy_shadowcat",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1777428916037,
+      "tag": "0020_lonely_mariko_yashida",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -16,6 +16,7 @@ export const posts = sqliteTable("posts", {
   source_id: integer("source_id").references(() => sources.id),
   author_id: integer("author_id").references(() => people.id, { onDelete: "set null" }),
   banner_image_id: integer("banner_image_id").references(() => media.id, { onDelete: "set null" }),
+  is_featured: integer("is_featured", { mode: "boolean" }).notNull().default(false),
   published_at: integer("published_at", { mode: "timestamp" }),
   created_at: integer("created_at", { mode: "timestamp" }).notNull(),
   updated_at: integer("updated_at", { mode: "timestamp" }).notNull(),

--- a/src/federation/__tests__/actor-profile.test.ts
+++ b/src/federation/__tests__/actor-profile.test.ts
@@ -21,6 +21,7 @@ const uris: ActorProfileUris = {
   outbox: new URL("/users/erik/outbox", origin),
   followers: new URL("/users/erik/followers", origin),
   following: new URL("/users/erik/following", origin),
+  featured: new URL("/users/erik/featured", origin),
   sharedInbox: new URL("/inbox", origin),
 };
 
@@ -130,6 +131,7 @@ describe("actor profile metadata", () => {
       outbox: "https://erikcraddock.me/users/erik/outbox",
       followers: "https://erikcraddock.me/users/erik/followers",
       following: "https://erikcraddock.me/users/erik/following",
+      featured: "https://erikcraddock.me/users/erik/featured",
       url: "https://erikcraddock.me/",
     });
     expect(json.publicKey).toBeDefined();
@@ -166,6 +168,7 @@ describe("actor profile metadata", () => {
       id: "https://erikcraddock.me/users/erik#update-test",
       actor: "https://erikcraddock.me/users/erik",
     });
+    expect(updateObject.featured).toBe("https://erikcraddock.me/users/erik/featured");
     expect(attachmentMap(updateObject)).toEqual(attachmentMap(actorJson));
   });
 });

--- a/src/federation/__tests__/following.test.ts
+++ b/src/federation/__tests__/following.test.ts
@@ -10,6 +10,8 @@ interface FollowingEndpointPayload {
   actor: Record<string, unknown>;
   followingStatus: number;
   following: Record<string, unknown>;
+  featuredStatus: number;
+  featured: Record<string, unknown>;
   missingStatus: number;
 }
 
@@ -25,10 +27,57 @@ function loadPayload(): FollowingEndpointPayload {
   }
 
   const script = String.raw`
-    import { db, remoteFollows } from "./src/db";
+    import { db, posts, remoteFollows } from "./src/db";
     import { federation } from "./src/federation/setup";
 
     const now = new Date("2026-04-20T12:00:00.000Z");
+    db.insert(posts).values([
+      {
+        slug: "featured-new",
+        type: "article",
+        title: "Featured New",
+        content: "Featured new content",
+        excerpt: "Featured new excerpt",
+        is_featured: true,
+        published_at: new Date("2026-04-22T12:00:00.000Z"),
+        created_at: new Date("2026-04-22T12:00:00.000Z"),
+        updated_at: new Date("2026-04-22T12:00:00.000Z"),
+      },
+      {
+        slug: "not-featured",
+        type: "article",
+        title: "Not Featured",
+        content: "Not featured content",
+        excerpt: "Not featured excerpt",
+        is_featured: false,
+        published_at: new Date("2026-04-21T12:00:00.000Z"),
+        created_at: new Date("2026-04-21T12:00:00.000Z"),
+        updated_at: new Date("2026-04-21T12:00:00.000Z"),
+      },
+      {
+        slug: "featured-draft",
+        type: "article",
+        title: "Featured Draft",
+        content: "Featured draft content",
+        excerpt: "Featured draft excerpt",
+        is_featured: true,
+        published_at: null,
+        created_at: new Date("2026-04-23T12:00:00.000Z"),
+        updated_at: new Date("2026-04-23T12:00:00.000Z"),
+      },
+      {
+        slug: "featured-old",
+        type: "note",
+        title: null,
+        content: "Featured old note",
+        excerpt: "Featured old note",
+        is_featured: true,
+        published_at: new Date("2026-04-19T12:00:00.000Z"),
+        created_at: new Date("2026-04-19T12:00:00.000Z"),
+        updated_at: new Date("2026-04-19T12:00:00.000Z"),
+      },
+    ]).run();
+
     db.insert(remoteFollows).values([
       {
         actor_uri: "https://example.social/users/accepted",
@@ -94,6 +143,9 @@ function loadPayload(): FollowingEndpointPayload {
     const followingResponse = await federation.fetch(activityRequest("/users/erik/following"), {
       contextData: undefined,
     });
+    const featuredResponse = await federation.fetch(activityRequest("/users/erik/featured"), {
+      contextData: undefined,
+    });
     const missingResponse = await federation.fetch(activityRequest("/users/alice/following"), {
       contextData: undefined,
       onNotFound: async () => new Response("Not found", { status: 404 }),
@@ -104,6 +156,8 @@ function loadPayload(): FollowingEndpointPayload {
       actor: await actorResponse.json(),
       followingStatus: followingResponse.status,
       following: await followingResponse.json(),
+      featuredStatus: featuredResponse.status,
+      featured: await featuredResponse.json(),
       missingStatus: missingResponse.status,
     }));
   `;
@@ -143,6 +197,7 @@ describe("ActivityPub following collection", () => {
 
     expect(result.actorStatus).toBe(200);
     expect(result.actor.following).toBe("http://localhost:5000/users/erik/following");
+    expect(result.actor.featured).toBe("http://localhost:5000/users/erik/featured");
     expect(result.actor.followers).toBe("http://localhost:5000/users/erik/followers");
     expect(result.actor.outbox).toBe("http://localhost:5000/users/erik/outbox");
   });
@@ -167,6 +222,27 @@ describe("ActivityPub following collection", () => {
     expect(JSON.stringify(result.following)).not.toContain("pending");
     expect(JSON.stringify(result.following)).not.toContain("rejected");
     expect(JSON.stringify(result.following)).not.toContain("cancelled");
+  });
+
+  it("returns only published featured posts in newest-first order", () => {
+    const result = loadPayload();
+    const featuredItems = (result.featured.orderedItems ?? result.featured.items) as Record<
+      string,
+      unknown
+    >[];
+
+    expect(result.featuredStatus).toBe(200);
+    expect(result.featured).toMatchObject({
+      id: "http://localhost:5000/users/erik/featured",
+      type: "OrderedCollection",
+      totalItems: 2,
+    });
+    expect(featuredItems.map((item) => item.id)).toEqual([
+      "http://localhost:5000/posts/featured-new",
+      "http://localhost:5000/posts/featured-old",
+    ]);
+    expect(JSON.stringify(result.featured)).not.toContain("not-featured");
+    expect(JSON.stringify(result.featured)).not.toContain("featured-draft");
   });
 
   it("returns not found for non-erik following collections", () => {

--- a/src/federation/actor-profile.ts
+++ b/src/federation/actor-profile.ts
@@ -37,6 +37,7 @@ export interface ActorProfileUris {
   outbox: URL;
   followers: URL;
   following: URL;
+  featured: URL;
   sharedInbox: URL;
 }
 
@@ -103,6 +104,7 @@ export function buildActorProfile(options: BuildActorProfileOptions): Person {
     outbox: uris.outbox,
     followers: uris.followers,
     following: uris.following,
+    featured: uris.featured,
     endpoints: new Endpoints({ sharedInbox: uris.sharedInbox }),
     publicKey: keys[0]?.cryptographicKey,
     assertionMethods: keys.map((key) => key.multikey),

--- a/src/federation/featured.ts
+++ b/src/federation/featured.ts
@@ -1,0 +1,84 @@
+import { and, count, desc, eq, isNotNull } from "drizzle-orm";
+
+import { db, media, postTags, posts, tags } from "@/db";
+import { mediaUrl } from "@/services/media";
+import { baseUrl } from "./utils";
+import { postToObject, type PostTag, type PublishedPost } from "./post-object";
+
+/**
+ * Get published posts marked as featured, ordered newest-first for stable
+ * Mastodon-compatible profile pinning. Draft featured posts are intentionally
+ * excluded so unpublished content never leaks through ActivityPub collections.
+ */
+export function getFeaturedPosts(): PublishedPost[] {
+  const results = db
+    .select({
+      id: posts.id,
+      slug: posts.slug,
+      type: posts.type,
+      title: posts.title,
+      content: posts.content,
+      excerpt: posts.excerpt,
+      url: posts.url,
+      published_at: posts.published_at,
+      updated_at: posts.updated_at,
+      banner_s3_key: media.s3_key,
+      banner_alt: media.alt_text,
+    })
+    .from(posts)
+    .leftJoin(media, eq(posts.banner_image_id, media.id))
+    .where(and(eq(posts.is_featured, true), isNotNull(posts.published_at)))
+    .orderBy(desc(posts.published_at), desc(posts.id))
+    .all();
+
+  const postIds = results.map((post) => post.id);
+  const allTags =
+    postIds.length > 0
+      ? db
+          .select({
+            postId: postTags.post_id,
+            name: tags.name,
+            slug: tags.slug,
+          })
+          .from(postTags)
+          .innerJoin(tags, eq(postTags.tag_id, tags.id))
+          .all()
+          .filter((tag) => postIds.includes(tag.postId))
+      : [];
+
+  const tagsMap = new Map<number, PostTag[]>();
+  for (const tag of allTags) {
+    const existing = tagsMap.get(tag.postId) ?? [];
+    existing.push({ name: tag.name, slug: tag.slug });
+    tagsMap.set(tag.postId, existing);
+  }
+
+  return results.map((post) => ({
+    id: post.id,
+    slug: post.slug,
+    type: post.type,
+    title: post.title,
+    content: post.content,
+    excerpt: post.excerpt,
+    url: post.url,
+    published_at: post.published_at!,
+    updated_at: post.updated_at,
+    banner_url: post.banner_s3_key ? new URL(mediaUrl(post.banner_s3_key), baseUrl).href : null,
+    banner_alt: post.banner_alt,
+    tags: tagsMap.get(post.id) ?? [],
+  }));
+}
+
+export function getFeaturedPostCount(): number {
+  const result = db
+    .select({ count: count() })
+    .from(posts)
+    .where(and(eq(posts.is_featured, true), isNotNull(posts.published_at)))
+    .get();
+
+  return result?.count ?? 0;
+}
+
+export function getFeaturedPostObjects(actorUri: URL, followersUri: URL) {
+  return getFeaturedPosts().map((post) => postToObject(post, actorUri, followersUri));
+}

--- a/src/federation/publish.ts
+++ b/src/federation/publish.ts
@@ -326,6 +326,7 @@ export async function sendActorUpdateActivity(): Promise<boolean> {
       outbox: ctx.getOutboxUri("erik"),
       followers: ctx.getFollowersUri("erik"),
       following: ctx.getFollowingUri("erik"),
+      featured: ctx.getFeaturedUri("erik"),
       sharedInbox: ctx.getInboxUri(),
     },
     keys,

--- a/src/federation/setup.ts
+++ b/src/federation/setup.ts
@@ -14,6 +14,7 @@ import {
 import { getOrCreateKeyPairs } from "./keys";
 import { addFollower, removeFollower, getAllFollowers, getFollowerCount } from "./followers";
 import { getOutboxActivities, getPublishedPostCount } from "./outbox";
+import { getFeaturedPostCount, getFeaturedPostObjects } from "./featured";
 import { getOrigin } from "./utils";
 import { logger } from "@/utils/logger";
 import { buildActorProfile } from "./actor-profile";
@@ -104,6 +105,7 @@ export function createFedifyFederation() {
           outbox: ctx.getOutboxUri(identifier),
           followers: ctx.getFollowersUri(identifier),
           following: ctx.getFollowingUri(identifier),
+          featured: ctx.getFeaturedUri(identifier),
           sharedInbox: ctx.getInboxUri(),
         },
         keys,
@@ -244,6 +246,19 @@ export function createFedifyFederation() {
     .setCounter((_ctx, identifier) =>
       identifier === "erik" ? listAcceptedRemoteFollows().length : null
     );
+
+  // Set up featured collection dispatcher - returns published posts pinned to the actor profile
+  federation
+    .setFeaturedDispatcher("/users/{identifier}/featured", async (ctx, identifier) => {
+      if (identifier !== "erik") {
+        return null;
+      }
+
+      return {
+        items: getFeaturedPostObjects(ctx.getActorUri(identifier), ctx.getFollowersUri(identifier)),
+      };
+    })
+    .setCounter((_ctx, identifier) => (identifier === "erik" ? getFeaturedPostCount() : null));
 
   // Set up followers collection dispatcher - returns list of followers
   federation

--- a/src/routes/api.tsx
+++ b/src/routes/api.tsx
@@ -208,6 +208,7 @@ const PostListItemSchema = z
     title: NullableStringSchema,
     excerpt: NullableStringSchema,
     published_at: IsoDateTimeSchema.nullable(),
+    is_featured: z.boolean().openapi({ example: false }),
     source_id: z.number().int().nullable(),
     author_id: z.number().int().nullable(),
     source: SourceSummarySchema.nullable(),
@@ -271,6 +272,7 @@ const PostSchema = z
     source_id: z.number().int().nullable(),
     author_id: z.number().int().nullable(),
     banner_image_id: z.number().int().nullable(),
+    is_featured: z.boolean().openapi({ example: false }),
     banner_url: NullableStringSchema,
     source: SourceSummarySchema.nullable(),
     author: PersonSummarySchema.nullable(),
@@ -332,6 +334,7 @@ const CreatePostBodySchema = z
     author_id: z.number().int().optional().nullable(),
     tags: z.array(z.string()).optional(),
     banner_image_id: z.number().int().optional().nullable(),
+    is_featured: z.boolean().optional().openapi({ example: false }),
     published_at: z.string().optional().nullable().openapi({ example: "2024-03-15T10:30:00Z" }),
   })
   .openapi("CreatePostBody");
@@ -346,6 +349,7 @@ const UpdatePostBodySchema = z
     author_id: z.number().int().optional().nullable(),
     tags: z.array(z.string()).optional(),
     banner_image_id: z.number().int().optional().nullable(),
+    is_featured: z.boolean().optional(),
   })
   .openapi("UpdatePostBody");
 
@@ -685,6 +689,7 @@ function hasFederatedPostChanges(
     source_id: number | null;
     author_id: number | null;
     banner_image_id: number | null;
+    is_featured: boolean;
   },
   input: {
     title?: string | null;
@@ -695,6 +700,7 @@ function hasFederatedPostChanges(
     author_id?: number | null;
     tags?: string[];
     banner_image_id?: number | null;
+    is_featured?: boolean;
   }
 ): boolean {
   if (input.title !== undefined && (input.title?.trim() || null) !== existingPost.title) {
@@ -725,6 +731,10 @@ function hasFederatedPostChanges(
     input.banner_image_id !== undefined &&
     input.banner_image_id !== existingPost.banner_image_id
   ) {
+    return true;
+  }
+
+  if (input.is_featured !== undefined && input.is_featured !== existingPost.is_featured) {
     return true;
   }
 
@@ -866,6 +876,7 @@ registerProtectedRoute(
       author_id,
       tags,
       banner_image_id,
+      is_featured,
       published_at,
     } = body;
 
@@ -925,6 +936,10 @@ registerProtectedRoute(
       return c.json({ error: "author_id must be a number" }, 400);
     }
 
+    if (is_featured !== undefined && typeof is_featured !== "boolean") {
+      return c.json({ error: "is_featured must be a boolean" }, 400);
+    }
+
     let publishedAtDate: Date | null = null;
     if (published_at !== undefined && published_at !== null) {
       if (typeof published_at !== "string") {
@@ -954,6 +969,7 @@ registerProtectedRoute(
         author_id: author_id ?? null,
         tags: tags || [],
         banner_image_id: banner_image_id ?? null,
+        is_featured: is_featured ?? false,
         published_at: publishedAtDate,
       });
 
@@ -1048,7 +1064,17 @@ registerProtectedRoute(
     }
 
     const body = await c.req.json();
-    const { title, content, excerpt, url, source_id, author_id, tags, banner_image_id } = body;
+    const {
+      title,
+      content,
+      excerpt,
+      url,
+      source_id,
+      author_id,
+      tags,
+      banner_image_id,
+      is_featured,
+    } = body;
 
     if (tags !== undefined && !Array.isArray(tags)) {
       return c.json({ error: "Tags must be an array" }, 400);
@@ -1070,6 +1096,10 @@ registerProtectedRoute(
       return c.json({ error: "author_id must be a number" }, 400);
     }
 
+    if (is_featured !== undefined && typeof is_featured !== "boolean") {
+      return c.json({ error: "is_featured must be a boolean" }, 400);
+    }
+
     try {
       const existingPost = getPost(id);
       if (!existingPost) {
@@ -1085,6 +1115,7 @@ registerProtectedRoute(
         author_id,
         tags,
         banner_image_id,
+        is_featured,
       });
       const nextUrl = url !== undefined ? url?.trim() || null : existingPost.url;
       const linkPreview =
@@ -1120,6 +1151,7 @@ registerProtectedRoute(
         author_id,
         tags,
         banner_image_id,
+        is_featured,
       });
 
       if (!post) {
@@ -1406,7 +1438,17 @@ registerProtectedRoute(
     }
 
     const body = await c.req.json();
-    const { title, content, excerpt, url, source_id, author_id, tags, banner_image_id } = body;
+    const {
+      title,
+      content,
+      excerpt,
+      url,
+      source_id,
+      author_id,
+      tags,
+      banner_image_id,
+      is_featured,
+    } = body;
 
     if (tags !== undefined && !Array.isArray(tags)) {
       return c.json({ error: "Tags must be an array" }, 400);
@@ -1428,6 +1470,10 @@ registerProtectedRoute(
       return c.json({ error: "author_id must be a number" }, 400);
     }
 
+    if (is_featured !== undefined && typeof is_featured !== "boolean") {
+      return c.json({ error: "is_featured must be a boolean" }, 400);
+    }
+
     try {
       const shouldFederateUpdate = hasFederatedPostChanges(existingPost, {
         title,
@@ -1438,6 +1484,7 @@ registerProtectedRoute(
         author_id,
         tags,
         banner_image_id,
+        is_featured,
       });
       const nextUrl = url !== undefined ? url?.trim() || null : existingPost.url;
       const linkPreview =
@@ -1469,6 +1516,7 @@ registerProtectedRoute(
         author_id,
         tags,
         banner_image_id,
+        is_featured,
       });
 
       if (!post) {

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -11,6 +11,7 @@ export interface PostListItem {
   title: string | null;
   excerpt: string | null;
   published_at: string | null;
+  is_featured: boolean;
   source_id: number | null;
   author_id: number | null;
   source: SourceSummary | null;
@@ -152,6 +153,7 @@ export function listPosts(options: ListPostsOptions = {}): PostListItem[] {
       title: posts.title,
       excerpt: posts.excerpt,
       published_at: posts.published_at,
+      is_featured: posts.is_featured,
       source_id: posts.source_id,
       author_id: posts.author_id,
     })
@@ -190,6 +192,7 @@ export function listPosts(options: ListPostsOptions = {}): PostListItem[] {
       title: post.title,
       excerpt: post.excerpt,
       published_at: post.published_at?.toISOString() ?? null,
+      is_featured: post.is_featured,
       source_id: post.source_id,
       author_id: post.author_id,
       source: post.source_id ? getSourceSummary(post.source_id) : null,
@@ -216,6 +219,7 @@ export interface CreatePostInput {
   author_id?: number | null;
   tags?: string[]; // Tag slugs
   banner_image_id?: number | null;
+  is_featured?: boolean;
   published_at?: Date | null; // For imports - set to create as already published
 }
 
@@ -271,6 +275,7 @@ export function createPost(input: CreatePostInput) {
     author_id,
     tags: tagSlugs,
     banner_image_id,
+    is_featured,
     published_at,
   } = input;
 
@@ -318,6 +323,7 @@ export function createPost(input: CreatePostInput) {
       source_id: source_id ?? null,
       author_id: author_id ?? null,
       banner_image_id: banner_image_id ?? null,
+      is_featured: is_featured ?? false,
       created_at: published_at ?? now,
       updated_at: published_at ?? now,
       published_at: published_at ?? null,
@@ -381,6 +387,7 @@ export interface UpdatePostInput {
   author_id?: number | null;
   tags?: string[]; // Tag slugs
   banner_image_id?: number | null;
+  is_featured?: boolean;
 }
 
 /**
@@ -406,6 +413,7 @@ export function updatePost(id: number, input: UpdatePostInput) {
     author_id,
     tags: tagSlugs,
     banner_image_id,
+    is_featured,
   } = input;
 
   // Validate banner_image_id if provided
@@ -445,6 +453,7 @@ export function updatePost(id: number, input: UpdatePostInput) {
   if (source_id !== undefined) updates.source_id = source_id;
   if (author_id !== undefined) updates.author_id = author_id;
   if (banner_image_id !== undefined) updates.banner_image_id = banner_image_id;
+  if (is_featured !== undefined) updates.is_featured = is_featured;
 
   // Update post
   db.update(posts).set(updates).where(eq(posts.id, id)).run();


### PR DESCRIPTION
## Summary
- add a post-level is_featured flag with Drizzle migration
- expose Mastodon-compatible actor featured URL and collection dispatcher
- return only published featured posts as ActivityPub objects in deterministic newest-first order
- include featured in actor Update payload and API post shapes

Task: #task-01235dd6

## Validation
- npm run typecheck
- make check
- pre-push hook (lint, typecheck, tests, migration check)
- make dev-tail grep for errors/warnings